### PR TITLE
Increase severity of "request failed: error reading the headers"

### DIFF
--- a/server/protocol.c
+++ b/server/protocol.c
@@ -1316,7 +1316,7 @@ request_rec *ap_read_request(conn_rec *conn)
 
         ap_get_mime_headers_core(r, tmp_bb);
         if (r->status != HTTP_OK) {
-            ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, r, APLOGNO(00567)
+            ap_log_rerror(APLOG_MARK, APLOG_NOTICE, 0, r, APLOGNO(00567)
                           "request failed: error reading the headers");
             ap_send_error_response(r, 0);
             ap_update_child_status(conn->sbh, SERVER_BUSY_LOG, r);


### PR DESCRIPTION
Hello,

This PR solves [bug 60681](https://bz.apache.org/bugzilla/show_bug.cgi?id=60681).

It's regarding error message `request failed: error reading the headers`.
Would be nice if it could be `APLOG_ERR` (as in Debian package), or at least `APLOG_NOTICE` / 
`APLOG_WARNING`.

We would then easily have these messages in the error log, without having to set `LogLevel` to `debug`.
Goal is then to ban (with fail2ban) hosts generating too frequently these messages. For example, a **slowloris** attacker will generate such messages.

Thank you very much 👍 

Ben