### PR TITLE
mod_xml2enc: avoid corrupting Microsoft Office documents

### DIFF
--- a/modules/filters/mod_xml2enc.c
+++ b/modules/filters/mod_xml2enc.c
@@ -343,8 +343,8 @@ static apr_status_t xml2enc_ffunc(ap_filter_t* f, apr_bucket_brigade* bb)
         if (isupper(*p))
             *p = tolower(*p);
 
-    /* only act if starts-with "text/" or contains "xml" */
-    if (strncmp(ctype, "text/", 5) && !strstr(ctype, "xml"))  {
+    /* only act if starts-with "text/" or contains "+xml" */
+    if (strncmp(ctype, "text/", 5) && !strstr(ctype, "+xml"))  {
         ap_remove_output_filter(f);
         return ap_pass_brigade(f->next, bb) ;
     }


### PR DESCRIPTION
The Microsoft OOXML format uses xml packaged into a zip file, and has
mimetypes like:

application/vnd.openxmlformats-officedocument.spreadsheetml.sheet

This mimetypes contains 'xml', but is unfortunately not an xml file.

xml2enc processes these files (in particular, when mod_proxy_html is
used), typically resulting in them being corrupted as it seems to
attempt to perform a ISO-8859-1 to UTF-8 conversion on them.

Update the check to look for '+xml', which hopefully reflects only
mimetypes that actually contain xml.

closes https://bz.apache.org/bugzilla/show_bug.cgi?id=64339