### PR TITLE
Add host header override for proxy health check 2.5.x

### DIFF
--- a/docs/manual/mod/mod_proxy_hcheck.xml
+++ b/docs/manual/mod/mod_proxy_hcheck.xml
@@ -82,6 +82,9 @@
     <tr><td>hcuri</td>
         <td>&nbsp;</td>
         <td>Additional URI to be appended to the worker URL for the health check.</td></tr>
+    <tr><td>hchost</td>
+        <td>&nbsp;</td>
+        <td>Override host header for the health check, instead of hust balancer hostname.</td></tr>
     <tr><td>hctemplate</td>
         <td>&nbsp;</td>
         <td>Name of template, created via <directive>ProxyHCTemplate</directive> to use for setting health check parameters for this worker</td></tr>

--- a/modules/proxy/mod_proxy.h
+++ b/modules/proxy/mod_proxy.h
@@ -396,6 +396,7 @@ typedef struct {
     char      uds_path[PROXY_WORKER_MAX_NAME_SIZE];   /* path to worker's unix domain socket if applicable */
     char      hcuri[PROXY_WORKER_MAX_ROUTE_SIZE];     /* health check uri */
     char      hcexpr[PROXY_WORKER_MAX_SCHEME_SIZE];   /* name of condition expr for health check */
+    char      hchost[PROXY_WORKER_MAX_HOSTNAME_SIZE];  /* remote backend address */
     int             lbset;      /* load balancer cluster set */
     int             retries;    /* number of retries on this worker */
     int             lbstatus;   /* Current lbstatus */

--- a/modules/proxy/mod_proxy_balancer.c
+++ b/modules/proxy/mod_proxy_balancer.c
@@ -1176,6 +1176,12 @@ static int balancer_handler(request_rec *r)
             else
                 *wsel->s->hcexpr = '\0';
         }
+        if ((val = apr_table_get(params, "w_hh"))) {
+            if (*val && strlen(val) < sizeof(wsel->s->hchost))
+                strcpy(wsel->s->hchost, val);
+            else
+                *wsel->s->hchost = '\0';
+        }
         /* If the health check method doesn't support an expr, then null it */
         if (wsel->s->method == NONE || wsel->s->method == TCP) {
             *wsel->s->hcexpr = '\0';
@@ -1616,6 +1622,7 @@ static int balancer_handler(request_rec *r)
                     ap_rprintf(r, "<td>%d (%d)</td>", worker->s->passes,worker->s->pcount);
                     ap_rprintf(r, "<td>%d (%d)</td>", worker->s->fails, worker->s->fcount);
                     ap_rprintf(r, "<td>%s</td>", worker->s->hcuri);
+                    ap_rprintf(r, "<td>%s</td>", worker->s->hchost);
                     ap_rprintf(r, "<td>%s", worker->s->hcexpr);
                 }
                 ap_rputs("</td></tr>\n", r);
@@ -1689,6 +1696,8 @@ static int balancer_handler(request_rec *r)
                            "value='%d'></td></tr>\n", wsel->s->fails);
                 ap_rprintf(r, "<tr><td>HC uri</td><td><input name='w_hu' id='w_hu' type='text'"
                         "value='%s'</td></tr>\n", ap_escape_html(r->pool, wsel->s->hcuri));
+                ap_rprintf(r, "<tr><td>HC uri</td><td><input name='w_hh' id='w_hh' type='text'"
+                        "value='%s'</td></tr>\n", ap_escape_html(r->pool, wsel->s->hchost));
                 ap_rputs("</table>\n</td></tr>\n", r);
             }
             ap_rputs("<tr><td colspan='2'><input type=submit value='Submit'></td></tr>\n", r);

