### PR TITLE
ASF-54339 interleaved logs

### DIFF
--- a/docs/manual/logs.xml
+++ b/docs/manual/logs.xml
@@ -614,6 +614,26 @@ CustomLog "|$/usr/local/apache/bin/rotatelogs   /var/log/access_log 86400" commo
     "<code>||</code>" is also supported and equivalent to using
     "<code>|</code>".</p>
 
+    <p>Depending on your OS, there may be a pipe buffer size limit
+    for safe, atomic writes to a pipe. Log records that exceed that
+    buffer limit may be interleaved and corrupted.
+    Use "<code>|&lt;</code>" (mnemonic, split pipe) to split log
+    records across the pipe so they may be reassembled by the piped
+    program to preserve their integrity. The program receiving the
+    records must know how to reassemble the records, and currently,
+    rotatelogs supports this. When used, a variable
+    (AP_MOD_LOG_CONFIG_CHUNKED_MSG) is exported to the environment
+    so the receiving program can take appropriate action. This option
+    may be used in conjunction with the shell option
+    <code>|&lt;$</code>" (or for compatibility "<code>||&lt;</code>").
+    This option is not available for ErrorLog directives and if
+    present, a warning will be emitted.</p>
+
+    <highlight language="config">
+# Invoke "rotatelogs" with a safe (atomic split) pipe
+CustomLog "|&lt;/usr/local/apache/bin/rotatelogs   /var/log/access_log 86400" common
+    </highlight>
+
     <note><title>Windows note</title>
     <p>Note that on Windows, you may run into problems when running many piped
     logger processes, especially when HTTPD is running as a service. This is

--- a/docs/manual/mod/mod_log_config.xml
+++ b/docs/manual/mod/mod_log_config.xml
@@ -476,7 +476,8 @@ expr=<var>expression</var>]</syntax>
       >ServerRoot</directive>.</dd>
 
       <dt><var>pipe</var></dt>
-      <dd>The pipe character "<code>|</code>", followed by the path
+      <dd>The pipe character "<code>|</code>" (or safe pipe
+      "<code>|&lt;</code>"), followed by the path
       to a program to receive the log information on its standard
       input. See the notes on <a href="../logs.html#piped">piped logs</a>
       for more information.

--- a/include/http_log.h
+++ b/include/http_log.h
@@ -282,6 +282,25 @@ AP_DECLARE_DATA extern int ap_default_loglevel;
  */
 #define APLOG_MARK     __FILE__,__LINE__,APLOG_MODULE_INDEX
 
+/* POSIX.1 defines PIPE_BUF as the maximum number of bytes that is
+ * guaranteed to be atomic when writing a pipe.  And PIPE_BUF >= 512
+ * is guaranteed.  So we'll just guess 512 in the event the system
+ * doesn't have this.  Now, for file writes there is actually no limit,
+ * the entire write is atomic.  Whether all systems implement this
+ * correctly is another question entirely ... so we'll just use PIPE_BUF
+ * because it's probably a good guess as to what is implemented correctly
+ * everywhere.
+ */
+#ifdef PIPE_BUF
+#define LOG_BUFSIZE     PIPE_BUF
+#else
+#define LOG_BUFSIZE     (512)
+#endif
+
+#define MSG_HEADER_ELT_CNT 5
+#define MSG_HEADER_LEN (sizeof(uint32_t) * MSG_HEADER_ELT_CNT)
+#define LOG_BUFSIZE_LESS_CHUNKHEAD (LOG_BUFSIZE - MSG_HEADER_LEN)
+
 /**
  * Set up for logging to stderr.
  * @param p The pool to allocate out of

--- a/include/scoreboard.h
+++ b/include/scoreboard.h
@@ -157,6 +157,10 @@ typedef struct {
 } scoreboard;
 
 typedef struct ap_sb_handle_t ap_sb_handle_t;
+struct ap_sb_handle_t {
+    int child_num;
+    int thread_num;
+};
 
 /*
  * Creation and deletion (internal)

--- a/modules/loggers/mod_log_config.h
+++ b/modules/loggers/mod_log_config.h
@@ -30,6 +30,8 @@
 #ifndef _MOD_LOG_CONFIG_H
 #define _MOD_LOG_CONFIG_H 1
 
+typedef struct config_log_state config_log_state;
+
 /**
  * callback function prototype for a external log handler
  */
