### PR TITLE
Common HTTP/1 parsing code between core and h2.

### DIFF
--- a/changes-entries/StrictHostCheck.txt
+++ b/changes-entries/StrictHostCheck.txt
@@ -1,0 +1,2 @@
+  *) core: Add StrictHostCheck to allow unconfigured hostnames to be
+     rejected. [Eric Covener]

--- a/changes-entries/ap_create_request.txt
+++ b/changes-entries/ap_create_request.txt
@@ -1,0 +1,1 @@
+  *) core: Split ap_create_request() from ap_read_request(). [Graham Leggett]

--- a/changes-entries/ap_parse_request_line.txt
+++ b/changes-entries/ap_parse_request_line.txt
@@ -1,0 +1,2 @@
+  *) core, h2: common ap_parse_request_line() and ap_check_request_header()
+     code. [Yann Ylavic]

--- a/docs/manual/mod/core.xml
+++ b/docs/manual/mod/core.xml
@@ -5207,6 +5207,42 @@ recognized methods to modules.</p>
 </directivesynopsis>
 
 <directivesynopsis>
+<name>StrictHostCheck</name>
+<description>Controls whether the server requires the requested hostname be
+             listed enumerated in the virtual host handling the request
+             </description>
+<syntax>StrictHostCheck ON|OFF</syntax>
+<default>StrictHostCheck OFF</default>
+<contextlist><context>server config</context><context>virtual host</context>
+</contextlist>
+<compatibility>Added in 2.5.1</compatibility>
+
+<usage>
+    <p>By default, the server will respond to requests for any hostname,
+    including requests addressed to unexpected or unconfigured hostnames. 
+    While this is convenient, it is sometimes desirable to limit what hostnames
+    a backend application handles since it will often generate self-referential
+    responses.</p>
+
+    <p>By setting <directive>StrictHostCheck</directive> to <em>ON</em>,
+    the server will return an HTTP 400 error if the requested hostname
+    hasn't been explicitly listed by either <directive module="core"
+    >ServerName</directive> or <directive module="core"
+    >ServerAlias</directive> in the virtual host that best matches the
+    details of the incoming connection.</p>
+
+   <p>This directive also allows matching of the requested hostname to hostnames
+   specified within the opening <directive module="core">VirtualHost</directive>
+   tag, which is a relatively obscure configuration mechanism that acts like
+   additional <directive module="core">ServerAlias</directive> entries.</p>
+
+   <p>This directive has no affect in non-default virtual hosts. The value
+   inherited from the global server configuration, or the default virtualhost 
+   for the ip:port the underlying connection, determine the effective value.</p>
+</usage>
+</directivesynopsis>
+
+<directivesynopsis>
 <name>MergeSlashes</name>
 <description>Controls whether the server merges consecutive slashes in URLs.
 </description>

--- a/include/ap_mmn.h
+++ b/include/ap_mmn.h
@@ -559,6 +559,9 @@
  *                           and ap_ssl_answer_challenge and hooks.
  * 20120211.104 (2.4.47-dev) Move ap_ssl_* into new http_ssl.h header file
  * 20120211.105 (2.4.47-dev) Add ap_ssl_ocsp* hooks and functions to http_ssl.h.
+ * 20120211.106 (2.4.47-dev) Add ap_create_request().
+ * 20120211.107 (2.4.47-dev) Add ap_parse_request_line() and
+ *                           ap_check_request_header()
  */
 
 #define MODULE_MAGIC_COOKIE 0x41503234UL /* "AP24" */
@@ -566,7 +569,7 @@
 #ifndef MODULE_MAGIC_NUMBER_MAJOR
 #define MODULE_MAGIC_NUMBER_MAJOR 20120211
 #endif
-#define MODULE_MAGIC_NUMBER_MINOR 105                 /* 0...n */
+#define MODULE_MAGIC_NUMBER_MINOR 107                 /* 0...n */
 
 /**
  * Determine if the server's current MODULE_MAGIC_NUMBER is at least a

--- a/include/http_core.h
+++ b/include/http_core.h
@@ -754,6 +754,7 @@ typedef struct {
  
     apr_size_t   flush_max_threshold;
     apr_int32_t  flush_max_pipelined;
+    unsigned int strict_host_check;
 } core_server_config;
 
 /* for AddOutputFiltersByType in core.c */
