### PR TITLE
PVS-Studio: fixed weaknesses

### DIFF
--- a/modules/generators/mod_cgid.c
+++ b/modules/generators/mod_cgid.c
@@ -1194,9 +1194,7 @@ static int log_script(request_rec *r, cgid_server_conf * conf, int ret,
                 apr_file_puts(argsbuffer, f);
             apr_file_puts("\n", f);
         }
-    }
-
-    if (script_err) {
+        
         apr_file_close(script_err);
     }
 

--- a/modules/http2/h2_stream.c
+++ b/modules/http2/h2_stream.c
@@ -457,11 +457,11 @@ apr_status_t h2_stream_recv_frame(h2_stream *stream, int ftype, int flags)
 apr_status_t h2_stream_recv_DATA(h2_stream *stream, uint8_t flags,
                                     const uint8_t *data, size_t len)
 {
+    ap_assert(stream);
     h2_session *session = stream->session;
     apr_status_t status = APR_SUCCESS;
     apr_bucket_brigade *tmp;
     
-    ap_assert(stream);
     if (len > 0) {
         ap_log_cerror(APLOG_MARK, APLOG_TRACE2, status, session->c,
                       H2_STRM_MSG(stream, "recv DATA, len=%d"), (int)len);

--- a/server/config.c
+++ b/server/config.c
@@ -2026,7 +2026,7 @@ static const char *process_resource_config_fnmatch(server_rec *s,
             /* If matching internal to path, and we happen to match something
              * other than a directory, skip it
              */
-            if (rest && (rv == APR_SUCCESS) && (dirent.filetype != APR_DIR)) {
+            if (rest && (dirent.filetype != APR_DIR)) {
                 continue;
             }
             fnew = (fnames *) apr_array_push(candidates);

--- a/server/util_expr_eval.c
+++ b/server/util_expr_eval.c
@@ -196,7 +196,7 @@ static const char *ap_expr_eval_re_backref(ap_expr_eval_ctx_t *ctx, unsigned int
 {
     int len;
 
-    if (!ctx->re_pmatch || !ctx->re_source || *ctx->re_source == '\0' ||
+    if (!ctx->re_pmatch || !ctx->re_source || !(*ctx->re_source) || **ctx->re_source == '\0' ||
         ctx->re_nmatch < n + 1)
         return "";
 


### PR DESCRIPTION
We have found and fixed weaknesses CWE-476 (NULL Pointer Dereference) and CWE-570 (Expression is Always True) using PVS-Studio tool.

Analyzer warnings: [V528](https://www.viva64.com/en/w/V528/), [V595](https://www.viva64.com/en/w/V595/), [V560](https://www.viva64.com/en/w/V560/), [V581](https://www.viva64.com/en/w/V581/).

PVS-Studio is a static code analyzer for C, C++ and C#.

This PR is related to the [issue #60903](https://bz.apache.org/bugzilla/show_bug.cgi?id=60903). I also mentioned there one more warning of PVS-Studio that wasn't fixed, but it seemed important to me. 

Thanks.