### PR TITLE
Add ap_get_mon_snap(ap_mon_snap_t *ms) to retrieve some averaged monitoring data from the server.

### DIFF
--- a/include/httpd.h
+++ b/include/httpd.h
@@ -1412,14 +1412,47 @@ struct server_rec {
  */
 typedef struct ap_sload_t ap_sload_t;
 struct ap_sload_t {
-    /* percentage of process/threads ready/idle (0->100)*/
-    int idle;
-    /* percentage of process/threads busy (0->100) */
-    int busy;
+    /* idle threads in pct (0-100) */
+    float idle;
+    /* busy threads in pct (0-100) */
+    float busy;
+    /* dead threads: no process or starting or stopping, in pct (0-100) */
+    float dead;
     /* total bytes served */
     apr_off_t bytes_served;
     /* total access count */
     unsigned long access_count;
+    /* total request duration */
+    apr_time_t duration;
+    /* cpu usr time including died children */
+    clock_t cpu_usr;
+    /* cpu system time including died children */
+    clock_t cpu_sys;
+    /* timestamp of data */
+    apr_time_t timestamp;
+};
+
+/**
+ * @struct ap_mon_snap_t
+ * @brief  A structure to hold a monitoring data snapshot
+ */
+typedef struct ap_mon_snap_t ap_mon_snap_t;
+struct ap_mon_snap_t {
+    ap_sload_t *sload;
+    /* averaging interval */
+    apr_interval_time_t interval;
+    /* accesses per second */
+    float acc_per_sec;
+    /* bytes per second */
+    float bytes_per_sec;
+    /* bytes per access */
+    float bytes_per_acc;
+    /* duration (ms) per acc */
+    float ms_per_acc;
+    /* average concurrency */
+    float average_concurrency;
+    /* cpu_load in percent of one core */
+    float cpu_load;
 };
 
 /**
@@ -2478,9 +2511,29 @@ AP_DECLARE(void *) ap_realloc(void *ptr, size_t size)
 
 /**
  * Get server load params
- * @param ld struct to populate: -1 in fields means error
+ * @param sl struct to populate: -1 in fields means error
  */
-AP_DECLARE(void) ap_get_sload(ap_sload_t *ld)
+AP_DECLARE(void) ap_get_sload(ap_sload_t *sl)
+                 AP_FN_ATTR_NONNULL_ALL;
+
+/**
+ * Monitor hook for scoreboard.
+ * Generates a snapshot for some averaging metrics.
+ * @param p and s currently unused.
+ */
+int ap_scoreboard_monitor(apr_pool_t *p, server_rec *s);
+
+/**
+ * Child init hook for scoreboard.
+ * @param p and s currently unused.
+ */
+void ap_scoreboard_child_init(apr_pool_t *p, server_rec *s);
+
+/**
+ * Get monitoring data snapshot
+ * @param ms struct to populate: -1 in fields means error
+ */
+AP_DECLARE(void) ap_get_mon_snap(ap_mon_snap_t *ms)
                  AP_FN_ATTR_NONNULL_ALL;
 
 /**

--- a/include/httpd.h
+++ b/include/httpd.h
@@ -1413,11 +1413,11 @@ struct server_rec {
 typedef struct ap_sload_t ap_sload_t;
 struct ap_sload_t {
     /* idle threads in pct (0-100) */
-    float idle;
+    int idle;
     /* busy threads in pct (0-100) */
-    float busy;
+    int busy;
     /* dead threads: no process or starting or stopping, in pct (0-100) */
-    float dead;
+    int dead;
     /* total bytes served */
     apr_off_t bytes_served;
     /* total access count */

--- a/include/httpd.h
+++ b/include/httpd.h
@@ -1438,7 +1438,6 @@ struct ap_sload_t {
  */
 typedef struct ap_mon_snap_t ap_mon_snap_t;
 struct ap_mon_snap_t {
-    ap_sload_t *sload;
     /* averaging interval */
     apr_interval_time_t interval;
     /* accesses per second */
@@ -2535,10 +2534,12 @@ void ap_scoreboard_child_init(apr_pool_t *p, server_rec *s);
 
 /**
  * Get monitoring data snapshot
- * @param ms struct to populate: -1 in fields means error
+ * @param ms struct to populate with averaged data; -1 in fields means error
+ * @param sl struct to populate with last absolute data;
+ * NULL allowed, to ignore those.
  */
-AP_DECLARE(void) ap_get_mon_snap(ap_mon_snap_t *ms)
-                 AP_FN_ATTR_NONNULL_ALL;
+AP_DECLARE(void) ap_get_mon_snap(ap_mon_snap_t *ms, ap_sload_t *sl)
+                 AP_FN_ATTR_NONNULL((1));
 
 /**
  * Get server load averages (ala getloadavg)

--- a/include/httpd.h
+++ b/include/httpd.h
@@ -2520,12 +2520,16 @@ AP_DECLARE(void) ap_get_sload(ap_sload_t *sl)
  * Monitor hook for scoreboard.
  * Generates a snapshot for some averaging metrics.
  * @param p and s currently unused.
+ * @note ap_scoreboard_monitor is not for use by modules; it is an
+ * internal core function
  */
 int ap_scoreboard_monitor(apr_pool_t *p, server_rec *s);
 
 /**
  * Child init hook for scoreboard.
  * @param p and s currently unused.
+ * @note ap_scoreboard_child_init is not for use by modules; it is an
+ * internal core function
  */
 void ap_scoreboard_child_init(apr_pool_t *p, server_rec *s);
 

--- a/include/scoreboard.h
+++ b/include/scoreboard.h
@@ -130,6 +130,11 @@ typedef struct {
 #ifdef HAVE_TIMES
     struct tms times;
 #endif
+    int snap_index;
+    ap_sload_t sload0;
+    ap_sload_t sload1;
+    ap_mon_snap_t snap0;
+    ap_mon_snap_t snap1;
 } global_score;
 
 /* stuff which the parent generally writes and the children rarely read */

--- a/include/scoreboard.h
+++ b/include/scoreboard.h
@@ -130,7 +130,7 @@ typedef struct {
 #ifdef HAVE_TIMES
     struct tms times;
 #endif
-    int snap_index;
+    apr_uint32_t volatile snap_index;
     ap_sload_t sload0;
     ap_sload_t sload1;
     ap_mon_snap_t snap0;

--- a/modules/arch/unix/mod_systemd.c
+++ b/modules/arch/unix/mod_systemd.c
@@ -84,8 +84,8 @@ static int systemd_monitor(apr_pool_t *p, server_rec *s)
     apr_strfsize((apr_off_t)snap.bytes_per_sec, bps);
     apr_strfsize((apr_off_t)snap.bytes_per_acc, bpr);
     sd_notifyf(0, "READY=1\n"
-               "STATUS=Pct Idle workers %.3g; Pct Busy workers %.3g; "
-               "Pct Dead workers %.3g; "
+               "STATUS=Pct Idle workers %d; Pct Busy workers %d; "
+               "Pct Dead workers %d; "
                "Requests/sec: %.3g; Bytes served/sec: %sB/sec; "
                "Bytes served/request: %sB/req; "
                "Avg Duration(ms): %.3g; Avg Concurrency: %.3g; "

--- a/modules/arch/unix/mod_systemd.c
+++ b/modules/arch/unix/mod_systemd.c
@@ -64,35 +64,38 @@ static int systemd_pre_mpm(apr_pool_t *p, ap_scoreboard_e sb_type)
     sd_notifyf(0, "READY=1\n"
                "STATUS=Processing requests...\n"
                "MAINPID=%" APR_PID_T_FMT, getpid());
-
     return OK;
 }
 
 static int systemd_monitor(apr_pool_t *p, server_rec *s)
 {
     ap_sload_t sload;
-    apr_interval_time_t up_time;
+    ap_mon_snap_t snap;
     char bps[5];
+    char bpr[5];
 
     if (!ap_extended_status) {
         /* Nothing useful to report with ExtendedStatus disabled. */
         return DECLINED;
     }
     
-    ap_get_sload(&sload);
-    /* up_time in seconds */
-    up_time = (apr_uint32_t) apr_time_sec(apr_time_now() -
-                               ap_scoreboard_image->global->restart_time);
-
-    apr_strfsize((unsigned long)((float) (sload.bytes_served)
-                                 / (float) up_time), bps);
-
+    snap.sload = &sload;
+    ap_get_mon_snap(&snap);
+    apr_strfsize((apr_off_t)snap.bytes_per_sec, bps);
+    apr_strfsize((apr_off_t)snap.bytes_per_acc, bpr);
     sd_notifyf(0, "READY=1\n"
-               "STATUS=Total requests: %lu; Idle/Busy workers %d/%d;"
-               "Requests/sec: %.3g; Bytes served/sec: %sB/sec\n",
-               sload.access_count, sload.idle, sload.busy,
-               ((float) sload.access_count) / (float) up_time, bps);
-
+               "STATUS=Pct Idle workers %.3g; Pct Busy workers %.3g; "
+               "Pct Dead workers %.3g; "
+               "Requests/sec: %.3g; Bytes served/sec: %sB/sec; "
+               "Bytes served/request: %sB/req; "
+               "Avg Duration(ms): %.3g; Avg Concurrency: %.3g; "
+               "Cpu Pct: %.3g\n",
+               snap.sload->idle, snap.sload->busy,
+               snap.sload->dead,
+               snap.acc_per_sec, bps, bpr,
+               snap.ms_per_acc,
+               snap.average_concurrency,
+               snap.cpu_load);
     return DECLINED;
 }
 

--- a/modules/arch/unix/mod_systemd.c
+++ b/modules/arch/unix/mod_systemd.c
@@ -79,8 +79,7 @@ static int systemd_monitor(apr_pool_t *p, server_rec *s)
         return DECLINED;
     }
     
-    snap.sload = &sload;
-    ap_get_mon_snap(&snap);
+    ap_get_mon_snap(&snap, &sload);
     apr_strfsize((apr_off_t)snap.bytes_per_sec, bps);
     apr_strfsize((apr_off_t)snap.bytes_per_acc, bpr);
     sd_notifyf(0, "READY=1\n"
@@ -90,8 +89,8 @@ static int systemd_monitor(apr_pool_t *p, server_rec *s)
                "Bytes served/request: %sB/req; "
                "Avg Duration(ms): %.3g; Avg Concurrency: %.3g; "
                "Cpu Pct: %.3g\n",
-               snap.sload->idle, snap.sload->busy,
-               snap.sload->dead,
+               sload.idle, sload.busy,
+               sload.dead,
                snap.acc_per_sec, bps, bpr,
                snap.ms_per_acc,
                snap.average_concurrency,

--- a/modules/generators/mod_status.c
+++ b/modules/generators/mod_status.c
@@ -505,9 +505,9 @@ static int status_handler(request_rec *r)
                        apr_time_as_msec(snap.sload->timestamp));
             ap_rprintf(r, "SnapInterval: %" APR_TIME_T_FMT "\n",
                        apr_time_as_msec(snap.interval));
-            ap_rprintf(r, "BusyPct: %.4g\n", snap.sload->busy);
-            ap_rprintf(r, "IdlePct: %.4g\n", snap.sload->idle);
-            ap_rprintf(r, "DeadPct: %.4g\n", snap.sload->dead);
+            ap_rprintf(r, "BusyPct: %d\n", snap.sload->busy);
+            ap_rprintf(r, "IdlePct: %d\n", snap.sload->idle);
+            ap_rprintf(r, "DeadPct: %d\n", snap.sload->dead);
             ap_rprintf(r, "ReqPerSec: %.4g\n", snap.acc_per_sec);
             ap_rprintf(r, "BytesPerSec: %.4g\n", snap.bytes_per_sec);
             ap_rprintf(r, "BytesPerReq: %.4g\n", snap.bytes_per_acc);
@@ -535,9 +535,9 @@ static int status_handler(request_rec *r)
                        apr_time_as_msec(snap.sload->timestamp));
             ap_rprintf(r, ", interval %" APR_TIME_T_FMT "ms</dt>\n",
                        apr_time_as_msec(snap.interval));
-            ap_rprintf(r, "<dt>%.4g%% busy", snap.sload->busy);
-            ap_rprintf(r, " - %.4g%% idle", snap.sload->idle);
-            ap_rprintf(r, " - %.4g%% dead</dt>\n", snap.sload->dead);
+            ap_rprintf(r, "<dt>%d%% busy", snap.sload->busy);
+            ap_rprintf(r, " - %d%% idle", snap.sload->idle);
+            ap_rprintf(r, " - %d%% dead</dt>\n", snap.sload->dead);
 
             ap_rprintf(r, "<dt>%.4g requests/sec - ", snap.acc_per_sec);
             format_byte_out(r, (unsigned long)(snap.bytes_per_sec));

--- a/modules/generators/mod_status.c
+++ b/modules/generators/mod_status.c
@@ -188,6 +188,7 @@ static int status_handler(request_rec *r)
     int j, i, res, written;
     int ready;
     int busy;
+    int dead;
     unsigned long count;
     unsigned long lres, my_lres, conn_lres;
     apr_off_t bytes, my_bytes, conn_bytes;
@@ -211,6 +212,8 @@ static int status_handler(request_rec *r)
     float tick;
     int times_per_thread;
 #endif
+    ap_sload_t sload;
+    ap_mon_snap_t snap;
 
     if (strcmp(r->handler, STATUS_MAGIC_TYPE) && strcmp(r->handler,
             "server-status")) {
@@ -233,6 +236,7 @@ static int status_handler(request_rec *r)
 
     ready = 0;
     busy = 0;
+    dead = 0;
     count = 0;
     bcount = 0;
     kbcount = 0;
@@ -252,6 +256,9 @@ static int status_handler(request_rec *r)
         thread_idle_buffer = apr_palloc(r->pool, server_limit * sizeof(int));
         thread_busy_buffer = apr_palloc(r->pool, server_limit * sizeof(int));
     }
+
+    snap.sload = &sload;
+    ap_get_mon_snap(&snap);
 
     nowtime = apr_time_now();
 #ifdef HAVE_TIMES
@@ -350,6 +357,8 @@ static int status_handler(request_rec *r)
                         else
                             thread_busy_buffer[i]++;
                     }
