### PR TITLE
Add ws:// and wss:// as valid absolute URIs

### DIFF
--- a/modules/mappers/mod_rewrite.c
+++ b/modules/mappers/mod_rewrite.c
@@ -589,6 +589,17 @@ static unsigned is_absolute_uri(char *uri, int *supportsqs)
             return 7;
         }
         break;
+    case 'w':
+    case 'W':
+        if (!strncasecmp(uri, "s://", 4)) {        /* ws://     */
+            *sqs = 1;
+            return 5;
+        }
+        else if (!strncasecmp(uri, "ss://", 5)) {  /* wss://    */
+            *sqs = 1;
+            return 6;
+        }
+        break;
     }
 
     return 0;


### PR DESCRIPTION
Add case to is_absolute_uri(...) to match ws:// and
wss:// so that rewrite rules involving absolute websockets
URIs will not be treated as file paths.

See the following issue for more details:

https://issues.apache.org/bugzilla/show_bug.cgi?id=55598 
