### PR TITLE
Improve the log message for dav_fs_copymove_file

### DIFF
--- a/modules/dav/fs/repos.c
+++ b/modules/dav/fs/repos.c
@@ -364,7 +364,7 @@ static dav_error * dav_fs_copymove_file(
                                 APR_OS_DEFAULT, p)) != APR_SUCCESS) {
         /* ### use something besides 500? */
         return dav_new_error(p, HTTP_INTERNAL_SERVER_ERROR, 0, status,
-                             apr_psprintf(p, "Could not open file"
+                             apr_psprintf(p, "Could not open file "
                                             "for reading: %s", src));
     }
 
@@ -375,7 +375,7 @@ static dav_error * dav_fs_copymove_file(
         apr_file_close(inf);
 
         return dav_new_error(p, MAP_IO2HTTP(status), 0, status,
-                             apr_psprintf(p, "Could not open file"
+                             apr_psprintf(p, "Could not open file "
                                             "for writing: %s", dst));
     }
 

--- a/modules/dav/fs/repos.c
+++ b/modules/dav/fs/repos.c
@@ -364,7 +364,8 @@ static dav_error * dav_fs_copymove_file(
                                 APR_OS_DEFAULT, p)) != APR_SUCCESS) {
         /* ### use something besides 500? */
         return dav_new_error(p, HTTP_INTERNAL_SERVER_ERROR, 0, status,
-                             "Could not open file for reading");
+                             apr_psprintf(p, "Could not open file"
+                                            "for reading: %s", src));
     }
 
     /* ### do we need to deal with the umask? */
@@ -374,7 +375,8 @@ static dav_error * dav_fs_copymove_file(
         apr_file_close(inf);
 
         return dav_new_error(p, MAP_IO2HTTP(status), 0, status,
-                             "Could not open file for writing");
+                             apr_psprintf(p, "Could not open file"
+                                            "for writing: %s", dst));
     }
 
     while (1) {


### PR DESCRIPTION
* modules/dav/fs/repo.c: Add filepath in the log messages of
    dav_fs_copymove_file to differentiate src and dst filepath
    location

The previous log message only says "Could not open file for reading/writing", 
but the file paths are different in reading or writing. I added the file name into 
the log message, so that people can see the which file path may have read/write
permission problems.

Any thoughts are appreciated!
