### PR TITLE
Attempt fallback resource if directory index fails

### DIFF
--- a/modules/mappers/mod_dir.c
+++ b/modules/mappers/mod_dir.c
@@ -388,14 +388,11 @@ static int dir_fixups(request_rec *r)
 {
     if (r->finfo.filetype == APR_DIR) {
         /* serve up a directory */
-        int res = fixup_dir(r);
-
-        if (res != OK) {
-           /* use fallback */
-           return fixup_dflt(r);
+        if (fixup_dir(r) != OK) {
+            return fixup_dflt(r);
+        } else {
+            return OK;
         }
-
-        return res;
     }
     else if ((r->finfo.filetype == APR_NOFILE) && (r->handler == NULL)) {
         /* No handler and nothing in the filesystem - use fallback */

--- a/modules/mappers/mod_dir.c
+++ b/modules/mappers/mod_dir.c
@@ -388,7 +388,14 @@ static int dir_fixups(request_rec *r)
 {
     if (r->finfo.filetype == APR_DIR) {
         /* serve up a directory */
-        return fixup_dir(r);
+        int res = fixup_dir(r);
+
+        if (res != OK) {
+           /* use fallback */
+           return fixup_dflt(r);
+        }
+
+        return res;
     }
     else if ((r->finfo.filetype == APR_NOFILE) && (r->handler == NULL)) {
         /* No handler and nothing in the filesystem - use fallback */


### PR DESCRIPTION
This fixes [bug 56067](https://issues.apache.org/bugzilla/show_bug.cgi?id=56067).

If a directory exists but no indexes can be resolved, the fallback resource should be attempted first before giving up. This is also discussed in [this serverfault question](http://serverfault.com/q/568952/121236).
