### PR TITLE
[AB] Replace 'HTML transferred' by 'Body transferred'

### DIFF
--- a/docs/man/ab.1
+++ b/docs/man/ab.1
@@ -191,7 +191,7 @@ If configured to send data as part of the test, this is the total number of byte
 Total transferred
 The total number of bytes received from the server\&. This number is essentially the number of bytes sent over the wire\&.  
 .TP
-HTML transferred
+Body transferred
 The total number of document bytes received from the server\&. This number excludes bytes received in HTTP headers  
 .TP
 Requests per second

--- a/docs/man/tr/ab.1
+++ b/docs/man/tr/ab.1
@@ -185,7 +185,7 @@ Sınamanın parçası olarak veri gönderimi yapılandırılmışsa, bu sınama 
 Total transferred
 Sunucudan alınan toplam bayt sayısı\&. Bu sayı aslında hattan gönderilen bayt sayısıdır\&.  
 .TP
-HTML transferred
+Body transferred
 Sunucudan alınan belge baytlarının sayısı\&. Bu sayı HTTP başlıklarının bayt sayısını içermez\&.  
 .TP
 Requests per second

--- a/docs/manual/programs/ab.html.en
+++ b/docs/manual/programs/ab.html.en
@@ -290,7 +290,7 @@
         <dd>The total number of bytes received from the server. This number
         is essentially the number of bytes sent over the wire.</dd>
 
-        <dt>HTML transferred</dt>
+        <dt>Body transferred</dt>
         <dd>The total number of document bytes received from the server. This
         number excludes bytes received in HTTP headers</dd>
 

--- a/docs/manual/programs/ab.html.tr.utf8
+++ b/docs/manual/programs/ab.html.tr.utf8
@@ -302,7 +302,7 @@
         <dd>Sunucudan alınan toplam bayt sayısı. Bu sayı aslında hattan
           gönderilen bayt sayısıdır.</dd>
 
-        <dt>HTML transferred</dt>
+        <dt>Body transferred</dt>
         <dd>Sunucudan alınan belge baytlarının sayısı. Bu sayı HTTP
           başlıklarının bayt sayısını içermez.</dd>
 

--- a/docs/manual/programs/ab.xml
+++ b/docs/manual/programs/ab.xml
@@ -283,7 +283,7 @@
         <dd>The total number of bytes received from the server. This number
         is essentially the number of bytes sent over the wire.</dd>
 
-        <dt>HTML transferred</dt>
+        <dt>Body transferred</dt>
         <dd>The total number of document bytes received from the server. This
         number excludes bytes received in HTTP headers</dd>
 

--- a/docs/manual/programs/ab.xml.tr
+++ b/docs/manual/programs/ab.xml.tr
@@ -298,7 +298,7 @@
         <dd>Sunucudan alınan toplam bayt sayısı. Bu sayı aslında hattan
           gönderilen bayt sayısıdır.</dd>
 
-        <dt>HTML transferred</dt>
+        <dt>Body transferred</dt>
         <dd>Sunucudan alınan belge baytlarının sayısı. Bu sayı HTTP
           başlıklarının bayt sayısını içermez.</dd>
 

--- a/support/ab.c
+++ b/support/ab.c
@@ -964,7 +964,7 @@ static void output_results(int sig)
     if (send_body)
         printf("Total body sent:        %" APR_INT64_T_FMT "\n",
                totalposted);
-    printf("HTML transferred:       %" APR_INT64_T_FMT " bytes\n", totalbread);
+    printf("Body transferred:       %" APR_INT64_T_FMT " bytes\n", totalbread);
 
     /* avoid divide by zero */
     if (timetaken && done) {
@@ -1256,7 +1256,7 @@ static void output_html_results(void)
            "<td colspan=2 %s>%" APR_INT64_T_FMT "</td></tr>\n",
            trstring, tdstring,
            tdstring, totalposted);
-    printf("<tr %s><th colspan=2 %s>HTML transferred:</th>"
+    printf("<tr %s><th colspan=2 %s>Body transferred:</th>"
        "<td colspan=2 %s>%" APR_INT64_T_FMT " bytes</td></tr>\n",
        trstring, tdstring, tdstring, totalbread);
 
@@ -1543,7 +1543,7 @@ read_more:
                 good++;
                 close_connection(c);
             }
-            else if (scode == SSL_ERROR_SYSCALL 
+            else if (scode == SSL_ERROR_SYSCALL
                      && c->read == 0
                      && destsa->next
                      && c->state == STATE_CONNECTING


### PR DESCRIPTION
Because the server can return something different from HTML.
Like JSON