### PR TITLE
Fix trivial typo

### DIFF
--- a/include/http_config.h
+++ b/include/http_config.h
@@ -886,7 +886,7 @@ AP_DECLARE(const char *) ap_build_cont_config(apr_pool_t *p,
  * @param conf_pool The pconf pool
  * @param temp_pool The temporary pool
  * @param conftree Place to store the root node of the config tree
- * @return Error string on erro, NULL otherwise
+ * @return Error string on error, NULL otherwise
  * @note If conf_pool == temp_pool, ap_build_config() will assume .htaccess
  *       context and use a lower maximum line length.
  */


### PR DESCRIPTION
Trivial typo in code documentation. I believe this was not covered in #6