### PR TITLE
Support for User: header in draft-vanrein-http-unauth-user

### DIFF
--- a/docs/manual/env.xml
+++ b/docs/manual/env.xml
@@ -120,6 +120,13 @@
 	the <a href="http://www.ietf.org/rfc/rfc3875">CGI
         specification</a>.</p>
 
+	<p>On top of this, when a <code>User</code> header is included in the
+	request on top of the resource specification provided by <code>Host</code>,
+	then CGI and SSI scripts will see <code>LOCAL_USER</code> set to the
+	unescaped form of this header value.  This header is specified
+	in <code>draft-vanrein-http-unauth-user</code> and is deliberately not
+	the result of any authentication process.</p>
+
     </section>
     <section id="caveats">
         <title>Some Caveats</title>

--- a/docs/manual/mod/mod_userdir.xml
+++ b/docs/manual/mod/mod_userdir.xml
@@ -95,6 +95,19 @@ host</context></contextlist>
           <td>/home/bob/www/one/two.html</td></tr>
     </table>
 
+    <p>Likewise, under <code>draft-vanrein-http-unauth-user</code>, the inclusion
+    of a <code>User</code> header in the request can be used as an equivalent form.
+    The URI <code>http://www.example.com/~bob/one/two.html</code> could
+    be written as <code>http://bob@www.example.com/one/two.html</code>
+    in a supporting client and lead to a request that triggers the
+    same logic, namely:</p>
+
+    <pre>
+    GET /one/two.html HTTP/1.1
+    Host: www.example.com
+    User: bob
+    </pre>
+
     <p>The following directives will send redirects to the client:</p>
 
     <table>

--- a/modules/mappers/mod_userdir.c
+++ b/modules/mappers/mod_userdir.c
@@ -217,6 +217,10 @@ static int translate_userdir(request_rec *r)
          * The code below assumes that dname may point anywhere in the URI.
          */
         dname = r->uri;
+        /*
+         * Impact by "User" MUST be mentioned in the "Vary" response header
+         */
+        apr_table_merge(r->headers_out, "Vary", "User");
     } else {
         /*
          * If the URI doesn't match our basic pattern, we've nothing to do with


### PR DESCRIPTION
According to draft-vanrein-httpd-unauth-user
Offers HTTP support for https://john@example.com
Implemented as equivalent to https://example.com/~john