--- a/modules/proxy/mod_proxy_hcheck.c
+++ b/modules/proxy/mod_proxy_hcheck.c
@@ -44,6 +44,7 @@ typedef struct {
     apr_interval_time_t interval;
     char *hurl;
     char *hcexpr;
+    char *hchost;
 } hc_template_t;
 
 typedef struct {
@@ -123,6 +124,7 @@ static const char *set_worker_hc_param(apr_pool_t *p,
                     worker->s->fails = template->fails;
                     PROXY_STRNCPY(worker->s->hcuri, template->hurl);
                     PROXY_STRNCPY(worker->s->hcexpr, template->hcexpr);
+                    PROXY_STRNCPY(worker->s->hchost, template->hchost);
                 } else {
                     temp->method = template->method;
                     temp->interval = template->interval;
@@ -130,6 +132,7 @@ static const char *set_worker_hc_param(apr_pool_t *p,
                     temp->fails = template->fails;
                     temp->hurl = apr_pstrdup(p, template->hurl);
                     temp->hcexpr = apr_pstrdup(p, template->hcexpr);
+                    temp->hchost = apr_pstrdup(p, template->hchost);
                 }
                 return NULL;
             }
@@ -211,6 +214,16 @@ static const char *set_worker_hc_param(apr_pool_t *p,
             temp->hcexpr = apr_pstrdup(p, val);
         }
     }
+    else if (!strcasecmp(key, "hchost")) {
+        if (strlen(val) >= sizeof(worker->s->hchost))
+            return apr_psprintf(p, "Health check host length must be < %d characters",
+                    (int)sizeof(worker->s->hchost));
+        if (worker) {
+            PROXY_STRNCPY(worker->s->hchost, val);
+        } else {
+            temp->hchost = apr_pstrdup(p, val);
+        }
+    }
   else {
         return "unknown Worker hcheck parameter";
     }
@@ -286,6 +299,7 @@ static const char *set_hc_template(cmd_parms *cmd, void *dummy, const char *arg)
     template->interval = apr_time_from_sec(HCHECK_WATHCHDOG_DEFAULT_INTERVAL);
     template->hurl = NULL;
     template->hcexpr = NULL;
+    template->hchost = NULL;
     while (*arg) {
         word = ap_getword_conf(cmd->pool, &arg);
         val = strchr(word, '=');
@@ -412,7 +426,7 @@ static void create_hcheck_req(wctx_t *wctx, proxy_worker *hc,
                                "OPTIONS * HTTP/1.0\r\n"
                                "Host: %s:%d\r\n"
                                "\r\n",
-                               hc->s->hostname, (int)hc->s->port);
+                               (*hc->s->hchost ? hc->s->hchost : hc->s->hostname), (int)hc->s->port);
             break;
 
         case HEAD:
@@ -430,7 +444,7 @@ static void create_hcheck_req(wctx_t *wctx, proxy_worker *hc,
                                (wctx->path ? wctx->path : ""),
                                (wctx->path && *hc->s->hcuri ? "/" : "" ),
                                (*hc->s->hcuri ? hc->s->hcuri : ""),
-                               hc->s->hostname, (int)hc->s->port);
+                               (*hc->s->hchost ? hc->s->hchost : hc->s->hostname), (int)hc->s->port);
             break;
 
         default:
@@ -466,6 +480,7 @@ static proxy_worker *hc_get_hcworker(sctx_t *ctx, proxy_worker *worker,
         PROXY_STRNCPY(hc->s->scheme,   worker->s->scheme);
         PROXY_STRNCPY(hc->s->hcuri,    worker->s->hcuri);
         PROXY_STRNCPY(hc->s->hcexpr,   worker->s->hcexpr);
+        PROXY_STRNCPY(hc->s->hchost,   worker->s->hchost);
         hc->hash.def = hc->s->hash.def = ap_proxy_hashfunc(hc->s->name, PROXY_HASHFUNC_DEFAULT);
         hc->hash.fnv = hc->s->hash.fnv = ap_proxy_hashfunc(hc->s->name, PROXY_HASHFUNC_FNV);
         hc->s->port = port;


### PR DESCRIPTION
Not able to test currently, but can be useful with backends using host-header.