### PR TITLE
mod_ldap: Use the LDAP API directly to implement the rebind callback

### DIFF
--- a/include/util_ldap.h
+++ b/include/util_ldap.h
@@ -32,7 +32,6 @@
 #if APR_MAJOR_VERSION < 2
 /* The LDAP API is currently only present in APR 1.x */
 #include "apr_ldap.h"
-#include "apr_ldap_rebind.h"
 #else
 #define APR_HAS_LDAP 0
 #endif

--- a/test/travis_Dockerfile_slapd
+++ b/test/travis_Dockerfile_slapd
@@ -4,6 +4,6 @@ RUN echo slapd slapd/password2 password travis | debconf-set-selections
 RUN echo slapd slapd/internal/adminpw password travis | debconf-set-selections
 RUN echo slapd slapd/internal/generated_adminpw password travis | debconf-set-selections
 RUN echo slapd slapd/domain string example.com | debconf-set-selections
-RUN apt-get update && apt-get -y install slapd
+RUN apt-get update && apt-get -y install slapd ldap-utils
 # With -d passed, slapd stays in the foreground
 CMD /usr/sbin/slapd -d1

--- a/test/travis_Dockerfile_slapd
+++ b/test/travis_Dockerfile_slapd
@@ -6,4 +6,4 @@ RUN echo slapd slapd/internal/generated_adminpw password travis | debconf-set-se
 RUN echo slapd slapd/domain string example.com | debconf-set-selections
 RUN apt-get update && apt-get -y install slapd ldap-utils
 # With -d passed, slapd stays in the foreground
-CMD /usr/sbin/slapd -d1
+CMD /usr/sbin/slapd -d1 '-h ldap:// ldapi:///'

--- a/test/travis_before_linux.sh
+++ b/test/travis_before_linux.sh
@@ -83,12 +83,12 @@ fi
 
 # For LDAP testing, run slapd listening on port 8389 and populate the
 # directory as described in t/modules/ldap.t in the test framework:
-LDIF=test/perl-framework/scripts/httpd.ldif
-if test -v TEST_LDAP -a -r $LDIF ; then
+LDAP_INIT=test/perl-framework/scripts/ldap-init.sh
+if test -v TEST_LDAP -a -x $LDAP_INIT ; then
     docker build -t httpd_slapd -f test/travis_Dockerfile_slapd test/
-    docker run -d -p 8389:389 httpd_slapd | tee .slapd.cid
-    sleep 5
-    ldapadd -H ldap://localhost:8389 -D cn=admin,dc=example,dc=com -w travis < $LDIF
+    pushd test/perl-framework
+       $LDAP_INIT
+    popd
 fi
 
 if test -v APR_VERSION; then

--- a/test/travis_before_linux.sh
+++ b/test/travis_before_linux.sh
@@ -85,7 +85,7 @@ fi
 # directory as described in t/modules/ldap.t in the test framework:
 LDAP_INIT=test/perl-framework/scripts/ldap-init.sh
 if test -v TEST_LDAP -a -x test/perl-framework/scripts/ldap-init.sh; then
-    docker build -t httpd_slapd -f test/travis_Dockerfile_slapd test/
+    docker build -t httpd_ldap -f test/travis_Dockerfile_slapd test/
     pushd test/perl-framework
        ./scripts/ldap-init.sh
     popd

--- a/test/travis_before_linux.sh
+++ b/test/travis_before_linux.sh
@@ -84,10 +84,10 @@ fi
 # For LDAP testing, run slapd listening on port 8389 and populate the
 # directory as described in t/modules/ldap.t in the test framework:
 LDAP_INIT=test/perl-framework/scripts/ldap-init.sh
-if test -v TEST_LDAP -a -x $LDAP_INIT ; then
+if test -v TEST_LDAP -a -x test/perl-framework/scripts/ldap-init.sh; then
     docker build -t httpd_slapd -f test/travis_Dockerfile_slapd test/
     pushd test/perl-framework
-       $LDAP_INIT
+       ./scripts/ldap-init.sh
     popd
 fi
 


### PR DESCRIPTION
```
mod_ldap: Use the LDAP API directly to implement the rebind callback
for modern versions of OpenLDAP, avoiding the overhead of the apr-util
implementation.

* modules/ldap/util_ldap.c:
  Define USE_APR_LDAP_REBIND if a modern version of OpenSSL is used.
  (uldap_rebind_proc): New function.
  (uldap_rebind_init, uldap_rebind_add): Define, using either the
  callback or the (bad) APR-util versions.
  (uldap_connection_unbind): Clear the rebind pool to remove rebind
  references prior to destroying the LDAP *.
  Omit for !USE_APR_LDAP_REBIND.
  (uldap_connection_init): Use new wrappers, only create the rebind
  pool if USE_APR_LDAP_REBIND.

* include/util_ldap.h: Don't include apr_ldap_rebind.h here.

PR: 64414
```