@@ -781,6 +782,11 @@ AP_DECLARE(void) ap_set_server_protocol(server_rec* s, const char* proto);
 
 typedef struct core_output_filter_ctx core_output_filter_ctx_t;
 typedef struct core_filter_ctx        core_ctx_t;
+
+struct core_filter_ctx {
+    apr_bucket_brigade *b;
+    apr_bucket_brigade *tmpbb;
+};
 
 typedef struct core_net_rec {
     /** Connection to the client */

--- a/include/http_protocol.h
+++ b/include/http_protocol.h
@@ -54,11 +54,32 @@ AP_DECLARE_DATA extern ap_filter_rec_t *ap_old_write_func;
  */
 
 /**
+ * Read an empty request and set reasonable defaults.
+ * @param c The current connection
+ * @return The new request_rec
+ */
+AP_DECLARE(request_rec *) ap_create_request(conn_rec *c);
+
+/**
  * Read a request and fill in the fields.
  * @param c The current connection
  * @return The new request_rec
  */
 request_rec *ap_read_request(conn_rec *c);
+
+/**
+ * Parse and validate the request line.
+ * @param r The current request
+ * @return 1 on success, 0 on failure
+ */
+AP_DECLARE(int) ap_parse_request_line(request_rec *r);
+
+/**
+ * Validate the request header and select vhost.
+ * @param r The current request
+ * @return 1 on success, 0 on failure
+ */
+AP_DECLARE(int) ap_check_request_header(request_rec *r);
 
 /**
  * Read the mime-encoded headers.

--- a/include/http_vhost.h
+++ b/include/http_vhost.h
@@ -100,6 +100,19 @@ AP_DECLARE(void) ap_update_vhost_given_ip(conn_rec *conn);
 AP_DECLARE(void) ap_update_vhost_from_headers(request_rec *r);
 
 /**
+ * Updates r->server with the best name-based virtual host match, within
+ * the chain of matching virtual hosts selected by ap_update_vhost_given_ip.
+ * @param r The current request
+ * @param require_match 1 to return an HTTP error if the requested hostname is
+ * not explicitly matched to a VirtualHost. 
+ * @return return HTTP_OK unless require_match was specified and the requested
+ * hostname did not match any ServerName, ServerAlias, or VirtualHost 
+ * address-spec.
+ */
+AP_DECLARE(int) ap_update_vhost_from_headers_ex(request_rec *r, int require_match);
+
+
+/**
  * Match the host in the header with the hostname of the server for this
  * request.
  * @param r The current request

--- a/server/core.c
+++ b/server/core.c
@@ -511,6 +511,8 @@ static void *create_core_server_config(apr_pool_t *a, server_rec *s)
     conf->protocols_honor_order = -1;
     conf->merge_slashes = AP_CORE_CONFIG_UNSET; 
     
+    conf->strict_host_check= AP_CORE_CONFIG_UNSET; 
+
     return (void *)conf;
 }
 
@@ -584,6 +586,12 @@ static void *merge_core_server_configs(apr_pool_t *p, void *basev, void *virtv)
     conf->flush_max_pipelined = (virt->flush_max_pipelined >= 0)
                                   ? virt->flush_max_pipelined
                                   : base->flush_max_pipelined;
+
+    conf->strict_host_check = (virt->strict_host_check != AP_CORE_CONFIG_UNSET)
+                              ? virt->strict_host_check 
+                              : base->strict_host_check;
+
+    AP_CORE_MERGE_FLAG(strict_host_check, conf, base, virt);
 
     return conf;
 }
@@ -4623,7 +4631,10 @@ AP_INIT_TAKE2("CGIVar", set_cgi_var, NULL, OR_FILEINFO,
 AP_INIT_FLAG("QualifyRedirectURL", set_qualify_redirect_url, NULL, OR_FILEINFO,
              "Controls whether the REDIRECT_URL environment variable is fully "
              "qualified"),
-
+AP_INIT_FLAG("StrictHostCheck", set_core_server_flag, 
+             (void *)APR_OFFSETOF(core_server_config, strict_host_check),  
+             RSRC_CONF,
+             "Controls whether a hostname match is required"),
 AP_INIT_TAKE1("ForceType", ap_set_string_slot_lower,
        (void *)APR_OFFSETOF(core_dir_config, mime_type), OR_FILEINFO,
      "a mime type that overrides other configured type"),
@@ -5623,4 +5634,3 @@ AP_DECLARE_MODULE(core) = {
     core_cmds,                    /* command apr_table_t */
     register_hooks                /* register hooks */
 };