+                } else {
+                    dead++;
                 }
             }
 
@@ -474,7 +483,6 @@ static int status_handler(request_rec *r)
     }
 
     if (ap_extended_status) {
-        clock_t cpu = gu + gs + gcu + gcs + tu + ts + tcu + tcs;
         if (short_report) {
             ap_rprintf(r, "Total Accesses: %lu\nTotal kBytes: %"
                        APR_OFF_T_FMT "\nTotal Duration: %"
@@ -486,25 +494,25 @@ static int status_handler(request_rec *r)
             ap_rprintf(r, "CPUUser: %g\nCPUSystem: %g\nCPUChildrenUser: %g\nCPUChildrenSystem: %g\n",
                        (gu + tu) / tick, (gs + ts) / tick, (gcu + tcu) / tick, (gcs + tcs) / tick);
 
-            if (cpu)
-                ap_rprintf(r, "CPULoad: %g\n",
-                           cpu / tick / up_time * 100.);
+            ap_rprintf(r, "CPUPct: %.4g\n", snap.cpu_load);
 #endif
 
             ap_rprintf(r, "Uptime: %ld\n", (long) (up_time));
-            if (up_time > 0) {
-                ap_rprintf(r, "ReqPerSec: %g\n",
-                           (float) count / (float) up_time);
-
-                ap_rprintf(r, "BytesPerSec: %g\n",
-                           KBYTE * (float) kbcount / (float) up_time);
-            }
-            if (count > 0) {
-                ap_rprintf(r, "BytesPerReq: %g\n",
-                           KBYTE * (float) kbcount / (float) count);
-                ap_rprintf(r, "DurationPerReq: %g\n",
-                           (float) apr_time_as_msec(duration_global) / (float) count);
-            }
+            ap_rvputs(r, "LastSnap: ",
+                      ap_ht_time(r->pool, snap.sload->timestamp, DEFAULT_TIME_FORMAT, 0),
+                      "\n", NULL);
+            ap_rprintf(r, "LastSnapEpoch: %" APR_TIME_T_FMT "\n",
+                       apr_time_as_msec(snap.sload->timestamp));
+            ap_rprintf(r, "SnapInterval: %" APR_TIME_T_FMT "\n",
+                       apr_time_as_msec(snap.interval));
+            ap_rprintf(r, "BusyPct: %.4g\n", snap.sload->busy);
+            ap_rprintf(r, "IdlePct: %.4g\n", snap.sload->idle);
+            ap_rprintf(r, "DeadPct: %.4g\n", snap.sload->dead);
+            ap_rprintf(r, "ReqPerSec: %.4g\n", snap.acc_per_sec);
+            ap_rprintf(r, "BytesPerSec: %.4g\n", snap.bytes_per_sec);
+            ap_rprintf(r, "BytesPerReq: %.4g\n", snap.bytes_per_acc);
+            ap_rprintf(r, "DurationPerReq: %.4g\n", snap.ms_per_acc);
+            ap_rprintf(r, "AvgConcurrency: %.4g\n", snap.average_concurrency);
         }
         else { /* !short_report */
             ap_rprintf(r, "<dt>Total accesses: %lu - Total Traffic: ", count);
@@ -517,41 +525,34 @@ static int status_handler(request_rec *r)
             ap_rprintf(r, "<dt>CPU Usage: u%g s%g cu%g cs%g",
                        (gu + tu) / tick, (gs + ts) / tick, (gcu + tcu) / tick, (gcs + tcs) / tick);
 
-            if (cpu)
-                ap_rprintf(r, " - %.3g%% CPU load</dt>\n",
-                           cpu / tick / up_time * 100.);
-            else
-                ap_rputs("</dt>\n", r);
+            ap_rprintf(r, " - %.4g%% CPU load</dt>\n", snap.cpu_load);
 #endif
 
-            ap_rputs("<dt>", r);
-            if (up_time > 0) {
-                ap_rprintf(r, "%.3g requests/sec - ",
-                           (float) count / (float) up_time);
+            ap_rvputs(r, "<dt>Last snap ",
+                      ap_ht_time(r->pool, snap.sload->timestamp, DEFAULT_TIME_FORMAT, 0),
+                      NULL);
+            ap_rprintf(r, " (%" APR_TIME_T_FMT ")",
+                       apr_time_as_msec(snap.sload->timestamp));
+            ap_rprintf(r, ", interval %" APR_TIME_T_FMT "ms</dt>\n",
+                       apr_time_as_msec(snap.interval));
+            ap_rprintf(r, "<dt>%.4g%% busy", snap.sload->busy);
+            ap_rprintf(r, " - %.4g%% idle", snap.sload->idle);
+            ap_rprintf(r, " - %.4g%% dead</dt>\n", snap.sload->dead);
 
-                format_byte_out(r, (unsigned long)(KBYTE * (float) kbcount
-                                                   / (float) up_time));
-                ap_rputs("/second", r);
-            }
-
-            if (count > 0) {
-                if (up_time > 0)
-                    ap_rputs(" - ", r);
-                format_byte_out(r, (unsigned long)(KBYTE * (float) kbcount
-                                                   / (float) count));
-                ap_rprintf(r, "/request - %g ms/request",
-                (float) apr_time_as_msec(duration_global) / (float) count);
-            }
-
-            ap_rputs("</dt>\n", r);
+            ap_rprintf(r, "<dt>%.4g requests/sec - ", snap.acc_per_sec);
+            format_byte_out(r, (unsigned long)(snap.bytes_per_sec));
+            ap_rputs("/second - ", r);
+            format_byte_out(r, (unsigned long)(snap.bytes_per_acc));
+            ap_rprintf(r, "/request - %.4g ms/request - %.4g avg concurrency</dt>\n",
+                       snap.ms_per_acc, snap.average_concurrency);
         } /* short_report */
     } /* ap_extended_status */
 
     if (!short_report)
         ap_rprintf(r, "<dt>%d requests currently being processed, "
-                      "%d idle workers</dt>\n", busy, ready);
+                      "%d idle workers, %d dead workers</dt>\n", busy, ready, dead);
     else
