### PR TITLE
mod_proxy_http: handle async tunneling of Upgrade(d) protocol.

### DIFF
--- a/include/ap_mmn.h
+++ b/include/ap_mmn.h
@@ -646,14 +646,16 @@
  * 20200420.9 (2.5.1-dev)  Add hooks deliver_report and gather_reports to
  *                         mod_dav.h.
  * 20200420.10 (2.5.1-dev) Add method_precondition hook to mod_dav.h.
+ * 20200701.0 (2.5.1-dev)  Axe ap_mpm_unregister_poll_callback and
+ *                         mpm_unregister_poll_callback hook.
  */
 
 #define MODULE_MAGIC_COOKIE 0x41503235UL /* "AP25" */
 
 #ifndef MODULE_MAGIC_NUMBER_MAJOR
-#define MODULE_MAGIC_NUMBER_MAJOR 20200420
+#define MODULE_MAGIC_NUMBER_MAJOR 20200701
 #endif
-#define MODULE_MAGIC_NUMBER_MINOR 10            /* 0...n */
+#define MODULE_MAGIC_NUMBER_MINOR 0             /* 0...n */
 
 /**
  * Determine if the server's current MODULE_MAGIC_NUMBER is at least a

--- a/include/ap_mpm.h
+++ b/include/ap_mpm.h
@@ -242,16 +242,6 @@ AP_DECLARE(apr_status_t) ap_mpm_register_poll_callback_timeout(
         ap_mpm_callback_fn_t *tofn, void *baton, apr_time_t timeout);
 
 
-/**
-* Unregister a previously registered callback.
-* @param pfds Array of apr_pollfd_t
-* @return APR_SUCCESS if all sockets/pipes could be removed from the pollset,
-* APR_ENOTIMPL if no asynch support, or an apr_pollset_remove error.
-* @remark This function triggers the cleanup registered on the pool p during
-* callback registration.
-*/
-AP_DECLARE(apr_status_t) ap_mpm_unregister_poll_callback(apr_array_header_t *pfds);
-
 typedef enum mpm_child_status {
     MPM_CHILD_STARTED,
     MPM_CHILD_EXITED,

--- a/include/mpm_common.h
+++ b/include/mpm_common.h
@@ -440,13 +440,6 @@ AP_DECLARE_HOOK(apr_status_t, mpm_register_poll_callback_timeout,
                 void *baton,
                 apr_time_t timeout))
 
-/**
- * Unregister the specified callback
- * @ingroup hooks
- */
-AP_DECLARE_HOOK(apr_status_t, mpm_unregister_poll_callback,
-                (apr_array_header_t *pds))
-
 /** Resume the suspended connection 
  * @ingroup hooks
  */

--- a/modules/proxy/mod_proxy.h
+++ b/modules/proxy/mod_proxy.h
@@ -247,6 +247,11 @@ typedef struct {
     unsigned int forward_100_continue_set:1;
 
     apr_array_header_t *error_override_codes;
+
+    apr_interval_time_t async_delay;
+    apr_interval_time_t async_idle_timeout;
+    unsigned int async_delay_set:1;
+    unsigned int async_idle_timeout_set:1;
 } proxy_dir_conf;
 
 /* if we interpolate env vars per-request, we'll need a per-request

--- a/modules/proxy/proxy_util.c
+++ b/modules/proxy/proxy_util.c
@@ -4327,11 +4327,8 @@ PROXY_DECLARE(apr_status_t) ap_proxy_tunnel_create(proxy_tunnel_rec **ptunnel,
     apr_socket_opt_set(tunnel->client->pfd->desc.s, APR_SO_NONBLOCK, 1);
     apr_socket_opt_set(tunnel->origin->pfd->desc.s, APR_SO_NONBLOCK, 1);
 
-    /* No coalescing filters */
-    ap_remove_output_filter_byhandle(c_i->output_filters,
-                                     "SSL/TLS Coalescing Filter");
-    ap_remove_output_filter_byhandle(c_o->output_filters,
-                                     "SSL/TLS Coalescing Filter");
+    /* Bidirectional non-HTTP stream will confuse mod_reqtimeoout */
+    ap_remove_input_filter_byhandle(c_i->input_filters, "reqtimeout");
 
     /* Bidirectional non-HTTP stream will confuse mod_reqtimeoout */
     ap_remove_input_filter_byhandle(c_i->input_filters, "reqtimeout");

--- a/server/mpm_common.c
+++ b/server/mpm_common.c
@@ -70,7 +70,6 @@
     APR_HOOK_LINK(mpm_register_timed_callback) \
     APR_HOOK_LINK(mpm_register_poll_callback) \
     APR_HOOK_LINK(mpm_register_poll_callback_timeout) \
-    APR_HOOK_LINK(mpm_unregister_poll_callback) \
     APR_HOOK_LINK(mpm_get_name) \
     APR_HOOK_LINK(mpm_resume_suspended) \
     APR_HOOK_LINK(end_generation) \
@@ -116,9 +115,6 @@ AP_IMPLEMENT_HOOK_RUN_FIRST(apr_status_t, mpm_register_poll_callback,
 AP_IMPLEMENT_HOOK_RUN_FIRST(apr_status_t, mpm_register_poll_callback_timeout,
                             (apr_array_header_t *pds, ap_mpm_callback_fn_t *cbfn, ap_mpm_callback_fn_t *tofn, void *baton, apr_time_t timeout),
                             (pds, cbfn, tofn, baton, timeout), APR_ENOTIMPL)
-AP_IMPLEMENT_HOOK_RUN_FIRST(apr_status_t, mpm_unregister_poll_callback,
-                            (apr_array_header_t *pds),
-                            (pds), APR_ENOTIMPL)
 AP_IMPLEMENT_HOOK_RUN_FIRST(int, output_pending,
                             (conn_rec *c), (c), DECLINED)
 AP_IMPLEMENT_HOOK_RUN_FIRST(int, input_pending,
@@ -583,12 +579,6 @@ AP_DECLARE(apr_status_t) ap_mpm_register_poll_callback_timeout(
 {
     return ap_run_mpm_register_poll_callback_timeout(pfds, cbfn, tofn, baton,
             timeout);
-}
-
-AP_DECLARE(apr_status_t) ap_mpm_unregister_poll_callback(
-        apr_array_header_t *pfds)
-{
-    return ap_run_mpm_unregister_poll_callback(pfds);
 }
 
 AP_DECLARE(const char *)ap_show_mpm(void)

--- a/server/mpm_fdqueue.h
+++ b/server/mpm_fdqueue.h
@@ -69,7 +69,7 @@ struct timer_event_t
     ap_mpm_callback_fn_t *cbfunc;
     void *baton;
     int canceled;
-    apr_array_header_t *remove;
+    apr_array_header_t *pfds;
 };
 typedef struct timer_event_t timer_event_t;
 


### PR DESCRIPTION
When supported by the MPM (i.e. "event"), provide async callbacks and let
them be scheduled by ap_mpm_register_poll_callback_timeout(), while the
handler returns SUSPENDED.