### PR TITLE
Fix 1 missing dependency in Makefile.in

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -298,7 +298,7 @@ install-suexec-caps: install-suexec-binary
             setcap 'cap_setuid,cap_setgid+pe' $(DESTDIR)$(sbindir)/suexec; \
 	fi
 
-suexec:
+suexec: support/suexec.h support/suexec.c
 	cd support && $(MAKE) suexec
 
 x-local-distclean:


### PR DESCRIPTION
Hi, I've fixed 1 missing dependency reported.
Those issues can cause incorrect results when `httpd` is incrementally built.
Detailed speaking, `support/suexec.h` and `support/suexec.c` are both read by the process when `suexec` is built. However, they are not specified as the prerequisites of it. I have added them to the corresponding rule in Makefile.in.
I've tested it on my computer, the fixed version worked as expected.
Looking forward to your confirmation.

Thanks
Vemake