### PR TITLE
63503 backport step3

### DIFF
--- a/modules/proxy/mod_proxy_balancer.c
+++ b/modules/proxy/mod_proxy_balancer.c
@@ -1436,7 +1436,7 @@ static int balancer_handler(request_rec *r)
                     /* by default, all new workers are disabled */
                     ap_proxy_set_wstatus(PROXY_WORKER_DISABLED_FLAG, 1, nworker);
                 } else {
-                            ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, APLOGNO(01207)
+                            ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, APLOGNO(10163)
                                   "%s: failed to add worker %s",
                                   bsel->s->name, val);
                     PROXY_GLOBAL_UNLOCK(bsel);
@@ -1448,7 +1448,7 @@ static int balancer_handler(request_rec *r)
                                   bsel->s->name);
                 }
             } else {
-                ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, APLOGNO(01207)
+                ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, APLOGNO(10164)
                                   "%s: failed to add worker %s",
                                   bsel->s->name, val);
                 return HTTP_BAD_REQUEST;

--- a/modules/proxy/mod_proxy_balancer.c
+++ b/modules/proxy/mod_proxy_balancer.c
@@ -1435,12 +1435,23 @@ static int balancer_handler(request_rec *r)
                     bsel->wupdated = bsel->s->wupdated = nworker->s->updated = apr_time_now();
                     /* by default, all new workers are disabled */
                     ap_proxy_set_wstatus(PROXY_WORKER_DISABLED_FLAG, 1, nworker);
+                } else {
+                            ap_log_rerror(APLOG_MARK, APLOG_ERR, rv, r, APLOGNO(01207)
+                                  "%s: failed to add worker %s",
+                                  bsel->s->name, val);
+                    PROXY_GLOBAL_UNLOCK(bsel);
+                    return HTTP_BAD_REQUEST;
                 }
                 if ((rv = PROXY_GLOBAL_UNLOCK(bsel)) != APR_SUCCESS) {
                     ap_log_rerror(APLOG_MARK, APLOG_ERR, rv, r, APLOGNO(01203)
                                   "%s: Unlock failed for adding worker",
                                   bsel->s->name);
                 }
+            } else {
+                ap_log_rerror(APLOG_MARK, APLOG_ERR, rv, r, APLOGNO(01207)
+                                  "%s: failed to add worker %s",
+                                  bsel->s->name, val);
+                return HTTP_BAD_REQUEST;
             }
 
         }

--- a/modules/proxy/mod_proxy_balancer.c
+++ b/modules/proxy/mod_proxy_balancer.c
@@ -1436,7 +1436,7 @@ static int balancer_handler(request_rec *r)
                     /* by default, all new workers are disabled */
                     ap_proxy_set_wstatus(PROXY_WORKER_DISABLED_FLAG, 1, nworker);
                 } else {
-                            ap_log_rerror(APLOG_MARK, APLOG_ERR, rv, r, APLOGNO(01207)
+                            ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, APLOGNO(01207)
                                   "%s: failed to add worker %s",
                                   bsel->s->name, val);
                     PROXY_GLOBAL_UNLOCK(bsel);
@@ -1448,7 +1448,7 @@ static int balancer_handler(request_rec *r)
                                   bsel->s->name);
                 }
             } else {
-                ap_log_rerror(APLOG_MARK, APLOG_ERR, rv, r, APLOGNO(01207)
+                ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, APLOGNO(01207)
                                   "%s: failed to add worker %s",
                                   bsel->s->name, val);
                 return HTTP_BAD_REQUEST;


### PR DESCRIPTION
Add error messages and return bad request.

fix incorrect rv. Sorry.

Follow up to r1847232.
There is no point to use "old" numbers in recent commit.

Also avoid number duplication. The messages are the same but in different code path, so having different numbers makes sense.
This also avoids a warning when running:
   make update-log-msg-tags
