### PR TITLE
more strict encoding check

### DIFF
--- a/modules/aaa/mod_authnz_ldap.c
+++ b/modules/aaa/mod_authnz_ldap.c
@@ -126,7 +126,7 @@ static char* derive_codepage_from_lang (apr_pool_t *p, char *language)
 
     charset = (char*) apr_hash_get(charset_conversions, language, APR_HASH_KEY_STRING);
 
-    if (!charset) {
+    if (!charset && strlen(language) > 2 && language[2] == '-') {
         language[2] = '\0';
         charset = (char*) apr_hash_get(charset_conversions, language, APR_HASH_KEY_STRING);
     }


### PR DESCRIPTION
This is with respect to the problem in https://bz.apache.org/bugzilla/show_bug.cgi?id=61193. Mainly this seems to be useful in the case when en-US is not available so it can fall back to en but any unknown encoding could be shortened as given in the bug link. 