### PR TITLE
wrong return value while create a new ticket

### DIFF
--- a/modules/ssl/ssl_engine_kernel.c
+++ b/modules/ssl/ssl_engine_kernel.c
@@ -2284,7 +2284,7 @@ int ssl_callback_SessionTicket(SSL *ssl,
                       "TLS session ticket key for %s successfully set, "
                       "creating new session ticket", sc->vhost_id);
 
-        return 0;
+        return 1;
     }
     else if (mode == 0) {
         /* 


### PR DESCRIPTION
from openssl online document: https://www.openssl.org/docs/manmaster/ssl/SSL_CTX_set_tlsext_ticket_key_cb.html

The return value of the cb function is used by OpenSSL to determine what further processing will occur. The following return values have meaning:

2
This indicates that the ctx and hctx have been set and the session can continue on those parameters. Additionally it indicates that the session ticket is in a renewal period and should be replaced. The OpenSSL library will call cb again with an enc argument of 1 to set the new ticket (see RFC5077 3.3 paragraph 2).

1
This indicates that the ctx and hctx have been set and the session can continue on those parameters.

0
This indicates that it was not possible to set/retrieve a session ticket and the SSL/TLS session will continue by by negotiating a set of cryptographic parameters or using the alternate SSL/TLS resumption mechanism, session ids.

If called with enc equal to 0 the library will call the cb again to get a new set of parameters.

less than 0
This indicates an error.
