### PR TITLE
mod_status: extended text-mode

### DIFF
--- a/modules/cache/mod_socache_shmcb.c
+++ b/modules/cache/mod_socache_shmcb.c
@@ -612,7 +612,7 @@ static void socache_shmcb_status(ap_socache_instance_t *ctx,
     cache_pct = (100 * cache_total) / (header->subcache_data_size *
                                        header->subcache_num);
     /* Generate Output */
-    if (!(flags & AP_STATUS_SHORT)) {
+    if (!(flags & AP_STATUS_SHORT) && !(flags & AP_STATUS_TEXT)) {
         ap_rprintf(r, "cache type: <b>SHMCB</b>, shared memory: <b>%" APR_SIZE_T_FMT "</b> "
                    "bytes, current entries: <b>%d</b><br>",
                    ctx->shm_size, total);

--- a/modules/generators/mod_status.h
+++ b/modules/generators/mod_status.h
@@ -32,6 +32,7 @@
 #define AP_STATUS_SHORT    (0x1)  /* short, non-HTML report requested */
 #define AP_STATUS_NOTABLE  (0x2)  /* HTML report without tables */
 #define AP_STATUS_EXTENDED (0x4)  /* detailed report */
+#define AP_STATUS_TEXT     (0x8)  /* long, text-mode report requested */
 
 #if !defined(WIN32)
 #define STATUS_DECLARE(type)            type

--- a/modules/ssl/ssl_scache.c
+++ b/modules/ssl/ssl_scache.c
@@ -201,7 +201,11 @@ static int ssl_ext_status_hook(request_rec *r, int flags)
     if (mc == NULL || mc->sesscache == NULL)
         return OK;
 
-    if (!(flags & AP_STATUS_SHORT)) {
+    if ((flags & AP_STATUS_TEXT)) {
+	    ap_rputs("=======\n", r);
+	    ap_rputs("SSL/TLS Session Cache Status:\n", r);
+    }
+    else if (!(flags & AP_STATUS_SHORT)) {
         ap_rputs("<hr>\n", r);
         ap_rputs("<table cellspacing=0 cellpadding=0>\n", r);
         ap_rputs("<tr><td bgcolor=\"#000000\">\n", r);
@@ -223,7 +227,7 @@ static int ssl_ext_status_hook(request_rec *r, int flags)
         ssl_mutex_off(r->server);
     }
 
-    if (!(flags & AP_STATUS_SHORT)) {
+    if (!(flags & AP_STATUS_SHORT) || !(flags & AP_STATUS_TEXT)) {
         ap_rputs("</td></tr>\n", r);
         ap_rputs("</table>\n", r);
     }


### PR DESCRIPTION
Currently, consuming extended server-status depends upon a HTML parser.
Most script/monitoring tools prefers a structured text input.
This introduce a ?short URL parameter which behave as the current ?auto:
It it shows stripped down information.
But using ?auto, the full extended status is shown in text-mode.

NB: some 3rd-party modules hooking mod_status many needs further adaptation.