@@ -39,7 +41,7 @@ typedef const char *ap_log_handler_fn_t(request_rec *r, char *a);
  * callback function prototype for external writer initialization.
  */
 typedef void *ap_log_writer_init(apr_pool_t *p, server_rec *s,
-                                 const char *name);
+                                 config_log_state* cls);
 /**
  * callback which gets called where there is a log line to write.
  */
@@ -49,7 +51,8 @@ typedef apr_status_t ap_log_writer(
                             const char **portions,
                             int *lengths,
                             int nelts,
-                            apr_size_t len);
+                            apr_size_t len,
+                            int chunk_msgs);
 
 typedef struct ap_log_handler {
     ap_log_handler_fn_t *func;

--- a/server/log.c
+++ b/server/log.c
@@ -313,6 +313,12 @@ static int open_error_log(server_rec *s, int is_main, apr_pool_t *p)
          */
         if (*fname == '|')
             ++fname;
+        if (*fname == '<') {
+            ap_log_error(APLOG_MARK, APLOG_STARTUP, rc, NULL, APLOGNO(035010)
+                         "Safe pipe '<' not supported for ErrorLog: '%s'.",
+                         s->error_fname);
+            ++fname;
+        }
         if (*fname == '$') {
             cmdtype = APR_SHELLCMD_ENV;
             ++fname;

--- a/server/scoreboard.c
+++ b/server/scoreboard.c
@@ -104,11 +104,6 @@ AP_IMPLEMENT_HOOK_RUN_ALL(int,pre_mpm,
 static APR_OPTIONAL_FN_TYPE(ap_logio_get_last_bytes)
                                 *pfn_ap_logio_get_last_bytes;
 
-struct ap_sb_handle_t {
-    int child_num;
-    int thread_num;
-};
-
 static int server_limit, thread_limit;
 static apr_size_t scoreboard_size;
 

--- a/support/rotatelogs.c
+++ b/support/rotatelogs.c
@@ -25,6 +25,9 @@
 #include "apr_getopt.h"
 #include "apr_thread_proc.h"
 #include "apr_signal.h"
+#include "apr_env.h"
+#include "apr_hash.h"
+#include "apr_tables.h"
 #if APR_FILES_AS_SOCKETS
 #include "apr_poll.h"
 #endif
@@ -33,7 +36,11 @@
 #include <stdlib.h>
 #endif
 #define APR_WANT_STRFUNC
+#define APR_WANT_BYTEFUNC   /* for htons() et al */
 #include "apr_want.h"
+
+#include "httpd.h"
+#include "http_log.h"
 
 #define BUFSIZE         65536
 
@@ -556,6 +563,121 @@ static const char *get_time_or_size(rotate_config_t *config,
     return NULL;
 }
 
+static apr_status_t read_chunk(apr_file_t *f_stdin, apr_pool_t *p, char *buf,
+                               char **msg, apr_hash_t *thread_chunks,
+                               apr_size_t *nRead)
+{
+    apr_status_t rv;
+    uint32_t chunk_header[MSG_HEADER_ELT_CNT];
+    uint32_t proc_slot, thd_slot, chunk_cnt, tot_chunk_cnt, chunk_body_len;
+
+    /* Read just the chunk header, expected to be present in its entirety. */
+    rv = apr_file_read_full(f_stdin, chunk_header, MSG_HEADER_LEN, nRead);
+    if (APR_STATUS_IS_EOF(rv)) {
+        return rv;
+    }
+    else if (rv != APR_SUCCESS) {
+        exit(3);
+    }
+    proc_slot = ntohl(chunk_header[0]);
+    thd_slot = ntohl(chunk_header[1]);
+    chunk_cnt = ntohl(chunk_header[2]);
+    tot_chunk_cnt = ntohl(chunk_header[3]);
+    chunk_body_len = ntohl(chunk_header[4]);
+
+    /* Read the full chunk body, expected to be present in its entirety. */
+    rv = apr_file_read_full(f_stdin, buf, (apr_size_t)chunk_body_len, nRead);
+    if (APR_STATUS_IS_EOF(rv)) {
+        return rv;
+    }
+    else if (rv != APR_SUCCESS) {
+        exit(3);
+    }
+
+    if (chunk_cnt != 1 || tot_chunk_cnt != 1) {
+        /* 
+         * If this is a multi-chunk log record, stage the chunks so they can be
+         * reassembled in order.
+         */
+        uint32_t chunk_idx = chunk_cnt - 1;
+        char *chunk_body;
+        char **chunk_elem;
+        char *slot_key;
+        apr_array_header_t *chunks_head;
+
+        slot_key = apr_psprintf(p, "%i.%i", proc_slot, thd_slot);
+        chunks_head = apr_hash_get(thread_chunks, slot_key,
+                                   APR_HASH_KEY_STRING);
+        /* A thread must write chunks of a message in order. */
+        if (chunks_head == NULL) {
+            if (chunk_idx > 0) {
+                /*
+                 * Expected to have a table entry here since we're in
+                 * mid-sequence for this chunk set.
+                 */
+                fprintf(stderr, "Chunks found in a non-ordered sequence, "
+                                "skipping this chunk set\n");
+                return APR_SUCCESS;
+            }
+            chunks_head = apr_array_make(p, 10, sizeof(char *));
+            apr_hash_set(thread_chunks, slot_key, APR_HASH_KEY_STRING,
+                         chunks_head);
+        }
+        else {
+            /* Check that the chunk list size jives with chunk_cnt. */
+            if (chunk_idx != chunks_head->nelts) {
+                fprintf(stderr, "Chunks found in a non-ordered sequence, "
+                                "skipping this chunk set\n");
+                apr_array_clear(chunks_head);
+                return APR_SUCCESS;
+            }
+        }
+
+        chunk_elem = apr_array_push(chunks_head);
+
+        /* Stage this chunk. */
+        chunk_body = malloc(chunk_body_len);
+        memcpy(chunk_body, buf, chunk_body_len);
+        *chunk_elem = chunk_body;
+
+        if (chunk_cnt == tot_chunk_cnt) {
+            /*
+             * If this is the final chunk, glue them together so the original
+             * message can be written below.
+             */
+            uint32_t chunk_len;
+            uint32_t chunk_iter;
+            uint32_t cpy_len = 0;
+
+            *msg = malloc(LOG_BUFSIZE_LESS_CHUNKHEAD * tot_chunk_cnt);
+            for (chunk_iter = 0; chunk_iter < chunks_head->nelts;
+                 ++chunk_iter) {
+                char *chunk = ((char**)chunks_head->elts)[chunk_iter];
+                chunk_len = LOG_BUFSIZE_LESS_CHUNKHEAD;
+                if (chunk_iter + 1 == tot_chunk_cnt)
+                    chunk_len = chunk_body_len;
+                memcpy(*msg + cpy_len, chunk, chunk_len);
+                cpy_len += chunk_len;
+                free(chunk);
+            }
+            *nRead = cpy_len;
+            apr_array_clear(chunks_head);
+        }
+        else {
+            /* Otherwise continue staging and writing single-chunk messages. */
+            return APR_SUCCESS;
+        }
+    }
+    else {
+        /*
+         * This log message is transferred in a single chunk, simply return and
+         * write it.
+         */
+        *msg = buf;
+    }
+    return APR_SUCCESS;
+}
+
 int main (int argc, const char * const argv[])
 {
     char buf[BUFSIZE];
@@ -565,8 +687,12 @@ int main (int argc, const char * const argv[])
     apr_getopt_t *opt;
     apr_status_t rv;
     char c;
+    char *env;
     const char *opt_arg;
     const char *err = NULL;
+    int chunked_msgs;
+    apr_hash_t *thread_chunks;
+    char *msg;
 #if APR_FILES_AS_SOCKETS
     apr_pollfd_t pollfd = { 0 };
     apr_status_t pollret = APR_SUCCESS;
@@ -693,6 +819,11 @@ int main (int argc, const char * const argv[])
     }
 #endif
 
+    rv = apr_env_get(&env, "AP_MOD_LOG_CONFIG_CHUNKED_MSG", status.pool);
+    chunked_msgs = (rv == APR_SUCCESS && env != NULL);
+
+    thread_chunks = apr_hash_make(status.pool);
+
     /*
      * Immediately open the logfile as we start, if we were forced
      * to do so via '-f'.
@@ -702,7 +833,10 @@ int main (int argc, const char * const argv[])
     }
 
     for (;;) {
+        int freemsg = 0;
+        int skip_write = 0;
         nRead = sizeof(buf);
+        msg = NULL;
 #if APR_FILES_AS_SOCKETS
         if (config.create_empty && config.tRotation) {
             polltimeout = status.tLogEnd ? status.tLogEnd - get_now(&config, NULL) : config.tRotation;
@@ -714,16 +848,28 @@ int main (int argc, const char * const argv[])
             }
         }
         if (pollret == APR_SUCCESS) {
-            rv = apr_file_read(f_stdin, buf, &nRead);
+            if (chunked_msgs) {
+                rv = read_chunk(f_stdin, status.pool, buf, &msg,
+                                thread_chunks, &nRead);
+            }
+            else {
+                rv = apr_file_read(f_stdin, buf, &nRead);
+                msg = buf;
+            }
             if (APR_STATUS_IS_EOF(rv)) {
                 break;
             }
             else if (rv != APR_SUCCESS) {
                 exit(3);
             }
+            if (msg == NULL)
+                skip_write = 1;
+            else if (msg != buf)
+                freemsg = 1;
         }
         else if (pollret == APR_TIMEUP) {
             *buf = 0;
+            msg = buf;
             nRead = 0;
         }
         else {
@@ -731,21 +877,35 @@ int main (int argc, const char * const argv[])
             exit(5);
         }
 #else /* APR_FILES_AS_SOCKETS */
-        rv = apr_file_read(f_stdin, buf, &nRead);
+        if (chunked_msgs) {
+            rv = read_chunk(f_stdin, status.pool, buf, &msg,
+                            thread_chunks, &nRead);
+        }
+        else {
+            rv = apr_file_read(f_stdin, buf, &nRead);
+            msg = buf;
+        }
         if (APR_STATUS_IS_EOF(rv)) {
             break;
         }
         else if (rv != APR_SUCCESS) {
             exit(3);
         }
+        if (msg == NULL)
+            skip_write = 1;
+        else if (msg != buf)
+            freemsg = 1;
 #endif /* APR_FILES_AS_SOCKETS */
         checkRotate(&config, &status);
         if (status.rotateReason != ROTATE_NONE) {
             doRotate(&config, &status);
         }
 
+        if (skip_write)
+            continue;
+
         nWrite = nRead;
-        rv = apr_file_write_full(status.current.fd, buf, nWrite, &nWrite);
+        rv = apr_file_write_full(status.current.fd, msg, nWrite, &nWrite);
         if (nWrite != nRead) {
             apr_off_t cur_offset;
             apr_pool_t *pool;
@@ -768,11 +928,13 @@ int main (int argc, const char * const argv[])
             status.nMessCount++;
         }
         if (config.echo) {
-            if (apr_file_write_full(f_stdout, buf, nRead, NULL)) {
+            if (apr_file_write_full(f_stdout, msg, nRead, NULL)) {
                 fprintf(stderr, "Unable to write to stdout\n");
                 exit(4);
             }
         }
+        if (freemsg)
+            free(msg);
     }
 
     return 0; /* reached only at stdin EOF. */


### PR DESCRIPTION
Under high load, log output showed interleaving of log
records. When writing to a pipe, any message
greater than PIPE_BUF may interleave with concurrent writers, any
message PIPE_BUF or less is guaranteed to be atomic. On Linux, this
is typically 4K.

* Patch Apache HTTPD Server to break up log messages > PIPE_BUF into
  smaller chunks that are guaranteed to remain intact with multiple
  writers when configured with '|<' (mnemonic, split pipe, rather than
  just '|' for piped log output).
* Patch rotatelogs program to reassemble the chunks.