-        ap_rprintf(r, "BusyWorkers: %d\nIdleWorkers: %d\n", busy, ready);
+        ap_rprintf(r, "BusyWorkers: %d\nIdleWorkers: %d\nDeadWorkers: %d\n", busy, ready, dead);
 
     if (!short_report)
         ap_rputs("</dl>", r);

--- a/modules/generators/mod_status.c
+++ b/modules/generators/mod_status.c
@@ -257,8 +257,7 @@ static int status_handler(request_rec *r)
         thread_busy_buffer = apr_palloc(r->pool, server_limit * sizeof(int));
     }
 
-    snap.sload = &sload;
-    ap_get_mon_snap(&snap);
+    ap_get_mon_snap(&snap, &sload);
 
     nowtime = apr_time_now();
 #ifdef HAVE_TIMES
@@ -499,15 +498,15 @@ static int status_handler(request_rec *r)
 
             ap_rprintf(r, "Uptime: %ld\n", (long) (up_time));
             ap_rvputs(r, "LastSnap: ",
-                      ap_ht_time(r->pool, snap.sload->timestamp, DEFAULT_TIME_FORMAT, 0),
+                      ap_ht_time(r->pool, sload.timestamp, DEFAULT_TIME_FORMAT, 0),
                       "\n", NULL);
             ap_rprintf(r, "LastSnapEpoch: %" APR_TIME_T_FMT "\n",
-                       apr_time_as_msec(snap.sload->timestamp));
+                       apr_time_as_msec(sload.timestamp));
             ap_rprintf(r, "SnapInterval: %" APR_TIME_T_FMT "\n",
                        apr_time_as_msec(snap.interval));
