### PR TITLE
Add host header override for proxy health check 2.4.x

### DIFF
--- a/docs/manual/mod/mod_proxy_hcheck.xml
+++ b/docs/manual/mod/mod_proxy_hcheck.xml
@@ -82,6 +82,9 @@
     <tr><td>hcuri</td>
         <td>&nbsp;</td>
         <td>Additional URI to be appended to the worker URL for the health check.</td></tr>
+    <tr><td>hchost</td>
+        <td>&nbsp;</td>
+        <td>Override host header for the health check, instead of hust balancer hostname.</td></tr>
     <tr><td>hctemplate</td>
         <td>&nbsp;</td>
         <td>Name of template, created via <directive>ProxyHCTemplate</directive> to use for setting health check parameters for this worker</td></tr>

--- a/modules/proxy/mod_proxy.h
+++ b/modules/proxy/mod_proxy.h
@@ -436,6 +436,7 @@ typedef struct {
     unsigned int     was_malloced:1;
     char      hcuri[PROXY_WORKER_MAX_ROUTE_SIZE];     /* health check uri */
     char      hcexpr[PROXY_WORKER_MAX_SCHEME_SIZE];   /* name of condition expr for health check */
+    char      hchost[PROXY_WORKER_MAX_HOSTNAME_SIZE];  /* remote backend address */
     int             passes;     /* number of successes for check to pass */
     int             pcount;     /* current count of passes */
     int             fails;      /* number of failures for check to fail */

--- a/modules/proxy/mod_proxy_balancer.c
+++ b/modules/proxy/mod_proxy_balancer.c
@@ -1176,6 +1176,12 @@ static int balancer_handler(request_rec *r)
             else
                 *wsel->s->hcexpr = '\0';
         }
+        if ((val = apr_table_get(params, "w_hh"))) {
+            if (strlen(val) && strlen(val) < sizeof(wsel->s->hchost))
+                strcpy(wsel->s->hchost, val);
+            else
+                *wsel->s->hchost = '\0';
+        }
         /* If the health check method doesn't support an expr, then null it */
         if (wsel->s->method == NONE || wsel->s->method == TCP) {
             *wsel->s->hcexpr = '\0';
@@ -1616,6 +1622,7 @@ static int balancer_handler(request_rec *r)
                     ap_rprintf(r, "<td>%d (%d)</td>", worker->s->passes,worker->s->pcount);
                     ap_rprintf(r, "<td>%d (%d)</td>", worker->s->fails, worker->s->fcount);
                     ap_rprintf(r, "<td>%s</td>", worker->s->hcuri);
+                    ap_rprintf(r, "<td>%s</td>", worker->s->hchost);
                     ap_rprintf(r, "<td>%s", worker->s->hcexpr);
                 }
                 ap_rputs("</td></tr>\n", r);
@@ -1689,6 +1696,8 @@ static int balancer_handler(request_rec *r)
                            "value='%d'></td></tr>\n", wsel->s->fails);
                 ap_rprintf(r, "<tr><td>HC uri</td><td><input name='w_hu' id='w_hu' type='text'"
                         "value='%s'</td></tr>\n", ap_escape_html(r->pool, wsel->s->hcuri));
+                ap_rprintf(r, "<tr><td>HC uri</td><td><input name='w_hh' id='w_hh' type='text'"
+                        "value='%s'</td></tr>\n", ap_escape_html(r->pool, wsel->s->hchost));
                 ap_rputs("</table>\n</td></tr>\n", r);
             }
             ap_rputs("<tr><td colspan='2'><input type=submit value='Submit'></td></tr>\n", r);


### PR DESCRIPTION
Not able to test currently, but can be useful with backends using host-header.