### PR TITLE
Delay some memory allocation.

### DIFF
--- a/modules/proxy/mod_proxy_ftp.c
+++ b/modules/proxy/mod_proxy_ftp.c
@@ -972,7 +972,7 @@ static int proxy_ftp_handler(request_rec *r, proxy_worker *worker,
     conn_rec *origin, *data = NULL;
     apr_status_t err = APR_SUCCESS;
     apr_status_t uerr = APR_SUCCESS;
-    apr_bucket_brigade *bb = apr_brigade_create(p, c->bucket_alloc);
+    apr_bucket_brigade *bb;
     char *buf, *connectname;
     apr_port_t connectport;
     char *ftpmessage = NULL;
@@ -1204,6 +1204,7 @@ static int proxy_ftp_handler(request_rec *r, proxy_worker *worker,
      * correct directory...
      */
 
+    bb = apr_brigade_create(p, c->bucket_alloc);
 
     /* possible results: */
     /* 120 Service ready in nnn minutes. */


### PR DESCRIPTION
If this handler will not handle the request, no need to waste bytes in the request pool.

git-svn-id: https://svn.apache.org/repos/asf/httpd/httpd/trunk@1829676 13f79535-47bb-0310-9956-ffa450edef68