### PR TITLE
Fix decrypt bug when error occurs

### DIFF
--- a/modules/session/mod_session_crypto.c
+++ b/modules/session/mod_session_crypto.c
@@ -403,6 +403,7 @@ static apr_status_t decrypt_string(request_rec * r, const apr_crypto_t *f,
          */
         compute_auth(slider, len, passphrase, passlen, auth);
         if (!ap_crypto_equals(auth, decoded, AP_SIPHASH_DSIZE)) {
+            res = APR_ECRYPT;
             ap_log_rerror(APLOG_MARK, APLOG_DEBUG, res, r, APLOGNO(10006)
                     "auth does not match, skipping");
             continue;


### PR DESCRIPTION
When the "auth" values ​​are different in the ap_crypto_equals() function, the value of the variable "res" should be set as an error, for example APR_ECRYPT.