### PR TITLE
Allow separation of file owner and user to run code

### DIFF
--- a/include/http_config.h
+++ b/include/http_config.h
@@ -63,7 +63,9 @@ enum cmd_how {
     TAKE23,             /**< two or three arguments */
     TAKE123,            /**< one, two or three arguments */
     TAKE13,             /**< one or three arguments */
-    TAKE_ARGV           /**< an argc and argv are passed */
+    TAKE_ARGV,          /**< an argc and argv are passed */
+    TAKE4,              /**< four arguments only */
+    TAKE24              /**< two or four arguments */
 };
 
 /**
@@ -96,6 +98,9 @@ typedef union {
     /** function to call for a take3 */
     const char *(*take3) (cmd_parms *parms, void *mconfig, const char *w,
                           const char *w2, const char *w3);
+    /** function to call for a take4 */
+    const char *(*take4) (cmd_parms *parms, void *mconfig, const char *w,
+                          const char *w2, const char *w3, const char *w4);
     /** function to call for a flag */
     const char *(*flag) (cmd_parms *parms, void *mconfig, int on);
 } cmd_func;
@@ -112,6 +117,8 @@ typedef union {
 # define AP_TAKE2       func.take2
 /** This configuration directive takes 3 arguments */
 # define AP_TAKE3       func.take3
+/** This configuration directive takes 4 arguments */
+# define AP_TAKE4       func.take4
 /** This configuration directive takes a flag (on/off) as a argument*/
 # define AP_FLAG        func.flag
 
@@ -154,7 +161,12 @@ typedef union {
 /** mechanism for declaring a directive which takes a flag (on/off) argument */
 # define AP_INIT_FLAG(directive, func, mconfig, where, help) \
     { directive, { .flag=func }, mconfig, where, FLAG, help }
-
+/** mechanism for declaring a directive which takes 4 arguments */
+# define AP_INIT_TAKE4(directive, func, mconfig, where, help) \
+    { directive, { .take4=func }, mconfig, where, TAKE4, help }
+/** mechanism for declaring a directive which takes 2 or 4 arguments */
+# define AP_INIT_TAKE24(directive, func, mconfig, where, help) \
+    { directive, { .take4=func }, mconfig, where, TAKE24, help }
 #else /* AP_HAVE_DESIGNATED_INITIALIZER */
 
 typedef const char *(*cmd_func) ();
@@ -165,6 +177,7 @@ typedef const char *(*cmd_func) ();
 # define AP_TAKE1    func
 # define AP_TAKE2    func
 # define AP_TAKE3    func
+# define AP_TAKE4    func
 # define AP_FLAG     func
 
 # define AP_INIT_NO_ARGS(directive, func, mconfig, where, help) \
@@ -193,6 +206,10 @@ typedef const char *(*cmd_func) ();
     { directive, func, mconfig, where, TAKE3, help }
 # define AP_INIT_FLAG(directive, func, mconfig, where, help) \
     { directive, func, mconfig, where, FLAG, help }
+# define AP_INIT_TAKE4(directive, func, mconfig, where, help) \
+    { directive, func, mconfig, where, TAKE4, help }
+# define AP_INIT_TAKE24(directive, func, mconfig, where, help) \
+    { directive, func, mconfig, where, TAKE24, help }
 
 #endif /* AP_HAVE_DESIGNATED_INITIALIZER */
 

--- a/modules/generators/mod_suexec.c
+++ b/modules/generators/mod_suexec.c
@@ -56,7 +56,8 @@ static void *create_mconfig_for_directory(apr_pool_t *p, char *dir)
 }
 
 static const char *set_suexec_ugid(cmd_parms *cmd, void *mconfig,
-                                   const char *uid, const char *gid)
+                                   const char *uid, const char *gid,
+                                   const char *ouid, const char *ogid)
 {
     suexec_config_t *cfg = (suexec_config_t *) mconfig;
     const char *err = ap_check_cmd_context(cmd, NOT_IN_DIR_CONTEXT);
@@ -73,6 +74,8 @@ static const char *set_suexec_ugid(cmd_parms *cmd, void *mconfig,
 
     cfg->ugid.uid = ap_uname2id(uid);
     cfg->ugid.gid = ap_gname2id(gid);
+    cfg->ugid.ouid = ouid ? ap_uname2id(ouid) : cfg->ugid.uid;
+    cfg->ugid.ogid = ogid ? ap_gname2id(ogid) : cfg->ugid.gid;
     cfg->ugid.userdir = 0;
     cfg->active = 1;
 
@@ -116,7 +119,7 @@ static const command_rec suexec_cmds[] =
 {
     /* XXX - Another important reason not to allow this in .htaccess is that
      * the ap_[ug]name2id() is not thread-safe */
-    AP_INIT_TAKE2("SuexecUserGroup", set_suexec_ugid, NULL, RSRC_CONF,
+    AP_INIT_TAKE24("SuexecUserGroup", set_suexec_ugid, NULL, RSRC_CONF,
       "User and group for spawned processes"),
     { NULL }
 };

--- a/os/unix/unixd.h
+++ b/os/unix/unixd.h
@@ -56,6 +56,8 @@ extern "C" {
 typedef struct {
     uid_t uid;
     gid_t gid;
+    uid_t ouid;
+    gid_t ogid;
     int userdir;
 } ap_unix_identity_t;
 

--- a/server/config.c
+++ b/server/config.c
@@ -856,7 +856,7 @@ static const char *invoke_cmd(const command_rec *cmd, cmd_parms *parms,
                               ap_directive_t *parent)
 {
     int override_list_ok = 0;
-    char *w, *w2, *w3;
+    char *w, *w2, *w3, *w4;
     const char *errmsg = NULL;
 
     /* Have we been provided a list of acceptable directives? */
@@ -995,6 +995,31 @@ static const char *invoke_cmd(const command_rec *cmd, cmd_parms *parms,
                                cmd->errmsg ? ", " : NULL, cmd->errmsg, NULL);
 
         return cmd->AP_TAKE3(parms, mconfig, w, w2, w3);
+
+    case TAKE4:
+        w = ap_getword_conf(parms->pool, &args);
+        w2 = ap_getword_conf(parms->pool, &args);
+        w3 = ap_getword_conf(parms->pool, &args);
+        w4 = ap_getword_conf(parms->pool, &args);
+
+        if (*w == '\0' || *w2 == '\0' || *w3 == '\0' || *w4 == '\0' || *args != 0)
+            return apr_pstrcat(parms->pool, cmd->name, " takes four arguments",
+                               cmd->errmsg ? ", " : NULL, cmd->errmsg, NULL);
+
+        return cmd->AP_TAKE4(parms, mconfig, w, w2, w3, w4);
+
+    case TAKE24:
+        w = ap_getword_conf(parms->pool, &args);
+        w2 = ap_getword_conf(parms->pool, &args);
+        w3 = *args ? ap_getword_conf(parms->pool, &args) : NULL;
+        w4 = *args ? ap_getword_conf(parms->pool, &args) : NULL;
+
+        if (*w == '\0' || *w2 == '\0' || (!w3 && w4 && *w4) || (w3 && *w3 && !w4) || *args != 0)
+            return apr_pstrcat(parms->pool, cmd->name, 
+			    " takes two or four arguments",
+                               cmd->errmsg ? ", " : NULL, cmd->errmsg, NULL);
+
+        return cmd->AP_TAKE4(parms, mconfig, w, w2, w3, w4);
 
     case ITERATE:
         w = ap_getword_conf(parms->pool, &args);

--- a/support/suexec.h
+++ b/support/suexec.h
@@ -56,6 +56,22 @@
 #endif
 
 /*
+ * OUID_MIN -- Define this as the lowest UID allowed to be a owner user
+ *            for suEXEC.  For most systems, 500 or 100 is common.
+ */
+#ifndef AP_OUID_MIN
+#define AP_OUID_MIN 100
+#endif
+
+/*
+ * OGID_MIN -- Define this as the lowest GID allowed to be a owner group
+ *            for suEXEC.  For most systems, 100 is common.
+ */
+#ifndef AP_OGID_MIN
+#define AP_OGID_MIN 100
+#endif
+
+/*
  * USERDIR_SUFFIX -- Define to be the subdirectory under users'
  *                   home directories where suEXEC access should
  *                   be allowed.  All executables under this directory


### PR DESCRIPTION
Small change to allow defining separately file owner and user to run as in suexec (WARNING - suexec modification).

With this patch 2 versions of SuexecUserGroup option are allowed
old one:
SuexecUserGroup user group
and new one:
SuexecUserGroup runasuser runasgroup fileowneruser fileownergroup

It allows using suexec with no write access to code that is being executed.
It also prevents execution of code that was uploaded due to security bugs in web application as long as both users are not the same.