### PR TITLE
Add lock database path in the log message mod_dav

### DIFF
--- a/modules/dav/fs/lock.c
+++ b/modules/dav/fs/lock.c
@@ -312,7 +312,9 @@ static dav_error * dav_fs_really_open_lockdb(dav_lockdb *lockdb)
         return dav_push_error(lockdb->info->pool,
                               HTTP_INTERNAL_SERVER_ERROR,
                               DAV_ERR_LOCK_OPENDB,
-                              "Could not open the lock database.",
+                              apr_psprintf(lockdb->info->pool,
+				  "Could not open the lock database: %s",
+				  lockdb->info->lockdb_path),
                               err);
     }
 

--- a/modules/dav/lock/locks.c
+++ b/modules/dav/lock/locks.c
@@ -328,7 +328,9 @@ static dav_error * dav_generic_really_open_lockdb(dav_lockdb *lockdb)
         return dav_push_error(lockdb->info->pool,
                               HTTP_INTERNAL_SERVER_ERROR,
                               DAV_ERR_LOCK_OPENDB,
-                              "Could not open the lock database.",
+                              apr_psprintf(lockdb->info->pool,
+				  "Could not open the lock database: %s",
+				  lockdb->info->lockdb_path),
                               err);
     }
 


### PR DESCRIPTION
Add database path in the log messages of dav_generic_really_open_lockdb and dav_fs_really_open_lockdb to show the lock database's path. The previous log message logs "Could not open the lock database”, but don’t have the detailed path of the lock database. Sysadmins may need to check the FS permissions for the path to resolve the problem. [1]


[1] https://stackoverflow.com/questions/7619658/could-not-open-property-database. 

