### PR TITLE
For optional_no_ca allow invalid purpose

### DIFF
--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -415,6 +415,7 @@ typedef enum {
     || (errnum == X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN) \
     || (errnum == X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY) \
     || (errnum == X509_V_ERR_CERT_UNTRUSTED) \
+    || (errnum == X509_V_ERR_INVALID_PURPOSE) \
     || (errnum == X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE))
 
 /**


### PR DESCRIPTION
Currently with this setting
`SSLVerifyClient optional_no_ca`
If the client cert has an invalid purpose, SSL fails.

This is necessary for the case when we always want Httpd to pass the client cert with validation information to the backend--and for the backend to make decisions based on that.