### PR TITLE
Try using SSL_CTX_set_dh_auto() which is present in 1.1.0 and later.

### DIFF
--- a/modules/ssl/ssl_engine_init.c
+++ b/modules/ssl/ssl_engine_init.c
@@ -92,7 +92,6 @@ static int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
 
     return 1;
 }
-#endif
 
 /*
  * Grab well-defined DH parameters from OpenSSL, see the BN_get_rfc*
@@ -172,6 +171,7 @@ DH *modssl_get_dh_params(unsigned keylen)
         
     return NULL; /* impossible to reach. */
 }
+#endif
 
 static void ssl_add_version_components(apr_pool_t *ptemp, apr_pool_t *pconf,
                                        server_rec *s)
@@ -456,8 +456,9 @@ apr_status_t ssl_init_Module(apr_pool_t *p, apr_pool_t *plog,
 
     modssl_init_app_data2_idx(); /* for modssl_get_app_data2() at request time */
 
+#if MODSSL_USE_OPENSSL_PRE_1_1_API
     init_dh_params();
-#if !MODSSL_USE_OPENSSL_PRE_1_1_API
+#else
     init_bio_methods();
 #endif
 
@@ -918,7 +919,11 @@ static void ssl_init_ctx_callbacks(server_rec *s,
 {
     SSL_CTX *ctx = mctx->ssl_ctx;
 
+#if MODSSL_USE_OPENSSL_PRE_1_1_API
     SSL_CTX_set_tmp_dh_callback(ctx,  ssl_callback_TmpDH);
+#else
+    SSL_CTX_set_dh_auto(ctx, 1);
+#endif
 
     /* The info callback is used for debug-level tracing.  For OpenSSL
      * versions where SSL_OP_NO_RENEGOTIATION is not available, the
@@ -2361,10 +2366,11 @@ apr_status_t ssl_init_ModuleKill(void *data)
 
     }
 
-#if !MODSSL_USE_OPENSSL_PRE_1_1_API
+#if MODSSL_USE_OPENSSL_PRE_1_1_API
+    free_dh_params();
+#else
     free_bio_methods();
 #endif
-    free_dh_params();
 
     return APR_SUCCESS;
 }

--- a/modules/ssl/ssl_engine_kernel.c
+++ b/modules/ssl/ssl_engine_kernel.c
@@ -1704,6 +1704,7 @@ const authz_provider ssl_authz_provider_verify_client =
 **  _________________________________________________________________
 */
 
+#if MODSSL_USE_OPENSSL_PRE_1_1_API
 /*
  * Hand out standard DH parameters, based on the authentication strength
  */
@@ -1749,6 +1750,7 @@ DH *ssl_callback_TmpDH(SSL *ssl, int export, int keylen)
 
     return modssl_get_dh_params(keylen);
 }
+#endif
 
 /*
  * This OpenSSL callback function is called when OpenSSL

--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -1150,7 +1150,7 @@ void ssl_init_ocsp_certificates(server_rec *s, modssl_ctx_t *mctx);
 
 #endif
 
-#ifndef MODSSL_USE_OPENSSL_PRE_1_1_API
+#if MODSSL_USE_OPENSSL_PRE_1_1_API
 /* Retrieve DH parameters for given key length.  Return value should
  * be treated as unmutable, since it is stored in process-global
  * memory. */

--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -1150,10 +1150,12 @@ void ssl_init_ocsp_certificates(server_rec *s, modssl_ctx_t *mctx);
 
 #endif
 
+#ifndef MODSSL_USE_OPENSSL_PRE_1_1_API
 /* Retrieve DH parameters for given key length.  Return value should
  * be treated as unmutable, since it is stored in process-global
  * memory. */
 DH *modssl_get_dh_params(unsigned keylen);
+#endif
 
 /* Returns non-zero if the request was made over SSL/TLS.  If sslconn
  * is non-NULL and the request is using SSL/TLS, sets *sslconn to the


### PR DESCRIPTION
It looks like the OpenSSL-internal implementation doesn't use a cache
of generated DH * objects, instead calling BN_bin2bn() each invocation.
Not sure whether this performance impact matters.  The
SSL_CTX_set_tmp_dh_callback() API is deprecated in OpenSSL 3.0.