### PR TITLE
Suggest bracketing with IfModule

### DIFF
--- a/docs/conf/extra/httpd-autoindex.conf.in
+++ b/docs/conf/extra/httpd-autoindex.conf.in
@@ -1,3 +1,4 @@
+<IfModule mod_autoindex>
 #
 # Directives controlling the display of server-generated directory listings.
 #
@@ -91,3 +92,4 @@ HeaderName HEADER.html
 #
 IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
 
+</IfModule>


### PR DESCRIPTION
Add ``<IfModule mod_autoindex></IfModule>`` around ``docs/conf/extra/httpd-autoindex.conf.in``

When my server was built earlier, ``autoindex.conf`` was apparently removed and ``mod_autoindex.so`` was commented out. On applying a recent update, this conf file was re-deployed, and prevented the server from starting.

The other ``*.conf`` files don't appear to be protected like this. I assume this has been discussed in places I haven't found yet.