-

--- a/server/core_filters.c
+++ b/server/core_filters.c
@@ -85,11 +85,6 @@ struct core_output_filter_ctx {
     apr_size_t nvec;
 };
 
-struct core_filter_ctx {
-    apr_bucket_brigade *b;
-    apr_bucket_brigade *tmpbb;
-};
-
 
 apr_status_t ap_core_input_filter(ap_filter_t *f, apr_bucket_brigade *b,
                                   ap_input_mode_t mode, apr_read_type_e block,


### PR DESCRIPTION
Merge [r1734009, r1734231, r1734281, r1838055, r1838079, r1876664, r1876674,
       r1876784, r1879078, r1881620] from trunk:

core: Split ap_create_request() from ap_read_request()


added AP_DECLARE for new ap_create_request


declaring ap_create_request for external linkage


Add StrictHostCheck 

.. to allow ucnonfigured hostnames to be rejected. 

The checks happen during NVH mapping and checks that the
mapped VH itself has the host as a name or alias.


add ids


core, h2: send EOR for early HTTP request failure.

The core output filters depend on EOR being sent at some point for correct
accounting of setaside limits and lifetime.

Rework ap_read_request() early failure (including in post_read_request() hooks)
so that it always sends the EOR after ap_die().

Apply the same scheme in h2_request_create_rec() which is the HTTP/2 to HTTP/1
counterpart.


core, h2: common ap_parse_request_line() and ap_check_request_header() code.

Extract parsing/validation code from read_request_line() and ap_read_request()
into ap_parse_request_line() and ap_check_request_header() helpers such that
mod_http2 can validate its HTTP/1 request with the same/configured policy.


core: follow up to r1876664: allow ErrorDocument to read body when applicable

Unless ap_read_request() failed to read the request line or header, or
Transfer-Encoding is invalid, we can still provide the request body to custom
error handlers (ErrorDocument) that ask it (e.g. internal redirects to CGI).

So this commit splits early failure path (previously die_early label) in two,
die_unusable_input and die_before_hooks, where the latter preserves input
filters (including HTTP_IN).

Also, the code to apply the connection timeout and r->per_dir_config from the
server is now in a new apply_server_config() helper since it's used multiple
times. Note that apr_socket_timeout_set() is a noop if the new timeout is the
same as the one already in place, so there is no need to cache the old timeout
nor use apr_socket_timeout_get(). Likewise, r->server is initially set to
c->base_server so apply_server_config() is overall a noop when no change is
needed.


Validate request-target per RFC 7230 section 5.3.

RFC 7230 requires that the request-line URI be absolute, besides
"CONNECT authority-form" and "OPTIONS asterisk-form".

Enforce it in ap_parse_request_line().


Process early errors via a dummy HTTP/1.1 request as well

Process early errors via a dummy HTTP/1.1 request as well to ensure
that the request gets logged correctly and possible custom error
pages are considered. The previous way of directly sending a HTTP/2
answer with the HTTP status code appropriate for the error is more
efficient, but does not log the request nor sents a possible custom
error page.


* modules/http2/h2.h: Add http_status to h2_request struct and define
  H2_HTTP_STATUS_UNSET.

* modules/http2/h2_request.c(h2_request_create_rec): Check if
  http_status is set for the request and die with the
  status code it contains if set.

* modules/http2/h2_session.c(on_header_cb): Adjust the error condition
  now that we mark early errors via http_status: Only return an error
  if the status is not success and http_status is not H2_HTTP_STATUS_UNSET.

* modules/http2/h2_stream.c(set_error_response): Set http_status
  on the request instead of creating headers for a response and a
  respective brigade.

Github: closes #137


Submitted by: minfrin, icing, icing, covener, covener, ylavic, ylavic,
              ylavic, ylavic, rpluem