### PR TITLE
Add reasons before returning declined in mod_dialup 

### DIFF
--- a/modules/test/mod_dialup.c
+++ b/modules/test/mod_dialup.c
@@ -181,6 +181,9 @@ dialup_handler(request_rec *r)
                        , 0, r->pool);
 
     if (rv) {
+        ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, APLOGNO()
+                      "dialup: decline because can not open file %s",
+                      r->filename);
         return DECLINED;
     }
 

--- a/modules/test/mod_dialup.c
+++ b/modules/test/mod_dialup.c
@@ -181,8 +181,8 @@ dialup_handler(request_rec *r)
                        , 0, r->pool);
 
     if (rv) {
-        ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, APLOGNO()
-                      "dialup: decline because can not open file %s",
+        ap_log_rerror(APLOG_MARK, APLOG_ERR, rv, r, APLOGNO()
+                      "dialup: declined because can not open file %s",
                       r->filename);
         return DECLINED;
     }


### PR DESCRIPTION
* modules/test/mod_dialup.c : apr_file_open() may fail in the dialup handler, so leave a log message before simply return declined.