### PR TITLE
Added model/gltf-binary to mime.types

### DIFF
--- a/docs/conf/mime.types
+++ b/docs/conf/mime.types
@@ -1632,6 +1632,7 @@ message/rfc822					eml mime
 # message/vnd.si.simp
 # message/vnd.wfa.wsc
 # model/example
+model/gltf-binary				glb
 # model/gltf+json
 model/iges					igs iges
 model/mesh					msh mesh silo


### PR DESCRIPTION
The model/gtlf-binary mime type was recently registered with the iana, and can be seen on the registry at: https://www.iana.org/assignments/media-types/media-types.xhtml
A full description of the type can be found at: https://www.iana.org/assignments/media-types/model/gltf-binary
The file type for model/gltf-binary is .glb, the spec for which is located at: https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#glb-file-format-specification
mime/gltf-binary is a binary container format for GLTF (GL Transmission fomat), an open source 3D model format.