### PR TITLE
Add .opus extension for audio/ogg mimetype, per RFC 7845

### DIFF
--- a/docs/conf/mime.types
+++ b/docs/conf/mime.types
@@ -1439,7 +1439,7 @@ audio/mp4					m4a mp4a
 audio/mpeg					mpga mp2 mp2a mp3 m2a m3a
 # audio/mpeg4-generic
 # audio/musepack
-audio/ogg					oga ogg spx
+audio/ogg					oga ogg spx opus
 # audio/opus
 # audio/parityfec
 # audio/pcma


### PR DESCRIPTION
RFC 7845: https://tools.ietf.org/html/rfc7845#section-9
> An "Ogg Opus file" consists of one or more sequentially multiplexed
> segments, each containing exactly one Ogg Opus stream.  The
> RECOMMENDED mime-type for Ogg Opus files is "audio/ogg".

> The RECOMMENDED filename extension for Ogg Opus files is '.opus'.

IANA template: https://www.iana.org/assignments/media-types/audio/ogg