### PR TITLE
Added support for passing 'Off' to ServerTokens to completely remove Server response header field

### DIFF
--- a/docs/manual/mod/core.xml
+++ b/docs/manual/mod/core.xml
@@ -4581,7 +4581,7 @@ ServerRoot "/home/httpd"
 <name>ServerTokens</name>
 <description>Configures the <code>Server</code> HTTP response
 header</description>
-<syntax>ServerTokens Major|Minor|Min[imal]|Prod[uctOnly]|OS|Full</syntax>
+<syntax>ServerTokens Major|Minor|Min[imal]|Prod[uctOnly]|OS|Full|Off</syntax>
 <default>ServerTokens Full</default>
 <contextlist><context>server config</context></contextlist>
 
@@ -4622,6 +4622,10 @@ header</description>
       <dd>Server sends (<em>e.g.</em>): <code>Server: Apache/2.4.2
       (Unix)</code></dd>
 
+      <dt><code>ServerTokens Off</code></dt>
+
+      <dd>Server sends no <code>Server</code> response header field</dd>
+
     </dl>
 
     <p>This setting applies to the entire server, and cannot be
@@ -4636,7 +4640,10 @@ header</description>
     difficult to debug interoperational problems. Also note that
     disabling the Server: header does nothing at all to make your
     server more secure. The idea of "security through obscurity"
-    is a myth and leads to a false sense of safety.</note>
+    is a myth and leads to a false sense of safety. The "Off" setting
+    has been instituted not for security, but instead for specialized environments
+    that have need of customized headers and have issues with Apache's
+    <code>Server</code> header.</note>
 </usage>
 <seealso><directive module="core">ServerSignature</directive></seealso>
 </directivesynopsis>

--- a/modules/http/http_filters.c
+++ b/modules/http/http_filters.c
@@ -1063,8 +1063,16 @@ static void basic_http_header(request_rec *r, apr_bucket_brigade *bb,
 
     if (!server && *us)
         server = us;
-    if (server)
-        form_header_field(&h, "Server", server);
+    if (server) {
+        const char *server_version = ap_get_server_banner();
+        if(server_version[0] != '\0') {
+            form_header_field(&h, "Server", ap_get_server_banner());
+        }
+        else {
+            form_header_field(&h, "Server", server);
+        }
+    }
+        
 
     if (APLOGrtrace3(r)) {
         ap_log_rerror(APLOG_MARK, APLOG_TRACE3, 0, r,

--- a/server/core.c
+++ b/server/core.c
@@ -3479,7 +3479,8 @@ enum server_token_type {
     SrvTk_MINIMAL,       /* eg: Apache/2.0.41 */
     SrvTk_OS,            /* eg: Apache/2.0.41 (UNIX) */
     SrvTk_FULL,          /* eg: Apache/2.0.41 (UNIX) PHP/4.2.2 FooBar/1.2b */
-    SrvTk_PRODUCT_ONLY   /* eg: Apache */
+    SrvTk_PRODUCT_ONLY,   /* eg: Apache */
+    SrvTk_OFF            /* eg: Nothing - disables all output */
 };
 static enum server_token_type ap_server_tokens = SrvTk_FULL;
 
@@ -3555,6 +3556,9 @@ static void set_banner(apr_pool_t *pconf)
     else if (ap_server_tokens == SrvTk_MAJOR) {
         ap_add_version_component(pconf, AP_SERVER_BASEPRODUCT "/" AP_SERVER_MAJORVERSION);
     }
+    else if(ap_server_tokens == SrvTk_OFF) { /* handle SrvTk_OFF setting */
+        ap_add_version_component(pconf, "");
+    }
     else {
         ap_add_version_component(pconf, AP_SERVER_BASEVERSION " (" PLATFORM ")");
     }
@@ -3596,8 +3600,11 @@ static const char *set_serv_tokens(cmd_parms *cmd, void *dummy,
     else if (!ap_cstr_casecmp(arg, "Full")) {
         ap_server_tokens = SrvTk_FULL;
     }
+    else if (!ap_cstr_casecmp(arg, "Off")) {
+        ap_server_tokens = SrvTk_OFF;
+    }
     else {
-        return "ServerTokens takes 1 argument: 'Prod(uctOnly)', 'Major', 'Minor', 'Min(imal)', 'OS', or 'Full'";
+        return "ServerTokens takes 1 argument: 'Prod(uctOnly)', 'Major', 'Minor', 'Min(imal)', 'OS', 'Full', or 'OFF'";
     }
 
     return NULL;


### PR DESCRIPTION
Added support for passing 'Off' to ServerTokens to completely remove the Server response header field. This will allow specialized environments that need to carefully craft the web server headers to more easily integrate Apache into their setup.