### PR TITLE
libcurl dependency version fix for mod_md

### DIFF
--- a/modules/md/config2.m4
+++ b/modules/md/config2.m4
@@ -99,7 +99,7 @@ AC_DEFUN([APACHE_CHECK_CURL],[
 
     AC_CHECK_HEADERS([curl/curl.h])
 
-    AC_MSG_CHECKING([for curl version >= 7.50])
+    AC_MSG_CHECKING([for curl version >= 7.29])
     AC_TRY_COMPILE([#include <curl/curlver.h>],[
 #if !defined(LIBCURL_VERSION_MAJOR)
 #error "Missing libcurl version"
@@ -107,7 +107,7 @@ AC_DEFUN([APACHE_CHECK_CURL],[
 #if LIBCURL_VERSION_MAJOR < 7
 #error "Unsupported libcurl version " LIBCURL_VERSION
 #endif
-#if LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR < 50
+#if LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR < 29
 #error "Unsupported libcurl version " LIBCURL_VERSION
 #endif],
       [AC_MSG_RESULT(OK)


### PR DESCRIPTION
libcurl dependency version fix: mod_md builds and works fine against libcurl 7.29, so EL7 (CentOS 7, RHEL 7) is really supported.