### PR TITLE
server/utils: fix Bison directives

### DIFF
--- a/server/util_expr_parse.y
+++ b/server/util_expr_parse.y
@@ -98,22 +98,22 @@
 %right  T_OP_NOT
 %right  T_OP_CONCAT
 
-%type   <exVal>   cond              "condition"
-%type   <exVal>   comp              "comparison"
-%type   <exVal>   strfunc           "string function"
-%type   <exVal>   listfunc          "list function"
-%type   <exVal>   list              "list"
-%type   <exVal>   words             "words"
-%type   <exVal>   word              "word"
-%type   <exVal>   string            "string"
-%type   <exVal>   substr            "substring"
-%type   <exVal>   var               "variable"
-%type   <exVal>   regex             "match regex"
-%type   <exVal>   regsub            "substitution regex"
-%type   <exVal>   regany            "any regex"
-%type   <exVal>   split             "split"
-%type   <exVal>   join              "join"
-%type   <exVal>   sub               "sub"
+%nterm  <exVal>   cond
+%nterm  <exVal>   comp
+%nterm  <exVal>   strfunc
+%nterm  <exVal>   listfunc
+%nterm  <exVal>   list
+%nterm  <exVal>   words
+%nterm  <exVal>   word
+%nterm  <exVal>   string
+%nterm  <exVal>   substr
+%nterm  <exVal>   var
+%nterm  <exVal>   regex
+%nterm  <exVal>   regsub
+%nterm  <exVal>   regany
+%nterm  <exVal>   split
+%nterm  <exVal>   join
+%nterm  <exVal>   sub
 
 %{
 #include "util_expr_private.h"
@@ -249,4 +249,3 @@ void yyerror(ap_expr_parse_ctx_t *ctx, const char *s)
     /* s is allocated on the stack */
     ctx->error = apr_pstrdup(ctx->ptemp, s);
 }
-


### PR DESCRIPTION
Non terminal cannot have string aliases (only tokens appear in error
messages).  %token is used to define tokens, and %nterm non terminals.
The hidden %type (which was only recently documented) is meant for
both tokens and non terminals.  Yet

    %type <foo> expr "expression"

is actually more or less equivalent to

    %nterm <foo> expr
    %token <foo> "expression"

which is clearly not the intention of the author here.

* server/util_expr_parse.y: Remove useless string-literal only tokens.
Prefer %nterm to %type to avoid this error.