### PR TITLE
mod_autoindex: add CSS class name when Description is empty.

### DIFF
--- a/modules/generators/mod_autoindex.c
+++ b/modules/generators/mod_autoindex.c
@@ -1782,7 +1782,7 @@ static void output_directories(struct ent **ar, int n,
                     }
                 }
                 else {
-                    ap_rputs("</td><td>&nbsp;", r);
+                    ap_rvputs(r, "</td><td", (d->style_sheet != NULL) ? " class=\"indexcoldesc\">" : ">", "&nbsp;", NULL);
                 }
             }
             ap_rputs("</td></tr>\n", r);


### PR DESCRIPTION
Add CSS "class" for description column when this one is empty.