-            ap_rprintf(r, "BusyPct: %d\n", snap.sload->busy);
-            ap_rprintf(r, "IdlePct: %d\n", snap.sload->idle);
-            ap_rprintf(r, "DeadPct: %d\n", snap.sload->dead);
+            ap_rprintf(r, "BusyPct: %d\n", sload.busy);
+            ap_rprintf(r, "IdlePct: %d\n", sload.idle);
+            ap_rprintf(r, "DeadPct: %d\n", sload.dead);
             ap_rprintf(r, "ReqPerSec: %.4g\n", snap.acc_per_sec);
             ap_rprintf(r, "BytesPerSec: %.4g\n", snap.bytes_per_sec);
             ap_rprintf(r, "BytesPerReq: %.4g\n", snap.bytes_per_acc);
@@ -529,15 +528,15 @@ static int status_handler(request_rec *r)
 #endif
 
             ap_rvputs(r, "<dt>Last snap ",
-                      ap_ht_time(r->pool, snap.sload->timestamp, DEFAULT_TIME_FORMAT, 0),
+                      ap_ht_time(r->pool, sload.timestamp, DEFAULT_TIME_FORMAT, 0),
                       NULL);
             ap_rprintf(r, " (%" APR_TIME_T_FMT ")",
-                       apr_time_as_msec(snap.sload->timestamp));
+                       apr_time_as_msec(sload.timestamp));
             ap_rprintf(r, ", interval %" APR_TIME_T_FMT "ms</dt>\n",
                        apr_time_as_msec(snap.interval));
