### PR TITLE
mod_lua: fix documentation about LuaHookCheckUserID

### DIFF
--- a/docs/manual/developer/lua.html.en
+++ b/docs/manual/developer/lua.html.en
@@ -342,7 +342,7 @@ end</pre>
     processing, allowing you to either add new requirements that were not previously
     supported by httpd, or tweaking existing ones to accommodate your needs.
 </p>
-<pre class="prettyprint lang-config">LuaHookAuthChecker /path/too/foo.lua check_auth</pre>
+<pre class="prettyprint lang-config">LuaHookCheckUserID /path/too/foo.lua check_auth</pre>
 
 
 

--- a/docs/manual/developer/lua.xml
+++ b/docs/manual/developer/lua.xml
@@ -353,7 +353,7 @@ end
     supported by httpd, or tweaking existing ones to accommodate your needs.
 </p>
 <highlight language="config">
-LuaHookAuthChecker /path/too/foo.lua check_auth
+LuaHookCheckUserID /path/too/foo.lua check_auth
 </highlight>
 
 <!-- BEGIN EXAMPLE CODE -->


### PR DESCRIPTION
changed lua authentication examples to use the correct hook
function