### PR TITLE
mod_ssl: Update the ssl_var_lookup() API:

### DIFF
--- a/modules/http2/h2_h2.c
+++ b/modules/http2/h2_h2.c
@@ -473,7 +473,7 @@ int h2_is_acceptable_connection(conn_rec *c, request_rec *r, int require_all)
          */
         apr_pool_t *pool = c->pool;
         server_rec *s = c->base_server;
-        char *val;
+        const char *val;
 
         if (!opt_ssl_var_lookup) {
             /* unable to check */

--- a/modules/ssl/mod_ssl.h
+++ b/modules/ssl/mod_ssl.h
@@ -53,11 +53,13 @@
 #endif
 
 /** The ssl_var_lookup() optional function retrieves SSL environment
- * variables. */
-APR_DECLARE_OPTIONAL_FN(char *, ssl_var_lookup,
-                        (apr_pool_t *, server_rec *,
-                         conn_rec *, request_rec *,
-                         char *));
+ * variables.  The pool in which to allocate the return value must be
+ * non-NULL since httpd 2.5.1.  c and/or r may be NULL. */
+APR_DECLARE_OPTIONAL_FN(const char *, ssl_var_lookup,
+                        (apr_pool_t *p, server_rec *s,
+                         conn_rec *c, request_rec *r,
+                         const char *name))
+    AP_FN_ATTR_NONNULL((1, 2, 5)) AP_FN_ATTR_WARN_UNUSED_RESULT;
 
 /** The ssl_ext_list() optional function attempts to build an array
  * of all the values contained in the named X.509 extension. The

--- a/modules/ssl/ssl_engine_init.c
+++ b/modules/ssl/ssl_engine_init.c
@@ -176,10 +176,12 @@ DH *modssl_get_dh_params(unsigned keylen)
 static void ssl_add_version_components(apr_pool_t *ptemp, apr_pool_t *pconf,
                                        server_rec *s)
 {
-    char *modver = ssl_var_lookup(ptemp, s, NULL, NULL, "SSL_VERSION_INTERFACE");
-    char *libver = ssl_var_lookup(ptemp, s, NULL, NULL, "SSL_VERSION_LIBRARY");
-    char *incver = ssl_var_lookup(ptemp, s, NULL, NULL,
-                                  "SSL_VERSION_LIBRARY_INTERFACE");
+    const char *modver = ssl_var_lookup(ptemp, s, NULL, NULL,
+                                        "SSL_VERSION_INTERFACE");
+    const char *libver = ssl_var_lookup(ptemp, s, NULL, NULL,
+                                        "SSL_VERSION_LIBRARY");
+    const char *incver = ssl_var_lookup(ptemp, s, NULL, NULL,
+                                        "SSL_VERSION_LIBRARY_INTERFACE");
 
     ap_add_version_component(pconf, libver);
 

--- a/modules/ssl/ssl_engine_io.c
+++ b/modules/ssl/ssl_engine_io.c
@@ -1361,7 +1361,7 @@ static apr_status_t ssl_io_filter_handshake(ssl_filter_ctx_t *filter_ctx)
             const char *hostname;
             int match = 0;
 
-            hostname = ssl_var_lookup(NULL, server, c, NULL,
+            hostname = ssl_var_lookup(c->pool, server, c, NULL,
                                       "SSL_CLIENT_S_DN_CN");
 
             /* Do string match or simplest wildcard match if that

--- a/modules/ssl/ssl_engine_kernel.c
+++ b/modules/ssl/ssl_engine_kernel.c
@@ -1294,10 +1294,10 @@ int ssl_hook_Access(request_rec *r)
      * we need to postpone setting the username until later.
      */
     if ((dc->nOptions & SSL_OPT_FAKEBASICAUTH) == 0 && dc->szUserName) {
-        char *val = ssl_var_lookup(r->pool, r->server, r->connection,
-                                   r, (char *)dc->szUserName);
+        const char *val = ssl_var_lookup(r->pool, r->server, r->connection,
+                                         r, dc->szUserName);
         if (val && val[0])
-            r->user = val;
+            r->user = apr_pstrdup(r->pool, val);
         else
             ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, r, APLOGNO(02227)
                           "Failed to set r->user to '%s'", dc->szUserName);
@@ -1545,7 +1545,7 @@ int ssl_hook_Fixup(request_rec *r)
 {
     SSLDirConfigRec *dc = myDirConfig(r);
     apr_table_t *env = r->subprocess_env;
-    char *var, *val = "";
+    const char *var, *val = "";
 #ifdef HAVE_TLSEXT
     const char *servername;
 #endif
@@ -1578,7 +1578,7 @@ int ssl_hook_Fixup(request_rec *r)
         modssl_var_extract_san_entries(env, ssl, r->pool);
 
         for (i = 0; ssl_hook_Fixup_vars[i]; i++) {
-            var = (char *)ssl_hook_Fixup_vars[i];
+            var = ssl_hook_Fixup_vars[i];
             val = ssl_var_lookup(r->pool, r->server, r->connection, r, var);
             if (!strIsEmpty(val)) {
                 apr_table_setn(env, var, val);
@@ -2257,10 +2257,10 @@ static void log_tracing_state(const SSL *ssl, conn_rec *c,
     if (where & SSL_CB_HANDSHAKE_DONE) {
         ap_log_cerror(APLOG_MARK, APLOG_DEBUG, 0, c, APLOGNO(02041)
                       "Protocol: %s, Cipher: %s (%s/%s bits)",
-                      ssl_var_lookup(NULL, s, c, NULL, "SSL_PROTOCOL"),
-                      ssl_var_lookup(NULL, s, c, NULL, "SSL_CIPHER"),
-                      ssl_var_lookup(NULL, s, c, NULL, "SSL_CIPHER_USEKEYSIZE"),
-                      ssl_var_lookup(NULL, s, c, NULL, "SSL_CIPHER_ALGKEYSIZE"));
+                      ssl_var_lookup(c->pool, s, c, NULL, "SSL_PROTOCOL"),
+                      ssl_var_lookup(c->pool, s, c, NULL, "SSL_CIPHER"),
+                      ssl_var_lookup(c->pool, s, c, NULL, "SSL_CIPHER_USEKEYSIZE"),
+                      ssl_var_lookup(c->pool, s, c, NULL, "SSL_CIPHER_ALGKEYSIZE"));
     }
 }
 

--- a/modules/ssl/ssl_engine_vars.c
+++ b/modules/ssl/ssl_engine_vars.c
@@ -246,8 +246,6 @@ const char *ssl_var_lookup(apr_pool_t *p, server_rec *s,
     const char *result = NULL;
     apr_time_exp_t tm;
 
-    AP_DEBUG_ASSERT(s);
-    
     /*
      * Request dependent stuff
      */

--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -1091,7 +1091,13 @@ void ssl_log_rxerror(const char *file, int line, int level,
 
 /* Register variables for the lifetime of the process pool 'p'. */
 void         ssl_var_register(apr_pool_t *p);
-char        *ssl_var_lookup(apr_pool_t *, server_rec *, conn_rec *, request_rec *, char *);
+
+/* Matches optional function of the same name in the public API.  The
+ * pool in which to allocate the return value must be non-NULL; c
+ * and/or r may be NULL. */
+const char  *ssl_var_lookup(apr_pool_t *p, server_rec *s, conn_rec *c, request_rec *r,
+                            const char *name)
+    AP_FN_ATTR_NONNULL((1, 2, 5)) AP_FN_ATTR_WARN_UNUSED_RESULT;
 apr_array_header_t *ssl_ext_list(apr_pool_t *p, conn_rec *c, int peer, const char *extension);
 
 void         ssl_var_log_config_register(apr_pool_t *p);


### PR DESCRIPTION
```
mod_ssl: Update the ssl_var_lookup() API:
a) constify return value and variable name passed-in
b) require that pool argument is non-NULL
c) add gcc warning attributes for NULL arguments or ignored result.

This allows removal of inefficient internal duplication of constant
strings which was necessary only to allow non-const char *.

* modules/ssl/ssl_engine_vars.c (ssl_var_lookup): Assume pool is
  non-NULL; return constant and remove apr_pstrdup of constant
  result string.  Also constify variable name.
  (ssl_var_lookup_*): Update to return const char * and avoid
  duplication where that is now possible.

* modules/ssl/mod_ssl.h: Update ssl_var_lookup() optional function
  API description and add GCC warning attributes as per private API.

* modules/ssl/ssl_engine_init.c (ssl_add_version_components): Pass
  ptemp to ssl_var_lookup.

* modules/ssl/ssl_engine_io.c (ssl_io_filter_handshake): Pass c->pool
  to ssl_var_lookup.

* modules/ssl/ssl_engine_kernel.c (ssl_hook_Access): Pass r->pool to
  ssl_var_lookup.
  (log_tracing_state): Pass c->pool to ssl_var_lookup.

* modules/http2/h2_h2.c (h2_is_acceptable_connection): Assume
  return value of ssl_var_lookup is const.
```