### PR TITLE
Fix to compile against openssl-1.1.1

### DIFF
--- a/support/ab.c
+++ b/support/ab.c
@@ -651,11 +651,11 @@ static void ssl_print_cert_info(BIO *bio, X509 *cert)
 
     BIO_printf(bio, "Certificate version: %ld\n", X509_get_version(cert)+1);
     BIO_printf(bio,"Valid from: ");
-    ASN1_UTCTIME_print(bio, X509_get_notBefore(cert));
+    ASN1_UTCTIME_print(bio, X509_getm_notBefore(cert));
     BIO_printf(bio,"\n");
 
     BIO_printf(bio,"Valid to  : ");
-    ASN1_UTCTIME_print(bio, X509_get_notAfter(cert));
+    ASN1_UTCTIME_print(bio, X509_getm_notAfter(cert));
     BIO_printf(bio,"\n");
 
     pk = X509_get_pubkey(cert);
@@ -2629,8 +2629,7 @@ int main(int argc, const char * const argv[])
     CRYPTO_malloc_init();
 #endif
 #endif
-    SSL_load_error_strings();
-    SSL_library_init();
+    OPENSSL_init_ssl(0, NULL);
     bio_out=BIO_new_fp(stdout,BIO_NOCLOSE);
     bio_err=BIO_new_fp(stderr,BIO_NOCLOSE);
 


### PR DESCRIPTION
replace deprecated openssl functions to make it compile with openssl-1.1.1
- X509_get_notBefore
- X509_get_notAfter
see https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-pre8/include/openssl/x509.h#L653-L658
- SSL_library_init
see https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-pre8/include/openssl/ssl.h#L1921-L1923
- SSL_load_error_strings
see https://github.com/openssl/openssl/blob/c5d1fb78fd0fdbe1f1e61211bd56192a0f95bc91/include/openssl/ssl.h#L1583-L1587