### PR TITLE
Fix typo in htpasswd.c

### DIFF
--- a/support/htpasswd.c
+++ b/support/htpasswd.c
@@ -355,7 +355,7 @@ int main(int argc, const char * const argv[])
         }
         else {
             /*
-             * Error out if -c was omitted for this non-existant file.
+             * Error out if -c was omitted for this non-existent file.
              */
             if (!(mask & APHTP_NEWFILE)) {
                 apr_file_printf(errfile,


### PR DESCRIPTION
non-existant -> non-existent