### PR TITLE
Define X509_up_ref and EVP_PKEY_up_ref for OpenSSL pre-1.1 and

### DIFF
--- a/modules/ssl/ssl_engine_kernel.c
+++ b/modules/ssl/ssl_engine_kernel.c
@@ -1950,19 +1950,11 @@ static void modssl_proxy_info_log(conn_rec *c,
  * so we need to increment here to prevent them from
  * being freed.
  */
-#if MODSSL_USE_OPENSSL_PRE_1_1_API
-#define modssl_set_cert_info(info, cert, pkey) \
-    *cert = info->x509; \
-    CRYPTO_add(&(*cert)->references, +1, CRYPTO_LOCK_X509); \
-    *pkey = info->x_pkey->dec_pkey; \
-    CRYPTO_add(&(*pkey)->references, +1, CRYPTO_LOCK_X509_PKEY)
-#else
 #define modssl_set_cert_info(info, cert, pkey) \
     *cert = info->x509; \
     X509_up_ref(*cert); \
     *pkey = info->x_pkey->dec_pkey; \
     EVP_PKEY_up_ref(*pkey);
-#endif
 
 int ssl_callback_proxy_cert(SSL *ssl, X509 **x509, EVP_PKEY **pkey)
 {

--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -237,6 +237,8 @@
 #define BIO_get_shutdown(x)        (x->shutdown)
 #define BIO_set_shutdown(x,v)      (x->shutdown=v)
 #define DH_bits(x)                 (BN_num_bits(x->p))
+#define X509_up_ref(x)             (CRYPTO_add(&(x)->references, +1, CRYPTO_LOCK_X509))
+#define EVP_PKEY_up_ref(pk)        (CRYPTO_add(&(pk)->references, +1, CRYPTO_LOCK_X509_PKEY))
 #else
 void init_bio_methods(void);
 void free_bio_methods(void);

--- a/modules/ssl/ssl_util_stapling.c
+++ b/modules/ssl/ssl_util_stapling.c
@@ -107,11 +107,7 @@ static X509 *stapling_get_issuer(modssl_ctx_t *mctx, X509 *x)
     for (i = 0; i < sk_X509_num(extra_certs); i++) {
         issuer = sk_X509_value(extra_certs, i);
         if (X509_check_issued(issuer, x) == X509_V_OK) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-            CRYPTO_add(&issuer->references, 1, CRYPTO_LOCK_X509);
-#else
             X509_up_ref(issuer);
-#endif
             return issuer;
         }
     }


### PR DESCRIPTION
use throughout.