-            ap_rprintf(r, "<dt>%d%% busy", snap.sload->busy);
-            ap_rprintf(r, " - %d%% idle", snap.sload->idle);
-            ap_rprintf(r, " - %d%% dead</dt>\n", snap.sload->dead);
+            ap_rprintf(r, "<dt>%d%% busy", sload.busy);
+            ap_rprintf(r, " - %d%% idle", sload.idle);
+            ap_rprintf(r, " - %d%% dead</dt>\n", sload.dead);
 
             ap_rprintf(r, "<dt>%.4g requests/sec - ", snap.acc_per_sec);
             format_byte_out(r, (unsigned long)(snap.bytes_per_sec));

--- a/modules/metadata/mod_headers.c
+++ b/modules/metadata/mod_headers.c
@@ -235,14 +235,14 @@ static const char *header_request_idle(request_rec *r, char *a)
 {
     ap_sload_t t;
     ap_get_sload(&t);
-    return apr_psprintf(r->pool, "i=%.3g", t.idle);
+    return apr_psprintf(r->pool, "i=%d", t.idle);
 }
 
 static const char *header_request_busy(request_rec *r, char *a)
 {
     ap_sload_t t;
     ap_get_sload(&t);
-    return apr_psprintf(r->pool, "b=%.3g", t.busy);
+    return apr_psprintf(r->pool, "b=%d", t.busy);
 }
 
 /*

--- a/modules/metadata/mod_headers.c
+++ b/modules/metadata/mod_headers.c
@@ -235,14 +235,14 @@ static const char *header_request_idle(request_rec *r, char *a)
 {
     ap_sload_t t;
     ap_get_sload(&t);
-    return apr_psprintf(r->pool, "i=%d", t.idle);
+    return apr_psprintf(r->pool, "i=%.3g", t.idle);
 }
 
 static const char *header_request_busy(request_rec *r, char *a)
 {
     ap_sload_t t;
     ap_get_sload(&t);
-    return apr_psprintf(r->pool, "b=%d", t.busy);
+    return apr_psprintf(r->pool, "b=%.3g", t.busy);
 }
 
 /*

--- a/server/core.c
+++ b/server/core.c
@@ -5910,6 +5910,8 @@ static void register_hooks(apr_pool_t *p)
                       APR_HOOK_MIDDLE);
     ap_hook_pre_mpm(ap_create_scoreboard, NULL, NULL, APR_HOOK_MIDDLE);
     ap_hook_child_status(ap_core_child_status, NULL, NULL, APR_HOOK_MIDDLE);
+    ap_hook_child_init(ap_scoreboard_child_init,NULL,NULL, APR_HOOK_REALLY_FIRST);
+    ap_hook_monitor(ap_scoreboard_monitor, NULL, NULL, APR_HOOK_REALLY_FIRST);
     ap_hook_insert_network_bucket(core_insert_network_bucket, NULL, NULL,
                                   APR_HOOK_REALLY_LAST);
     ap_hook_dirwalk_stat(core_dirwalk_stat, NULL, NULL, APR_HOOK_REALLY_LAST);

--- a/server/scoreboard.c
+++ b/server/scoreboard.c
@@ -857,7 +857,7 @@ static void calc_mon_data(ap_mon_snap_t *last,
     next->interval = -1;
 
     /* Need two iterations for complete data in s0 and s1 */
