### PR TITLE
Enable fdpassing in mod_cgid by default, and unify test for CMSG_DATA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,6 +117,9 @@ jobs:
     - name: Linux Ubuntu, Event MPM, all-modules, mod_cgid only
       env: CONFIG="--enable-mods-shared=reallyall --with-mpm=event --disable-cgi"
     # -------------------------------------------------------------------------
+    - name: Linux Ubuntu, Event MPM, all-modules, no CMSG_DATA
+      env: CONFIG="--enable-mods-shared=reallyall --with-mpm=event --disable-cgi ac_cv_have_decl_CMSG_DATA=no"
+    # -------------------------------------------------------------------------
     - if: *condition_not_24x
       name: Linux Ubuntu, PCRE 1, GCC 7 maintainer-mode w/-Werror
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,10 +118,6 @@ jobs:
       env: CONFIG="--enable-mods-shared=reallyall --with-mpm=event --disable-cgi"
     # -------------------------------------------------------------------------
     - if: *condition_not_24x
-      name: Linux Ubuntu, Event MPM, all-modules, mod_cgid fdpassing
-      env: CONFIG="--enable-mods-shared=reallyall --with-mpm=event --disable-cgi --enable-cgid-fdpassing"
-    # -------------------------------------------------------------------------
-    - if: *condition_not_24x
       name: Linux Ubuntu, PCRE 1, GCC 7 maintainer-mode w/-Werror
       os: linux
       env: CONFIG="--enable-mods-shared=reallyall --with-pcre=/usr/bin/pcre-config --enable-maintainer-mode NOTEST_CFLAGS=-Werror CC=gcc-7"

--- a/configure.in
+++ b/configure.in
@@ -567,6 +567,16 @@ if test "$ac_cv_struct_tm_gmtoff" = "yes"; then
     AC_DEFINE(HAVE_GMTOFF, 1, [Define if struct tm has a tm_gmtoff field])
 fi
 
+AC_CHECK_DECL(CMSG_DATA,,, [#include <sys/types.h>
+#include <sys/socket.h>])
+if test $ac_cv_have_decl_CMSG_DATA = "yes"; then
+   AC_DEFINE([HAVE_FDPASSING], 1, [Define if file descriptor passing is supported])
+   ap_has_fdpassing=1
+else
+   ap_has_fdpassing=0
+   AC_MSG_WARN([This system does not support file descriptor passing.])
+fi
+
 APACHE_CHECK_SYSTEMD
 
 dnl ## Set up any appropriate OS-specific environment variables for apachectl

--- a/modules/generators/config5.m4
+++ b/modules/generators/config5.m4
@@ -78,15 +78,4 @@ fi
 
 APR_ADDTO(INCLUDES, [-I\$(top_srcdir)/$modpath_current])
 
-AC_ARG_ENABLE(cgid-fdpassing,
-  [APACHE_HELP_STRING(--enable-cgid-fdpassing,Enable experimental mod_cgid support for fd passing)],
-  [if test "$enableval" = "yes"; then
-     AC_CHECK_DECL(CMSG_DATA,
-       [AC_DEFINE([HAVE_CGID_FDPASSING], 1, [Enable FD passing support in mod_cgid])],
-       [AC_MSG_ERROR([cannot support mod_cgid fd-passing on this system])], [
-#include <sys/types.h>
-#include <sys/socket.h>])
-  fi
-])
-
 APACHE_MODPATH_FINISH

--- a/modules/generators/mod_cgid.c
+++ b/modules/generators/mod_cgid.c
@@ -218,7 +218,7 @@ typedef struct {
 #define cgi_server_conf cgid_server_conf
 #define cgi_module cgid_module
 
-#ifdef HAVE_CGID_FDPASSING
+#ifdef HAVE_FDPASSING
 /* Pull in CGI bucket implementation. */
 #define WANT_CGI_BUCKET
 #endif
@@ -353,7 +353,7 @@ static apr_status_t close_unix_socket(void *thefd)
 static apr_status_t sock_readhdr(int fd, int *errfd, void *vbuf, size_t buf_size)
 {
     int rc;
-#ifndef HAVE_CGID_FDPASSING
+#ifndef HAVE_FDPASSING
     char *buf = vbuf;
     size_t bytes_read = 0;
 
@@ -458,7 +458,7 @@ static apr_status_t sock_writev(int fd, int auxfd, request_rec *r, int count, ..
     }
     va_end(ap);
 
-#ifndef HAVE_CGID_FDPASSING
+#ifndef HAVE_FDPASSING
     do {
         rc = writev(fd, vec, count);
     } while (rc < 0 && errno == EINTR);
@@ -1541,7 +1541,7 @@ static int cgid_handler(request_rec *r)
     }
     */
 
-#ifdef HAVE_CGID_FDPASSING
+#ifdef HAVE_FDPASSING
     rv = apr_file_pipe_create(&script_err, &errpipe_out, r->pool);
     if (rv) {
         return log_scripterror(r, conf, HTTP_SERVICE_UNAVAILABLE, rv, APLOGNO(10176),
@@ -1623,7 +1623,7 @@ static int cgid_handler(request_rec *r)
     shutdown(sd, 1);
 
     bb = apr_brigade_create(r->pool, c->bucket_alloc);
-#ifdef HAVE_CGID_FDPASSING
+#ifdef HAVE_FDPASSING
     b = cgi_bucket_create(r, dc->timeout, tempsock, script_err, c->bucket_alloc);
     if (b == NULL)
         return HTTP_INTERNAL_SERVER_ERROR; /* should call log_scripterror() w/ _UNAVAILABLE? */

--- a/modules/proxy/config.m4
+++ b/modules/proxy/config.m4
@@ -40,12 +40,7 @@ APACHE_MODULE(proxy_fcgi, Apache proxy FastCGI module.  Requires --enable-proxy.
 APACHE_MODULE(proxy_scgi, Apache proxy SCGI module.  Requires --enable-proxy., $proxy_scgi_objs, , most, , proxy)
 APACHE_MODULE(proxy_uwsgi, Apache proxy UWSGI module.  Requires --enable-proxy., $proxy_uwsgi_objs, , most, , proxy)
 APACHE_MODULE(proxy_fdpass, Apache proxy to Unix Daemon Socket module.  Requires --enable-proxy., $proxy_fdpass_objs, , most, [
-  AC_CHECK_DECL(CMSG_DATA,,, [
-    #include <sys/types.h>
-    #include <sys/socket.h>
-  ])
-  if test $ac_cv_have_decl_CMSG_DATA = "no"; then
-    AC_MSG_WARN([Your system does not support CMSG_DATA.])
+  if test $ap_has_fdpassing = 0; then
     enable_proxy_fdpass=no
   fi
 ],proxy)


### PR DESCRIPTION
```
* configure.in: Check for CMSG_DATA here, and define HAVE_FDPASSING
   and $ap_has_fdpassing if fd passing is supported.

* modules/generator/config5.m4,
  modules/generator/mod_cgid.c: Drop configure flag for mod_cgid
  fdpassing support, instead enable where possible by default.

* modules/proxy/config.m4: Rely on configure test for CMSG_DATA.
```