### PR TITLE
BZ-62497: Make r.ap_auth_type writable via mod_lua

### DIFF
--- a/docs/manual/mod/mod_lua.xml
+++ b/docs/manual/mod/mod_lua.xml
@@ -353,7 +353,7 @@ end
         <tr>
           <td><code>ap_auth_type</code></td>
           <td>string</td>
-          <td>no</td>
+          <td>yes</td>
           <td>If an authentication check was made, this is set to the type
           of authentication (f.x. <code>basic</code>)</td>
         </tr>

--- a/docs/manual/mod/mod_lua.xml.fr
+++ b/docs/manual/mod/mod_lua.xml.fr
@@ -376,7 +376,7 @@ end
         <tr>
           <td><code>ap_auth_type</code></td>
           <td>string</td>
-          <td>non</td>
+          <td>oui</td>
 	  <td>Ce champ contient le type d'authentification effectuée
 	  (par exemple <code>basic</code>)</td>
         </tr>

--- a/modules/lua/lua_request.c
+++ b/modules/lua/lua_request.c
@@ -2542,6 +2542,12 @@ static int req_newindex(lua_State *L)
     request_rec *r = ap_lua_check_request_rec(L, 1);
     key = luaL_checkstring(L, 2);
 
+    if (0 == strcmp("ap_auth_type", key)) {
+        const char *value = luaL_checkstring(L, 3);
+        r->ap_auth_type = apr_pstrdup(r->pool, value);
+        return 0;
+    }
+
     if (0 == strcmp("args", key)) {
         const char *value = luaL_checkstring(L, 3);
         r->args = apr_pstrdup(r->pool, value);


### PR DESCRIPTION
This completes the option of setting the remote user by the authentication
mechanism which actually verified the user.

One possible usecase is that a proxied (upstream) server performs the
authentication, but the access log of HTTPd does not contain this information.
The upstream server can pass this kind of information back to HTTPd and both
servers will have consistent access logs.