### PR TITLE
Add flag support to syslog logging method

### DIFF
--- a/docs/manual/mod/core.xml
+++ b/docs/manual/mod/core.xml
@@ -1515,7 +1515,7 @@ ErrorDocument 404 /cgi-bin/bad_urls.pl
 <directivesynopsis>
 <name>ErrorLog</name>
 <description>Location where the server will log errors</description>
-<syntax> ErrorLog <var>file-path</var>|syslog[:<var>facility</var>]</syntax>
+<syntax> ErrorLog <var>file-path</var>|syslog[:[<var>facility</var>][:<var>tag</var>]]</syntax>
 <default>ErrorLog logs/error_log (Unix) ErrorLog logs/error.log (Windows and OS/2)</default>
 <contextlist><context>server config</context><context>virtual host</context>
 </contextlist>
@@ -1548,10 +1548,15 @@ ErrorLog "|/usr/local/bin/httpd_errors"
     <var>facility</var> can be one of the names usually documented in
     syslog(1).  The facility is effectively global, and if it is changed
     in individual virtual hosts, the final facility specified affects the
-    entire server.</p>
+    entire server. Same rules apply for the syslog tag, which by default
+    uses the Apache binary name, <code>httpd</code> in most cases. You can
+    also override this by using the <code>syslog::<var>tag</var></code>
+    syntax.</p>
 
     <highlight language="config">
 ErrorLog syslog:user
+ErrorLog syslog:user:httpd.srv1
+ErrorLog syslog::httpd.srv2
     </highlight>
 
     <p>Additional modules can provide their own ErrorLog providers. The syntax

--- a/server/log.c
+++ b/server/log.c
@@ -397,39 +397,42 @@ static int open_error_log(server_rec *s, int is_main, apr_pool_t *p)
 
 #ifdef HAVE_SYSLOG
     else if (!strncasecmp(s->error_fname, "syslog", 6)) {
-        const char *tag;
-        tag = ap_server_argv0;
         if ((fname = strchr(s->error_fname, ':'))) {
+            /* s->error_fname could be [level]:[tag] (see #60525) */
+            const char *tag;
+            apr_size_t flen;
             const TRANS *fac;
 
             fname++;
-            /* s->error_fname could be [level]:[tag] (see #60525) */
-            tag = strchr(s->error_fname, ':');
-            tag++;
-            int level_len = 0;
-            while (level_len < strlen(fname)) {
-                if (fname[level_len] == ':') {
-                    level_len++;
-                    break;
+            tag = strchr(fname, ':');
+            if (tag) {
+                flen = tag - fname;
+                tag++;
+                if (*tag == '\0') {
+                    tag = ap_server_argv0;
                 }
-                level_len++;
-            }
-            tag += level_len;
-            if (*tag == '\0') {
+            } else {
+                flen = strlen(fname);
                 tag = ap_server_argv0;
             }
-            level_len--;
-
-            for (fac = facilities; fac->t_name; fac++) {
-                if ((level_len > 0)
-                    && !strncasecmp(fname, fac->t_name, level_len)) {
-                    openlog(tag, LOG_NDELAY|LOG_CONS|LOG_PID, fac->t_val);
-                    s->error_log = NULL;
-                    return OK;
+            if (flen == 0) {
+                /* Was something like syslog::foobar */
+                openlog(tag, LOG_NDELAY|LOG_CONS|LOG_PID, LOG_LOCAL7);
+            } else {
+                for (fac = facilities; fac->t_name; fac++) {
+                    if (!strncasecmp(fname, fac->t_name, flen)) {
+                        openlog(tag, LOG_NDELAY|LOG_CONS|LOG_PID,
+                                fac->t_val);
+                        s->error_log = NULL;
+                        return OK;
+                    }
                 }
             }
         }
-        openlog(tag, LOG_NDELAY|LOG_CONS|LOG_PID, LOG_LOCAL7);
+        else {
+            openlog(ap_server_argv0, LOG_NDELAY|LOG_CONS|LOG_PID, LOG_LOCAL7);
+        }
+
         s->error_log = NULL;
     }
 #endif

--- a/server/log.c
+++ b/server/log.c
@@ -397,23 +397,39 @@ static int open_error_log(server_rec *s, int is_main, apr_pool_t *p)
 
 #ifdef HAVE_SYSLOG
     else if (!strncasecmp(s->error_fname, "syslog", 6)) {
+        const char *tag;
+        tag = ap_server_argv0;
         if ((fname = strchr(s->error_fname, ':'))) {
             const TRANS *fac;
 
             fname++;
+            /* s->error_fname could be [level]:[tag] (see #60525) */
+            tag = strchr(s->error_fname, ':');
+            tag++;
+            int level_len = 0;
+            while (level_len < strlen(fname)) {
+                if (fname[level_len] == ':') {
+                    level_len++;
+                    break;
+                }
+                level_len++;
+            }
+            tag += level_len;
+            if (*tag == '\0') {
+                tag = ap_server_argv0;
+            }
+            level_len--;
+
             for (fac = facilities; fac->t_name; fac++) {
-                if (!strcasecmp(fname, fac->t_name)) {
-                    openlog(ap_server_argv0, LOG_NDELAY|LOG_CONS|LOG_PID,
-                            fac->t_val);
+                if ((level_len > 0)
+                    && !strncasecmp(fname, fac->t_name, level_len)) {
+                    openlog(tag, LOG_NDELAY|LOG_CONS|LOG_PID, fac->t_val);
                     s->error_log = NULL;
                     return OK;
                 }
             }
         }
-        else {
-            openlog(ap_server_argv0, LOG_NDELAY|LOG_CONS|LOG_PID, LOG_LOCAL7);
-        }
-
+        openlog(tag, LOG_NDELAY|LOG_CONS|LOG_PID, LOG_LOCAL7);
         s->error_log = NULL;
     }
 #endif


### PR DESCRIPTION
Hello,

This PR solves [req #60525](https://bz.apache.org/bugzilla/show_bug.cgi?id=60525).
We can now specify `ErrorLog:[facility]:[tag]`.

Very useful when there are several Apache instances on the same server.

Thank you 👍 

Ben