### PR TITLE
Move FILE buckets on setaside 

### DIFF
--- a/include/http_request.h
+++ b/include/http_request.h
@@ -589,15 +589,6 @@ AP_DECLARE(int) ap_if_walk(request_rec *r);
 AP_DECLARE_DATA extern const apr_bucket_type_t ap_bucket_type_eor;
 
 /**
- * Determine if a bucket is morphing, that is which changes its
- * type on read (usually to "heap" allocated data), while moving
- * itself at the next position to remain plugged until exhausted.
- * @param e The bucket to inspect
- * @return true or false
- */
-#define AP_BUCKET_IS_MORPHING(e)    ((e)->length == (apr_size_t)-1)
-
-/**
  * Determine if a bucket is an End Of REQUEST (EOR) bucket
  * @param e The bucket to inspect
  * @return true or false

--- a/server/util_filter.c
+++ b/server/util_filter.c
@@ -976,8 +976,9 @@ AP_DECLARE(apr_status_t) ap_filter_setaside_brigade(ap_filter_t *f,
              e = next) {
             next = APR_BUCKET_NEXT(e);
 
-            /* Morphing buckets are moved, so assumed to have next EOR's
-             * lifetime or at least the lifetime of the connection.
+            /* Morphing (i.e. opaque or FILE) buckets are moved, so assumed
+             * to have next EOR's lifetime or at least the lifetime of the
+             * connection.
              */
             if (e->length == (apr_size_t)-1 || APR_BUCKET_IS_FILE(e)) {
                 /* Save buckets batched below? */
@@ -1058,7 +1059,7 @@ AP_DECLARE(apr_status_t) ap_filter_reinstate_brigade(ap_filter_t *f,
 {
     apr_bucket *bucket, *next;
     apr_size_t bytes_in_brigade, memory_bytes_in_brigade;
-    int eor_buckets_in_brigade, morphing_buckets_in_brigade;
+    int eor_buckets_in_brigade, opaque_buckets_in_brigade;
     struct ap_filter_private *fp = f->priv;
     core_server_config *conf;
  
@@ -1094,8 +1095,8 @@ AP_DECLARE(apr_status_t) ap_filter_reinstate_brigade(ap_filter_t *f,
      *     of everything up to the last one.
      *
      *  b) The brigade contains at least flush_max_threshold bytes in memory,
-     *     that is non-file and non-morphing buckets: do blocking writes of
-     *     everything up the last bucket above flush_max_threshold.
+     *     that is non-morphing buckets (length != -1 && !FILE) : do blocking
+     *     writes of everything up the last bucket above flush_max_threshold.
      *     (The point of this rule is to provide flow control, in case a
      *     handler is streaming out lots of data faster than the data can be
      *     sent to the client.)
@@ -1115,7 +1116,7 @@ AP_DECLARE(apr_status_t) ap_filter_reinstate_brigade(ap_filter_t *f,
     bytes_in_brigade = 0;
     memory_bytes_in_brigade = 0;
     eor_buckets_in_brigade = 0;
-    morphing_buckets_in_brigade = 0;
+    opaque_buckets_in_brigade = 0;
 
     conf = ap_get_core_module_config(f->c->base_server->module_config);
 
@@ -1126,8 +1127,8 @@ AP_DECLARE(apr_status_t) ap_filter_reinstate_brigade(ap_filter_t *f,
         if (AP_BUCKET_IS_EOR(bucket)) {
             eor_buckets_in_brigade++;
         }
-        else if (AP_BUCKET_IS_MORPHING(bucket)) {
-            morphing_buckets_in_brigade++;
+        else if (bucket->length == (apr_size_t)-1) {
+            opaque_buckets_in_brigade++;
         }
         else if (bucket->length) {
             bytes_in_brigade += bucket->length;
@@ -1151,13 +1152,13 @@ AP_DECLARE(apr_status_t) ap_filter_reinstate_brigade(ap_filter_t *f,
                 ap_log_cerror(APLOG_MARK, APLOG_TRACE8, 0, f->c,
                               "seen in brigade%s: bytes: %" APR_SIZE_T_FMT
                               ", memory bytes: %" APR_SIZE_T_FMT ", eor "
-                              "buckets: %d, morphing buckets: %d",
+                              "buckets: %d, opaque buckets: %d",
                               *flush_upto == NULL ? " so far"
                                                   : " since last flush point",
                               bytes_in_brigade,
                               memory_bytes_in_brigade,
                               eor_buckets_in_brigade,
-                              morphing_buckets_in_brigade);
+                              opaque_buckets_in_brigade);
             }
             /*
              * Defer the actual blocking write to avoid doing many writes.
@@ -1167,17 +1168,17 @@ AP_DECLARE(apr_status_t) ap_filter_reinstate_brigade(ap_filter_t *f,
             bytes_in_brigade = 0;
             memory_bytes_in_brigade = 0;
             eor_buckets_in_brigade = 0;
-            morphing_buckets_in_brigade = 0;
+            opaque_buckets_in_brigade = 0;
         }
     }
 
     ap_log_cerror(APLOG_MARK, APLOG_TRACE8, 0, f->c,
                   "brigade contains%s: bytes: %" APR_SIZE_T_FMT
                   ", non-file bytes: %" APR_SIZE_T_FMT
-                  ", eor buckets: %d, morphing buckets: %d",
+                  ", eor buckets: %d, opaque buckets: %d",
                   *flush_upto == NULL ? "" : " since last flush point",
                   bytes_in_brigade, memory_bytes_in_brigade,
-                  eor_buckets_in_brigade, morphing_buckets_in_brigade);
+                  eor_buckets_in_brigade, opaque_buckets_in_brigade);
 
     return APR_SUCCESS;
 }
@@ -1308,7 +1309,7 @@ AP_DECLARE_NONSTD(int) ap_filter_input_pending(conn_rec *c)
          fp = APR_RING_PREV(fp, pending)) {
         apr_bucket *e;
 
-        /* if there is a leading non-morphing bucket
+        /* if there is a leading non-opaque (length != -1) bucket
          * in place, then we have data pending
          */
         AP_DEBUG_ASSERT(fp->bb);

--- a/server/util_filter.c
+++ b/server/util_filter.c
@@ -979,7 +979,7 @@ AP_DECLARE(apr_status_t) ap_filter_setaside_brigade(ap_filter_t *f,
             /* Morphing buckets are moved, so assumed to have next EOR's
              * lifetime or at least the lifetime of the connection.
              */
-            if (AP_BUCKET_IS_MORPHING(e)) {
+            if (e->length == (apr_size_t)-1 || APR_BUCKET_IS_FILE(e)) {
                 /* Save buckets batched below? */
                 if (batched_buckets) {
                     batched_buckets = 0;


### PR DESCRIPTION
This is to prevent the original/underlying apr_file_t->filedes from being
reset to -1, invalidating all other shared buckets (e.g. splitted)
pointing to the same file.

Like for opaque buckets (->length == -1) which are also moved, we now
assume that FILE buckets have the appropriate lifetime, that is the one
of the current request (i.e. until EOR) or at least the one of the
connection. This is the case for all of httpd codebase (AFAICT).