### PR TITLE
Lua 5.4 support for 2.4.x

### DIFF
--- a/modules/lua/config.m4
+++ b/modules/lua/config.m4
@@ -34,7 +34,7 @@ AC_DEFUN([CHECK_LUA_PATH], [dnl
     fi
 ])
 
-dnl Check for Lua 5.3/5.2/5.1 Libraries
+dnl Check for Lua Libraries
 dnl CHECK_LUA(ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND])
 dnl Sets:
 dnl  LUA_CFLAGS
@@ -44,7 +44,7 @@ AC_DEFUN([CHECK_LUA],
 
 AC_ARG_WITH(
     lua,
-    [AC_HELP_STRING([--with-lua=PATH],[Path to the Lua 5.3/5.2/5.1 prefix])],
+    [AC_HELP_STRING([--with-lua=PATH],[Path to the Lua installation prefix])],
     lua_path="$withval",
     :)
 
@@ -55,16 +55,25 @@ else
     test_paths="${lua_path}"
 fi
 
-if test -n "$PKGCONFIG" -a -z "$lua_path" \
-   && $PKGCONFIG --atleast-version=5.1 lua; then
-  LUA_LIBS="`$PKGCONFIG --libs lua`"
-  LUA_CFLAGS="`$PKGCONFIG --cflags lua`"
-  LUA_VERSION="`$PKGCONFIG --modversion lua`"
-  AC_MSG_NOTICE([using Lua $LUA_VERSION configuration from pkg-config])
-else
+for pklua in lua lua5.4 lua5.3 lua5.2 lua5.1; do
+  if test -n "$PKGCONFIG" -a -z "$lua_path" \
+     && $PKGCONFIG --atleast-version=5.1 $pklua; then
+    LUA_LIBS="`$PKGCONFIG --libs $pklua`"
+    LUA_CFLAGS="`$PKGCONFIG --cflags $pklua`"
+    LUA_VERSION="`$PKGCONFIG --modversion $pklua`"
+    AC_MSG_NOTICE([using Lua $LUA_VERSION configuration from pkg-config])
+    break
+  fi
+done
+
+if test -z "$LUA_VERSION"; then
   AC_CHECK_LIB(m, pow, lib_m="-lm")
   AC_CHECK_LIB(m, sqrt, lib_m="-lm")
   for x in $test_paths ; do
+    CHECK_LUA_PATH([${x}], [include/lua-5.4], [lib/lua-5.4], [lua-5.4])
+    CHECK_LUA_PATH([${x}], [include/lua5.4], [lib], [lua5.4])
+    CHECK_LUA_PATH([${x}], [include/lua54], [lib/lua54], [lua])
+
     CHECK_LUA_PATH([${x}], [include/lua-5.3], [lib/lua-5.3], [lua-5.3])
     CHECK_LUA_PATH([${x}], [include/lua5.3], [lib], [lua5.3])
     CHECK_LUA_PATH([${x}], [include/lua53], [lib/lua53], [lua])
@@ -85,13 +94,13 @@ AC_SUBST(LUA_LIBS)
 AC_SUBST(LUA_CFLAGS)
 
 if test -z "${LUA_LIBS}"; then
-  AC_MSG_WARN([*** Lua 5.3 5.2 or 5.1 library not found.])
+  AC_MSG_WARN([*** Lua 5.4 5.3 5.2 or 5.1 library not found.])
   ifelse([$2], ,
     enable_lua="no"
     if test -z "${lua_path}"; then
-        AC_MSG_WARN([Lua 5.3 5.2 or 5.1 library is required])
+        AC_MSG_WARN([Lua 5.4 5.3 5.2 or 5.1 library is required])
     else
-        AC_MSG_ERROR([Lua 5.3 5.2 or 5.1 library is required])
+        AC_MSG_ERROR([Lua 5.4 5.3 5.2 or 5.1 library is required])
     fi,
     $2)
 else

--- a/modules/lua/mod_lua.h
+++ b/modules/lua/mod_lua.h
@@ -48,11 +48,20 @@
 #if LUA_VERSION_NUM > 501
 /* Load mode for lua_load() */
 #define lua_load(a,b,c,d)  lua_load(a,b,c,d,NULL)
-#define lua_resume(a,b)    lua_resume(a, NULL, b)
+
+#if LUA_VERSION_NUM > 503
+#define lua_resume(a,b,c)    lua_resume(a, NULL, b, c)
+#else
+/* ### For version < 5.4, assume that exactly one stack item is on the
+ * stack, which is what the code did before but seems dubious. */
+#define lua_resume(a,b,c)    (*(c) = 1, lua_resume(a, NULL, b))
+#endif
+
 #define luaL_setfuncs_compat(a,b) luaL_setfuncs(a,b,0)
 #else
 #define lua_rawlen(L,i)    lua_objlen(L, (i))
 #define luaL_setfuncs_compat(a,b) luaL_register(a,NULL,b)
+#define lua_resume(a,b,c)    (*(c) = 1, lua_resume(a, b))
 #endif
 #if LUA_VERSION_NUM > 502
 #define lua_dump(a,b,c) lua_dump(a,b,c,0)


### PR DESCRIPTION
```
* modules/lua/config.m4 (CHECK_LUA): Support Debian-style
  pkg-config naming for lua.

Reviewed by: ylavic

Support building against Lua 5.4 by adjusting to the 3-arg form of
lua_resume().

* modules/lua/config.m4 (CHECK_LUA): Check for lua5.4 paths.

* modules/lua/mod_lua.c (lua_output_filter_handle,
  lua_input_filter_handle): Check that exactly one item is on the
  stack as indicated by lua_resume().

Submitted by: Lubos Uhliarik <luhliari redhat.com>, jorton
PR: 64591

improve Lua 5.4 handling

Submitted by: jorton, gbechis
```