### PR TITLE
mod_rewrite: Added error checking for RewriteRule flags starting with "D"

### DIFF
--- a/modules/mappers/mod_rewrite.c
+++ b/modules/mappers/mod_rewrite.c
@@ -3452,6 +3452,9 @@ static const char *cmd_rewriterule_setflag(apr_pool_t *p, void *_cfg,
         if (!*key || !strcasecmp(key, "PI") || !strcasecmp(key,"iscardpath")) {
             cfg->flags |= (RULEFLAG_DISCARDPATHINFO);
         }
+        else {
+            ++error;
+        }
         break;
     case 'e':
     case 'E':


### PR DESCRIPTION
Currently, mod_rewrite has a fallback case to generate an error message for invalid RewriteRule flags - except of those beginning with a "D". This patch fixes this.
