### PR TITLE
fix websocket proxy worker naming for UDS

### DIFF
--- a/modules/proxy/mod_proxy_wstunnel.c
+++ b/modules/proxy/mod_proxy_wstunnel.c
@@ -77,7 +77,10 @@ static int proxy_wstunnel_canon(request_rec *r, char *url)
     if (path == NULL)
         return HTTP_BAD_REQUEST;
 
-    apr_snprintf(sport, sizeof(sport), ":%d", port);
+    if (port != def_port)
+        apr_snprintf(sport, sizeof(sport), ":%d", port);
+    else
+        sport[0] = '\0';
 
     if (ap_strchr_c(host, ':')) {
         /* if literal IPv6 address */


### PR DESCRIPTION
configuration example:
<Location "/apis">
  ProxyPass unix:/var/run/unix.sock|ws://127.0.0.1/api
</Location>

currently ap_proxy_get_worker can't get matched pre-defined worker because of different uri formatting in proxy_wstunnel_canon and ap_proxy_define_worker

from additionally added logs i see how ap_proxy_get_worker has failed to match

ws://127.0.0.1:80/api/router/proxy AND ws://127.0.0.1/api
and fallback to default (*) proxy worker (which does work because nothing know about UDS path)

imho this patch should be pushed to trunk also
