### PR TITLE
* modules/filters/mod_xml2enc.c (xml2enc_ffunc): do not remove error buckets

### DIFF
--- a/modules/filters/mod_xml2enc.c
+++ b/modules/filters/mod_xml2enc.c
@@ -404,6 +404,10 @@ static apr_status_t xml2enc_ffunc(ap_filter_t* f, apr_bucket_brigade* bb)
                 /* send remaining data */
                 APR_BRIGADE_INSERT_TAIL(ctx->bbnext, b);
                 return ap_fflush(f->next, ctx->bbnext);
+            } else if (AP_BUCKET_IS_ERROR(b)) {
+                /* passing error bucket down the chain */
+                APR_BRIGADE_INSERT_TAIL(ctx->bbnext, b);
+                continue;
             } else if (APR_BUCKET_IS_FLUSH(b)) {
                 ap_fflush(f->next, ctx->bbnext);
             }


### PR DESCRIPTION
Error bucket is a special kind of meta bucket that is not part of apr but added in httpd and can be created via the ap_bucket_error_create() call.  This type of bucket is simply destroyed by mod_xml2enc.