### PR TITLE
Backport: Arrange the xml display and make it uses xml.

### DIFF
--- a/modules/proxy/mod_proxy_balancer.c
+++ b/modules/proxy/mod_proxy_balancer.c
@@ -1225,7 +1225,6 @@ static int balancer_handler(request_rec *r)
          )
         )
        ) {
-        apr_table_clear(params);
         ok2change = 0;
     }
 
@@ -1509,7 +1508,7 @@ static int balancer_handler(request_rec *r)
                            (balancer->s->sticky_force ? "On" : "Off"));
             }
             ap_rprintf(r,
-                       "      <httpd:timeout>%" APR_TIME_T_FMT "</httpd:timeout>",
+                       "      <httpd:timeout>%" APR_TIME_T_FMT "</httpd:timeout>\n",
                        apr_time_sec(balancer->s->timeout));
             if (balancer->s->max_attempts_set) {
                 ap_rprintf(r,


### PR DESCRIPTION
It is currently very difficult to use the xml interface of the balancer-manager because it needs a nonce even when you only want to view data. This is fixed in master but not in 2.4. This PR backports this change.
Bugreport: https://bz.apache.org/bugzilla/show_bug.cgi?id=63074
git-svn-id: https://svn.apache.org/repos/asf/httpd/httpd/trunk@1847295 13f79535-47bb-0310-9956-ffa450edef68