### PR TITLE
2.4.x

### DIFF
--- a/modules/ssl/ssl_util_stapling.c
+++ b/modules/ssl/ssl_util_stapling.c
@@ -397,10 +397,10 @@ static int stapling_check_response(server_rec *s, modssl_ctx_t *mctx,
 
     bs = OCSP_response_get1_basic(rsp);
     if (bs == NULL) {
-        /* If we can't parse response just pass it to client */
+        /* If we can't parse response as OCSP basic, then don't pass it to client */
         ap_log_error(APLOG_MARK, APLOG_ERR, 0, s, APLOGNO(01934)
                      "stapling_check_response: Error Parsing Response!");
-        return SSL_TLSEXT_ERR_OK;
+        return SSL_TLSEXT_ERR_NOACK;
     }
 
     if (!OCSP_resp_find_status(bs, cinf->cid, &status, &reason, &rev,

--- a/modules/ssl/ssl_util_stapling.c
+++ b/modules/ssl/ssl_util_stapling.c
@@ -549,6 +549,7 @@ static BOOL stapling_renew_response(server_rec *s, modssl_ctx_t *mctx, SSL *ssl,
                      "stapling_renew_response: responder error");
         if (mctx->stapling_fake_trylater) {
             *prsp = OCSP_response_create(OCSP_RESPONSE_STATUS_TRYLATER, NULL);
+            *pok = FALSE;
         }
         else {
             goto done;

--- a/modules/ssl/ssl_util_stapling.c
+++ b/modules/ssl/ssl_util_stapling.c
@@ -435,7 +435,7 @@ static int stapling_check_response(server_rec *s, modssl_ctx_t *mctx,
             rv = SSL_TLSEXT_ERR_NOACK;
         }
 
-        if (status != V_OCSP_CERTSTATUS_GOOD) {
+        if (status != V_OCSP_CERTSTATUS_GOOD && pok) {
             char snum[MAX_STRING_LEN] = { '\0' };
             BIO *bio = BIO_new(BIO_s_mem());
 
@@ -456,12 +456,6 @@ static int stapling_check_response(server_rec *s, modssl_ctx_t *mctx,
                          (reason != OCSP_REVOKED_STATUS_NOSTATUS) ?
                          OCSP_crl_reason_str(reason) : "n/a",
                          snum[0] ? snum : "[n/a]");
-
-            if (mctx->stapling_return_errors == FALSE) {
-                if (pok)
-                    *pok = FALSE;
-                rv = SSL_TLSEXT_ERR_NOACK;
-            }
         }
     }
 


### PR DESCRIPTION
These three commits aim to improve the behavior of mod_ssl with OCSP stapling.

Generated TryLater (as well as received) Trylater messages should be stored in the cache in the category of non definitive ('error') answers. This will allow them to be cached shorter and not sent out to the client when ResponderErrors is off. There are problems with clients blocking the site in some circumstance when they receive a TryLater. See https://bugzilla.mozilla.org/show_bug.cgi?id=1323141

Also OCSP revocation messages are incorrectly dropped in the 'error' bin and not sent out when ReturnResponderErrors is off. This would make it nonsensical to run with ReturnResponderErrors set to off.

Finally OCSP responses that are impossible to parse as basic response are sent out to the client. Which may be a bit future proving, but is more likely to just pass on garbage and block the site in the receiving client.

I refer to bugzilla bugs:
- https://bz.apache.org/bugzilla/show_bug.cgi?id=60182
- https://bz.apache.org/bugzilla/show_bug.cgi?id=57121