### PR TITLE
Make mod_lua compatible with lua 5.4

### DIFF
--- a/modules/lua/mod_lua.h
+++ b/modules/lua/mod_lua.h
@@ -57,6 +57,11 @@
 #if LUA_VERSION_NUM > 502
 #define lua_dump(a,b,c) lua_dump(a,b,c,0)
 #endif
+#if LUA_VERSION_NUM > 503
+int nresults;
+#undef lua_resume
+#define lua_resume(a,b) lua_resume(a, NULL, b, &nresults)
+#endif
 
 /* Create a set of AP_LUA_DECLARE(type), AP_LUA_DECLARE_NONSTD(type) and
  * AP_LUA_DECLARE_DATA with appropriate export and import tags for the platform


### PR DESCRIPTION
Recently released Lua 5.4 introduced additional argument in `lua_resume` function.
