### PR TITLE
Prevent passed -S variable values from being interpolated

### DIFF
--- a/support/apxs.in
+++ b/support/apxs.in
@@ -178,7 +178,7 @@ if (@opt_S) {
 		&usage;
 	    }
 
-	    eval "\$CFG_${var}=\"${val}\"";
+	    eval "\$CFG_${var}='${val}'";
 	} else {
 	    print STDERR "apxs:Error: malformatted -S option\n";
 	    &usage;


### PR DESCRIPTION
This avoids problems with paths that include "@".