-    if (s0->access_count < 0 || s0->access_count < 0) {
+    if (s0->access_count < 0 || s1->access_count < 0) {
         return;
     }
 

--- a/server/scoreboard.c
+++ b/server/scoreboard.c
@@ -831,9 +831,9 @@ AP_DECLARE(void) ap_get_sload(ap_sload_t *sl)
 #endif
     total = busy + ready + dead;
     if (total) {
-        sl->idle = ready * 100 / total;
-        sl->busy = busy * 100 / total;
-        sl->dead = dead * 100 / total;
+        sl->idle = (ready * 1000 / total + 5) / 10;
+        sl->busy = (busy * 1000 / total + 5) / 10;
+        sl->dead = (dead * 1000 / total + 5) / 10;
     }
 }
 

--- a/server/scoreboard.c
+++ b/server/scoreboard.c
@@ -947,10 +947,15 @@ AP_DECLARE(void) ap_get_mon_snap(ap_mon_snap_t *ms)
         sload = &ap_scoreboard_image->global->sload1;
         snap = &ap_scoreboard_image->global->snap1;
     }
-    memcpy(ms, snap, sizeof(*snap));
     if (ms->sload) {
         memcpy(ms->sload, sload, sizeof(*sload));
+        sload = ms->sload;
+    } else {
+        sload = NULL;
     }
