### PR TITLE
Add option to include file MD5 checksums when generating ETags

### DIFF
--- a/modules/http/http_etag.c
+++ b/modules/http/http_etag.c
@@ -158,6 +158,7 @@ AP_DECLARE(char *) ap_make_etag(request_rec *r, int force_weak)
                               "file permissions deny server access: %s", r->filename);
             } else {
                 apr_cpystrn(next, ap_md5digest(r->pool, fd), 25 * sizeof(char));
+                apr_file_close(fd);
                 next += 25 * sizeof(char) - 1;
             }
         }


### PR DESCRIPTION
In some cases, we cannot use the file attributes to generate ETags as the resulting entity tags will differ. This is where using file MD5 checksums can help.

In our case, we're using mod_negotiation's MultiViews to serve up different versions of a page based on LanguagePriority (index.html.en, index.html.fr, index.html.it, etc.), we cannot use INodes because these files are served from a bunch of servers.

We cannot use the last modified time (MTime) because these files are checked out from a distributed revision control system (bzr) periodically and therefore file times vary slightly as shown below:

```
| hloeung@server1:/.../www/current$ stat index.html.en | grep Modify
| Modify: 2013-04-18 15:57:55.000000000 +0000

| hloeung@server2:/.../www/current$ stat index.html.en | grep Modify
| Modify: 2013-04-18 15:57:54.924959000 +0000

| hloeung@server3:/.../www/current$ stat index.html.en | grep Modify
| Modify: 2013-04-18 15:57:55.083770000 +0000
```

We cannot use the file size (Size) because there are some files with the same size but different content:

```
| hloeung@server1:/.../www/current$ ls -la index.html.id index.html.io  index.html.zh-cn index.html.zh-hk index.html.zh-tw
| -rw-r--r-- 1 root root 6009 Apr 18  2013 index.html.id
| -rw-r--r-- 1 root root 6009 Apr 18  2013 index.html.io
| -rw-r--r-- 1 root root 6011 Apr 18  2013 index.html.zh-cn
| -rw-r--r-- 1 root root 6011 Apr 29  2014 index.html.zh-hk
| -rw-r--r-- 1 root root 6011 Apr 18  2013 index.html.zh-tw

| hloeung@server1:/.../www/current$ md5sum index.html.id index.html.io  index.html.zh-cn index.html.zh-hk index.html.zh-tw
| 2ec4965bdaf36e4a54cda7e8e22ae174  index.html.id
| c1fd4229d941c8d025863f626bc4748e  index.html.io
| 41ec77b46ef177fbf71aa860a4b0c282  index.html.zh-cn
| c30f90dd96c5ba91c9750aab13cd7353  index.html.zh-hk
| 067684373630c893d76378b895e2a841  index.html.zh-tw
```

See https://bugs.launchpad.net/ubuntu-start-page/+bug/1427844; right now we're working around this by setting the modification time to a number from the file checksum and revision.

Below shows example output of headers.

With just "FileETag MD5":

```
| < HTTP/1.1 200 OK
| < Date: Sun, 05 Apr 2015 12:01:54 GMT
| * Server Apache/2.4.7 (Ubuntu) is not blacklisted
| < Server: Apache/2.4.7 (Ubuntu)
| < Last-Modified: Sun, 05 Apr 2015 08:11:43 GMT
| < ETag: "wyrYAt9avKlB14Sr9kLn/Q=="
| < Accept-Ranges: bytes
| < Content-Length: 11510
| < Vary: Accept-Encoding
| < Content-Type: text/html
```

With "FileETag All MD5", so that's inode-size-mtime-md5:

```
| < HTTP/1.1 200 OK
| < Date: Sun, 05 Apr 2015 12:02:33 GMT
| * Server Apache/2.4.7 (Ubuntu) is not blacklisted
| < Server: Apache/2.4.7 (Ubuntu)
| < Last-Modified: Sun, 05 Apr 2015 08:11:43 GMT
| < ETag: "2028d-2cf6-512f5bb656cc0-wyrYAt9avKlB14Sr9kLn/Q=="
| < Accept-Ranges: bytes
| < Content-Length: 11510
| < Vary: Accept-Encoding
| < Content-Type: text/html
```

With "FileETag Size MD5":

```
| < HTTP/1.1 200 OK
| < Date: Sun, 05 Apr 2015 12:03:13 GMT
| * Server Apache/2.4.7 (Ubuntu) is not blacklisted
| < Server: Apache/2.4.7 (Ubuntu)
| < Last-Modified: Sun, 05 Apr 2015 08:11:43 GMT
| < ETag: "2cf6-wyrYAt9avKlB14Sr9kLn/Q=="
| < Accept-Ranges: bytes
| < Content-Length: 11510
| < Vary: Accept-Encoding
| < Content-Type: text/html
```

NOTE: Because it can cause performance problems, it is not enabled when FileETag is set to "All".
