### PR TITLE
Apache does not deliberately violate open standards

### DIFF
--- a/docs/conf/httpd.conf.in
+++ b/docs/conf/httpd.conf.in
@@ -409,13 +409,3 @@ Include @rel_sysconfdir@/extra/proxy-html.conf
 SSLRandomSeed startup builtin
 SSLRandomSeed connect builtin
 </IfModule>
-
-# Deal with user agents that deliberately violate open standards
-#
-<IfModule setenvif_module>
-BrowserMatch "MSIE 10.0;" bad_DNT
-</IfModule>
-<IfModule headers_module>
-RequestHeader unset DNT env=bad_DNT
-</IfModule>
-


### PR DESCRIPTION
Section 4.2 of the DNT specification (http://www.w3.org/2011/tracking-protection/drafts/tracking-dnt.html#dnt-header-field) states that "An HTTP intermediary must not add, delete, or modify the DNT header field in requests forwarded through that intermediary unless that intermediary has been specifically installed or configured to do so by the user making the requests." This commit reverts a change made by an employee of Adobe Systems Incorporated which caused Apache httpd to default to deleting the DNT header field for all users of a popular web browser, including those who had explicitly made an informed decision to enable the DNT:1 header.