+    /* This will overwrite our ms-sload pointer, need to reconstruct */
+    memcpy(ms, snap, sizeof(*snap));
+    ms->sload = sload;
 }
 
 void ap_scoreboard_child_init(apr_pool_t *p, server_rec *s)

--- a/server/scoreboard.c
+++ b/server/scoreboard.c
@@ -837,50 +837,50 @@ AP_DECLARE(void) ap_get_sload(ap_sload_t *sl)
 }
 
 static void calc_mon_data(ap_sload_t *s0, ap_sload_t *s1,
-                          ap_mon_snap_t *next)
+                          ap_mon_snap_t *snap)
 {
     unsigned long accesses;
 #ifdef HAVE_TIMES
     float tick;
 #endif
 
-    next->acc_per_sec = -1;
-    next->bytes_per_sec = -1;
-    next->average_concurrency = -1;
-    next->cpu_load = -1;
-    next->bytes_per_acc = -1;
-    next->ms_per_acc = -1;
-    next->interval = -1;
-    next->sload = NULL;
+    snap->acc_per_sec = -1;
+    snap->bytes_per_sec = -1;
+    snap->average_concurrency = -1;
+    snap->cpu_load = -1;
+    snap->bytes_per_acc = -1;
+    snap->ms_per_acc = -1;
+    snap->interval = -1;
+    snap->sload = NULL;
 
     /* Need two iterations for complete data in s0 and s1 */
     if (s0->access_count < 0 || s1->access_count < 0) {
         return;
     }
 
-    next->interval = (apr_interval_time_t) (s1->timestamp - s0->timestamp);
+    snap->interval = (apr_interval_time_t) (s1->timestamp - s0->timestamp);
     accesses = s1->access_count - s0->access_count;
-    if (next->interval > 0) {
-        next->acc_per_sec = (float)accesses / next->interval * APR_USEC_PER_SEC;
-        next->bytes_per_sec = (float)(s1->bytes_served - s0->bytes_served)
-                              / next->interval * APR_USEC_PER_SEC;
-        next->average_concurrency = (float)(s1->duration - s0->duration)
-                                    / next->interval;
+    if (snap->interval > 0) {
+        snap->acc_per_sec = (float)accesses / snap->interval * APR_USEC_PER_SEC;
+        snap->bytes_per_sec = (float)(s1->bytes_served - s0->bytes_served)
+                              / snap->interval * APR_USEC_PER_SEC;
+        snap->average_concurrency = (float)(s1->duration - s0->duration)
+                                    / snap->interval;
 #ifdef HAVE_TIMES
 #ifdef _SC_CLK_TCK
         tick = sysconf(_SC_CLK_TCK);
 #else
         tick = HZ;
 #endif
-        next->cpu_load = (float)(s1->cpu_usr - s0->cpu_usr
+        snap->cpu_load = (float)(s1->cpu_usr - s0->cpu_usr
                                  + s1->cpu_sys - s0->cpu_sys)
-                              / tick / next->interval * APR_USEC_PER_SEC;
+                              / tick / snap->interval * APR_USEC_PER_SEC;
 #endif
     }
     if (accesses > 0) {
-        next->bytes_per_acc = (float)(s1->bytes_served - s0->bytes_served)
+        snap->bytes_per_acc = (float)(s1->bytes_served - s0->bytes_served)
                               / accesses;
-        next->ms_per_acc = (float)(s1->duration - s0->duration)
+        snap->ms_per_acc = (float)(s1->duration - s0->duration)
                            / accesses / 1000.0;
     }
 }

--- a/server/scoreboard.c
+++ b/server/scoreboard.c
@@ -831,9 +831,9 @@ AP_DECLARE(void) ap_get_sload(ap_sload_t *sl)
 #endif
     total = busy + ready + dead;
     if (total) {
-        sl->idle = (float)ready * 100 / total;
-        sl->busy = (float)busy * 100 / total;
-        sl->dead = (float)dead * 100 / total;
+        sl->idle = ready * 100 / total;
+        sl->busy = busy * 100 / total;
+        sl->dead = dead * 100 / total;
     }
 }
 


### PR DESCRIPTION
The data will be updated during the monitor hook, ie. every 10 seconds.

Consumers are mod_systemd and mod_status.

More details:

Patch available at

home.apache.org/~rjung/patches/httpd-trunk-mon-snaps-v1_2.patch

Some notes:

- in order to use the data from mod_systemd (monitor hook), which runs in the maim process, and also from mod_status, so from child processes, it needs to sit in shared memory. Since most of the data is tightly coupled to the scoreboard, I added the new cached data to the global part of the scoreboard.

- it was then IMHO a good fit to move the existing ap_get_sload(ap_sload_t *ld) from server/util.c to server/scoreboard.c.

- ap_sload_t is used as a collection of data which can be used to generate averaged data from a pair of ap_sload_t structs. It was extended to also contain the total request duration plus total usr and sys CPU and the timestamp when the data was taken. So it should now contain all data from which mod-systemd and mod_status currently like to display derived averaged values.

- busy and idle in ap_sload_t have been changed from int to float, because they were already only used a percentages. IMHO it doesn't make sense to express idle and busy as percentages based on a total of busy plus idle, because that sum is not a meaningful total. The server can grow by creating new processes and suddenly your busy percentage might shrink, although the absolute number of busy threads increases. That's counter intuitive. So I added the unused process slots to the total count, and we have three counters that sum up to this total, busy, idle and dead. We need a better name than "dead" for these unused process slots that might get used later. "unused" is to close to "idle" and I don't have a good name yet.

- the new ap_mon_snap_t contains a pointer to an ap_sload_t, six averaged values generated from two ap_sload_t and a member that conatins the time delta between those two ap_sload_t. The ap_sload_t referenced by ap_mon_snap_t contains the data at time t1. During the next monitor run, new t1 data will be collected and the previous t1 data will be used as t0 data to generate the new averages.

- the scoreboard contains two ap_mon_snap_t (plus the two ap_sload_t referenced by them) to be able to update one of them without breaking access by consumers to the other one. After the update the roles get switched.

- both structs, ap_sload_t and ap_mon_snap_t are declared in httpd.h, because ap_sload_t already had been there. t might be a better fit to move them to scoreboard.h, but I'm not sure about that and I don't know if that would be allowed by the compatibility rules.

- also in httpd.h there are now three new function declarations. Two only used by server/core.c as hook functions:

  int ap_scoreboard_monitor(apr_pool_t *p, server_rec *s);
  void ap_scoreboard_child_init(apr_pool_t *p, server_rec *s);

and one for public consumption:

  AP_DECLARE(void) ap_get_mon_snap(ap_mon_snap_t *ms);

- mod_systemd and mod_status now call ap_get_mon_snap(&snap) to retrieve the latest averaged data. mod_status still uses the scoreboard in addition to retrieve up-to-date current scalar metrics. Small adjustments to the mod_status output plus additions to mod_systemd notification messages. Tne STATUS in the notification of mod_systemd now looks liek this:

STATUS=Pct Idle workers 28.4; Pct Busy workers 10.6; Pct Dead workers 60.9; Requests/sec: 5030; Bytes served/sec: 2.9MB/sec; Bytes served/request: 596 B/req; Avg Duration(ms): 5.78; Avg Concurrency: 29.1; Cpu Pct: 40.5

- scoreboard.c changes:

  - take over ap_get_sload(ap_sload_t *sl) from server/util.c.
    Added copied code from mod_status to that function to also add up the request duration and the usr and sys CPU times.

  - ap_scoreboard_monitor() runs in the monitor hook. It calls ap_get_sload() and then a static utility function calc_mon_data() to calculate the new averages.

- Minor mmn change not yet part of the patch.

It compiles fine (maintainer mode) on RHEL 7 x86_64 and on Solaris 10 Sparc and I did some tests with mod_status and mod_systemd.
