### PR TITLE
Experimental mod_authnz_ldap feature:

### DIFF
--- a/include/util_ldap.h
+++ b/include/util_ldap.h
@@ -336,7 +336,8 @@ APR_DECLARE_OPTIONAL_FN(int,uldap_cache_check_subgroups,(request_rec *r, util_ld
  */
 APR_DECLARE_OPTIONAL_FN(int,uldap_cache_checkuserid,(request_rec *r, util_ldap_connection_t *ldc,
                               const char *url, const char *basedn, int scope, char **attrs,
-                              const char *filter, const char *bindpw, const char **binddn, const char ***retvals));
+                              const char *filter, const char *bindpw, const char **binddn,
+                              const char *alternateAuthAttr, const char ***retvals));
 
 /**
  * Searches for a specified user object in an LDAP directory


### PR DESCRIPTION
New directive called: AuthLDAPAlternateAuthAttr "attribueName"

It enables authentication using ldap_compare() against the content of attributeName
(an attribute with ldap server side restricted access, that the bindDn cannot read or
ldap_search(), but only ldap_compare()).

Advantage: Prevent misuse of httpd admins. Thus the userPassword is not disclosed to the bindDn the bindDn (httpd admin) cannot bind/impersonate as the users.

Further details, including an extract of an openldap (slapd) specific acl see my (8fJyHa) comment here: https://httpd.apache.org/docs/2.4/mod/mod_authnz_ldap.html (note the directive's name has changed: AuthLDAPAlternateAuthAttr sounds more appropriate to me)