### PR TITLE
Improve the error message for dav_fs_open_stream

### DIFF
--- a/modules/dav/fs/repos.c
+++ b/modules/dav/fs/repos.c
@@ -948,15 +948,26 @@ static dav_error * dav_fs_open_stream(const dav_resource *resource,
         else if (APR_STATUS_IS_EEXIST(rv)) {
             rv = apr_file_open(&ds->f, ds->pathname, flags, APR_OS_DEFAULT,
                                ds->p);
+            if (rv != APR_SUCCESS) {
+                return dav_new_error(p, MAP_IO2HTTP(rv), 0, rv,
+                                    apr_psprintf(p, "Could not open an existing resource for writing: %s.",
+                                    ds->pathname) );
+            }
         }
     }
     else {
         rv = apr_file_open(&ds->f, ds->pathname, flags, APR_OS_DEFAULT, ds->p);
+        if (rv != APR_SUCCESS) {
+            return dav_new_error(p, MAP_IO2HTTP(rv), 0, rv,
+                                apr_psprintf(p, "Could not open an existing resource for reading: %s.",
+                                ds->pathname) );
+        }
     }
 
     if (rv != APR_SUCCESS) {
         return dav_new_error(p, MAP_IO2HTTP(rv), 0, rv,
-                             "An error occurred while opening a resource.");
+                            apr_psprintf(p, "An error occurred while opening a resource for writing: %s.",
+                            ds->pathname) );
     }
 
     /* (APR registers cleanups for the fd with the pool) */


### PR DESCRIPTION
* modules/dav/fs/repo.c: Add specific logs for different modes in
  dav_fs_open_stream(), indicate failure because of diffenent file
  open modes. Also add the filepath in the log messages.

When dav fs want to PUT new contents, it first tries to open resource 
for writing in dav_fs_open_stream(). It specifies two modes, 
DAV_MODE_WRITE_TRUNC, DAV_MODE_WRITE_SEEKABLE, and default mode 
which simply open with OS default permissions. However, the previous log for all three 
modes is the same. "An error occurred while opening a resource." 

This becomes misleading since it may fail for two reasons (1) In the default mode 
to open with OS default permissions, the file may not exist (2) in the two modes 
DAV_MODE_WRITE_ , open for writing may fail because of file permissions.

Also, it is appreciated to specify the actual file path to be opened, since some 
Rewrite rules may be specified and cause errors with dav fs. The inconsistency 
between the real file path and URL in the log may remind sysadmin about this. [1]

Therefore, I think we can improve the log a bit by providing the file name and 
more detailed reasons for each failed case. 

Any thoughts are appreciated! 

[1]https://serverfault.com/questions/20169/webdav-on-centos-getting-403-error-when-attempt-to-upload

