### PR TITLE
complete back port the mapping=servlet to 2.4.x

### DIFF
--- a/docs/manual/developer/modguide.xml
+++ b/docs/manual/developer/modguide.xml
@@ -237,6 +237,7 @@ can create. Some other ways of hooking are:
 <li><code>ap_hook_child_init</code>: Place a hook that executes when a child process is spawned (commonly used for initializing modules after the server has forked)</li>
 <li><code>ap_hook_pre_config</code>: Place a hook that executes before any configuration data has been read (very early hook)</li>
 <li><code>ap_hook_post_config</code>: Place a hook that executes after configuration has been parsed, but before the server has forked</li>
+<li><code>ap_hook_pre_translate_name</code>: Place a hook that executes when a URI needs to be translated into a filename on the server, before decoding</li>
 <li><code>ap_hook_translate_name</code>: Place a hook that executes when a URI needs to be translated into a filename on the server (think <code>mod_rewrite</code>)</li>
 <li><code>ap_hook_quick_handler</code>: Similar to <code>ap_hook_handler</code>, except it is run before any other request hooks (translation, auth, fixups etc)</li>
 <li><code>ap_hook_log_transaction</code>: Place a hook that executes when the server is about to add a log entry of the current request</li>

--- a/docs/manual/mod/mod_log_debug.xml
+++ b/docs/manual/mod/mod_log_debug.xml
@@ -103,6 +103,7 @@
     <table border="1" style="zebra">
     <columnspec><column width="1"/></columnspec>
     <tr><th>Name</th></tr>
+    <tr><td><code>pre_translate_name</code></td></tr>
     <tr><td><code>translate_name</code></td></tr>
     <tr><td><code>type_checker</code></td></tr>
     <tr><td><code>quick_handler</code></td></tr>

--- a/docs/manual/mod/mod_lua.xml
+++ b/docs/manual/mod/mod_lua.xml
@@ -216,6 +216,13 @@ performing access control, or setting mime types:</p>
             been mapped to a host or virtual host</td>
     </tr>
     <tr>
+        <td>Pre-Translate name</td>
+        <td><directive module="mod_lua">LuaHookPreTranslateName</directive></td>
+        <td>This phase translates the requested URI into a filename on the
+            system, before decoding occurs. Modules such as <module>mod_proxy</module>
+            can operate in this phase.</td>
+    </tr>
+    <tr>
         <td>Translate name</td>
         <td><directive module="mod_lua">LuaHookTranslateName</directive></td>
         <td>This phase translates the requested URI into a filename on the 
@@ -439,7 +446,7 @@ end
           <td>string</td>
           <td>yes</td>
           <td>The file name that the request maps to, f.x. /www/example.com/foo.txt. This can be 
-            changed in the translate-name or map-to-storage phases of a request to allow the 
+            changed in the pre-translate-name, translate-name or map-to-storage phases of a request to allow the
             default handler (or script handlers) to serve a different file than what was requested.</td>
         </tr>
         <tr>
@@ -538,7 +545,7 @@ end
           <td>string</td>
           <td>yes</td>
           <td>Denotes whether this is a proxy request or not. This value is generally set in 
-            the post_read_request/translate_name phase of a request.</td>
+            the post_read_request/pre_translate_name/translate_name phase of a request.</td>
         </tr>
         <tr>
           <td><code>range</code></td>
@@ -1491,6 +1498,23 @@ end
    <note><title>Ordering</title><p>The optional arguments "early" or "late" 
    control when this script runs relative to other modules.</p></note>
 
+</usage>
+</directivesynopsis>
+
+<directivesynopsis>
+<name>LuaHookPreTranslate</name>
+<description>Provide a hook for the pre_translate phase of a request
+processing</description>
+<syntax>LuaHookPreTranslate  /path/to/lua/script.lua hook_function_name</syntax>
+<contextlist><context>server config</context><context>virtual host</context>
+<context>directory</context><context>.htaccess</context>
+</contextlist>
+<override>All</override>
+<usage>
+<p>
+    Just like LuaHookTranslateName, but executed at the pre_translate phase,
+    where the URI-path is not percent decoded.
+</p>
 </usage>
 </directivesynopsis>
 

--- a/include/ap_mmn.h
+++ b/include/ap_mmn.h
@@ -562,6 +562,7 @@
  * 20120211.106 (2.4.49-dev) Add ap_create_request().
  * 20120211.107 (2.4.49-dev) Add ap_parse_request_line() and
  *                           ap_check_request_header()
+ * 20120211.108 (2.4.49-dev) Add ap_normalize_path()
  */
 
 #define MODULE_MAGIC_COOKIE 0x41503234UL /* "AP24" */
@@ -569,7 +570,7 @@
 #ifndef MODULE_MAGIC_NUMBER_MAJOR
 #define MODULE_MAGIC_NUMBER_MAJOR 20120211
 #endif
-#define MODULE_MAGIC_NUMBER_MINOR 107                 /* 0...n */
+#define MODULE_MAGIC_NUMBER_MINOR 108                 /* 0...n */
 
 /**
  * Determine if the server's current MODULE_MAGIC_NUMBER is at least a

--- a/include/ap_mmn.h
+++ b/include/ap_mmn.h
@@ -562,8 +562,10 @@
  * 20120211.106 (2.4.49-dev) Add ap_create_request().
  * 20120211.107 (2.4.49-dev) Add ap_parse_request_line() and
  *                           ap_check_request_header()
- * 20120211.108 (2.4.49-dev) Add ap_normalize_path() and
- *                           pre_translate_name hook.
+ * 20120211.108 (2.4.49-dev) Add ap_normalize_path(),
+ *                           pre_translate_name hook and
+ *                           Add map_encoded_one and map_encoded_all bits to
+ *                           proxy_server_conf.
  */
 
 #define MODULE_MAGIC_COOKIE 0x41503234UL /* "AP24" */

--- a/include/ap_mmn.h
+++ b/include/ap_mmn.h
@@ -562,7 +562,8 @@
  * 20120211.106 (2.4.49-dev) Add ap_create_request().
  * 20120211.107 (2.4.49-dev) Add ap_parse_request_line() and
  *                           ap_check_request_header()
- * 20120211.108 (2.4.49-dev) Add ap_normalize_path()
+ * 20120211.108 (2.4.49-dev) Add ap_normalize_path() and
+ *                           pre_translate_name hook.
  */
 
 #define MODULE_MAGIC_COOKIE 0x41503234UL /* "AP24" */

--- a/include/http_request.h
+++ b/include/http_request.h
@@ -365,7 +365,6 @@ AP_DECLARE_HOOK(int,create_request,(request_rec *r))
 /**
  * This hook allow modules an opportunity to translate the URI into an
  * actual filename, before URL decoding happens.
- * rules will be followed.
  * @param r The current request
  * @return OK, DECLINED, or HTTP_...
  * @ingroup hooks

--- a/include/http_request.h
+++ b/include/http_request.h
@@ -366,7 +366,10 @@ AP_DECLARE_HOOK(int,create_request,(request_rec *r))
  * This hook allow modules an opportunity to translate the URI into an
  * actual filename, before URL decoding happens.
  * @param r The current request
- * @return OK, DECLINED, or HTTP_...
+ * @return DECLINED to let other modules handle the pre-translation,
+ *         OK if it was handled and no other module should process it,
+ *         DONE if no further transformation should happen on the URI,
+ *         HTTP_... in case of error.
  * @ingroup hooks
  */
 AP_DECLARE_HOOK(int,pre_translate_name,(request_rec *r))

--- a/include/http_request.h
+++ b/include/http_request.h
@@ -364,6 +364,16 @@ AP_DECLARE_HOOK(int,create_request,(request_rec *r))
 
 /**
  * This hook allow modules an opportunity to translate the URI into an
+ * actual filename, before URL decoding happens.
+ * rules will be followed.
+ * @param r The current request
+ * @return OK, DECLINED, or HTTP_...
+ * @ingroup hooks
+ */
+AP_DECLARE_HOOK(int,pre_translate_name,(request_rec *r))
+
+/**
+ * This hook allow modules an opportunity to translate the URI into an
  * actual filename.  If no modules do anything special, the server's default
  * rules will be followed.
  * @param r The current request

--- a/include/httpd.h
+++ b/include/httpd.h
@@ -1762,6 +1762,21 @@ AP_DECLARE(void) ap_no2slash(char *name);
  */
 AP_DECLARE(void) ap_no2slash_ex(char *name, int is_fs_path);
 
+#define AP_NORMALIZE_ALLOW_RELATIVE     (1u <<  0)
+#define AP_NORMALIZE_NOT_ABOVE_ROOT     (1u <<  1)
+#define AP_NORMALIZE_DECODE_UNRESERVED  (1u <<  2)
+#define AP_NORMALIZE_MERGE_SLASHES      (1u <<  3)
+#define AP_NORMALIZE_DROP_PARAMETERS    (1u <<  4)
+
+/**
+ * Remove all ////, /./ and /xx/../ substrings from a path, and more
+ * depending on passed in flags.
+ * @param path The path to normalize
+ * @param flags bitmask of AP_NORMALIZE_* flags
+ * @return non-zero on success
+ */
+AP_DECLARE(int) ap_normalize_path(char *path, unsigned int flags);
+
 /**
  * Remove all ./ and xx/../ substrings from a file name. Also remove
  * any leading ../ or /../ substrings.

--- a/modules/dav/main/util.c
+++ b/modules/dav/main/util.c
@@ -665,6 +665,7 @@ static dav_error * dav_process_if_header(request_rec *r, dav_if_header **p_ih)
 
             /* clean up the URI a bit */
             if (!ap_normalize_path(parsed_uri.path,
+                                   AP_NORMALIZE_NOT_ABOVE_ROOT |
                                    AP_NORMALIZE_DECODE_UNRESERVED)) {
                 return dav_new_error(r->pool, HTTP_BAD_REQUEST,
                                      DAV_ERR_IF_TAGGED, rv,

--- a/modules/dav/main/util.c
+++ b/modules/dav/main/util.c
@@ -664,7 +664,12 @@ static dav_error * dav_process_if_header(request_rec *r, dav_if_header **p_ih)
             /* note that parsed_uri.path is allocated; we can trash it */
 
             /* clean up the URI a bit */
-            ap_getparents(parsed_uri.path);
+            if (!ap_normalize_path(parsed_uri.path,
+                                   AP_NORMALIZE_DECODE_UNRESERVED)) {
+                return dav_new_error(r->pool, HTTP_BAD_REQUEST,
+                                     DAV_ERR_IF_TAGGED, rv,
+                                     "Invalid URI path tagged If-header.");
+            }
 
             /* the resources we will compare to have unencoded paths */
             if (ap_unescape_url(parsed_uri.path) != OK) {

--- a/modules/examples/mod_example_hooks.c
+++ b/modules/examples/mod_example_hooks.c
@@ -1175,6 +1175,22 @@ static int x_post_read_request(request_rec *r)
 
 /*
  * This routine gives our module an opportunity to translate the URI into an
+ * actual filename, before URL decoding happens.
+ *
+ * This is a RUN_FIRST hook.
+ */
+static int x_pre_translate_name(request_rec *r)
+{
+    /*
+     * We don't actually *do* anything here, except note the fact that we were
+     * called.
+     */
+    trace_request(r, "x_pre_translate_name()");
+    return DECLINED;
+}
+
+/*
+ * This routine gives our module an opportunity to translate the URI into an
  * actual filename.  If we don't do anything special, the server's default
  * rules (Alias directives and the like) will continue to be followed.
  *
@@ -1467,6 +1483,7 @@ static void x_register_hooks(apr_pool_t *p)
     ap_hook_log_transaction(x_log_transaction, NULL, NULL, APR_HOOK_MIDDLE);
     ap_hook_http_scheme(x_http_scheme, NULL, NULL, APR_HOOK_MIDDLE);
     ap_hook_default_port(x_default_port, NULL, NULL, APR_HOOK_MIDDLE);
+    ap_hook_pre_translate_name(x_pre_translate_name, NULL, NULL, APR_HOOK_MIDDLE);
     ap_hook_translate_name(x_translate_name, NULL, NULL, APR_HOOK_MIDDLE);
     ap_hook_map_to_storage(x_map_to_storage, NULL,NULL, APR_HOOK_MIDDLE);
     ap_hook_header_parser(x_header_parser, NULL, NULL, APR_HOOK_MIDDLE);

--- a/modules/generators/mod_autoindex.c
+++ b/modules/generators/mod_autoindex.c
@@ -1266,8 +1266,9 @@ static struct ent *make_parent_entry(apr_int32_t autoindex_opts,
     if (!(p->name = ap_make_full_path(r->pool, r->uri, "../"))) {
         return (NULL);
     }
-    ap_getparents(p->name);
-    if (!*p->name) {
+    if (!ap_normalize_path(p->name, AP_NORMALIZE_ALLOW_RELATIVE |
+                                    AP_NORMALIZE_NOT_ABOVE_ROOT)
+            || p->name[0] == '\0') {
         return (NULL);
     }
 

--- a/modules/generators/mod_info.c
+++ b/modules/generators/mod_info.c
@@ -322,6 +322,7 @@ static const hook_lookup_t request_hooks[] = {
     {"HTTP Scheme", ap_hook_get_http_scheme},
     {"Default Port", ap_hook_get_default_port},
     {"Quick Handler", ap_hook_get_quick_handler},
+    {"Pre-Translate Name", ap_hook_get_pre_translate_name},
     {"Translate Name", ap_hook_get_translate_name},
     {"Map to Storage", ap_hook_get_map_to_storage},
     {"Check Access", ap_hook_get_access_checker_ex},

--- a/modules/loggers/mod_log_debug.c
+++ b/modules/loggers/mod_log_debug.c
@@ -49,6 +49,7 @@ static const char * const hooks[] = {
     "check_authn",          /*  9 */
     "check_authz",          /* 10 */
     "insert_filter",        /* 11 */
+    "pre_translate_name",   /* 12 */
     NULL
 };
 
@@ -106,6 +107,12 @@ static int log_debug_quick_handler(request_rec *r, int lookup_uri)
 static int log_debug_handler(request_rec *r)
 {
     do_debug_log(r, hooks[2]);
+    return DECLINED;
+}
+
+static int log_debug_pre_translate_name(request_rec *r)
+{
+    do_debug_log(r, hooks[12]);
     return DECLINED;
 }
 
@@ -263,6 +270,7 @@ static void register_hooks(apr_pool_t *p)
     ap_hook_log_transaction(log_debug_log_transaction, NULL, NULL, APR_HOOK_FIRST);
     ap_hook_quick_handler(log_debug_quick_handler, NULL, NULL, APR_HOOK_FIRST);
     ap_hook_handler(log_debug_handler, NULL, NULL, APR_HOOK_FIRST);
+    ap_hook_pre_translate_name(log_debug_pre_translate_name, NULL, NULL, APR_HOOK_FIRST);
     ap_hook_translate_name(log_debug_translate_name, NULL, NULL, APR_HOOK_FIRST);
     ap_hook_map_to_storage(log_debug_map_to_storage, NULL, NULL, APR_HOOK_FIRST);
     ap_hook_fixups(log_debug_fixups, NULL, NULL, APR_HOOK_FIRST);

--- a/modules/proxy/mod_proxy.c
+++ b/modules/proxy/mod_proxy.c
@@ -922,12 +922,7 @@ PROXY_DECLARE(int) ap_proxy_trans_match(request_rec *r, struct proxy_alias *ent,
         }
     }
     else {
-        /* Ignore servlet mapping if r->uri was decoded already, or we
-         * might consider for instance that an original %3B is a delimiter
-         * for path parameters (which is not).
-         */
-        if (dconf->use_original_uri == 1
-                && (ent->flags & PROXYPASS_MAPPING_SERVLET)) {
+        if ((ent->flags & PROXYPASS_MAP_SERVLET) == PROXYPASS_MAP_SERVLET) {
             nocanon = 0; /* ignored since servlet's normalization applies */
             len = alias_match_servlet(r->pool, r->uri, fake);
         }
@@ -990,16 +985,17 @@ PROXY_DECLARE(int) ap_proxy_trans_match(request_rec *r, struct proxy_alias *ent,
 
 static int proxy_trans(request_rec *r, int pre_trans)
 {
-    int i;
+    int i, enc;
     struct proxy_alias *ent;
     proxy_dir_conf *dconf;
     proxy_server_conf *conf;
 
     if (r->proxyreq) {
         /* someone has already set up the proxy, it was possibly ourselves
-         * in proxy_detect
+         * in proxy_detect (DONE will prevent further decoding of r->uri,
+         * only if proxyreq is set before pre_trans already).
          */
-        return OK;
+        return pre_trans ? DONE : OK;
     }
 
     /* In early pre_trans hook, r->uri was not manipulated yet so we are
@@ -1008,11 +1004,17 @@ static int proxy_trans(request_rec *r, int pre_trans)
      */
 
     dconf = ap_get_module_config(r->per_dir_config, &proxy_module);
+    conf = (proxy_server_conf *) ap_get_module_config(r->server->module_config,
+                                                      &proxy_module);
 
-    /* Do the work from the hook corresponding to the ProxyUseOriginalURI
-     * configuration (off/default: translate hook, on: pre_translate hook).
+    /* Always and only do PROXY_MAP_ENCODED mapping in pre_trans, when
+     * r->uri is still encoded, or we might consider for instance that
+     * a decoded sub-delim is now a delimiter (e.g. "%3B" => ';' for
+     * path parameters), which it's not.
      */
-    if (pre_trans ^ (dconf->use_original_uri == 1)) {
+    if ((pre_trans && !conf->map_encoded_one)
+            || (!pre_trans && conf->map_encoded_all)) {
+        /* Fast path, nothing at this stage */
         return DECLINED;
     }
 
@@ -1027,20 +1029,21 @@ static int proxy_trans(request_rec *r, int pre_trans)
 
     /* short way - this location is reverse proxied? */
     if (dconf->alias) {
-        int rv = ap_proxy_trans_match(r, dconf->alias, dconf);
-        if (DONE != rv) {
-            return rv;
+        enc = (dconf->alias->flags & PROXYPASS_MAP_ENCODED) != 0;
+        if (!(pre_trans ^ enc)) {
+            int rv = ap_proxy_trans_match(r, dconf->alias, dconf);
+            if (DONE != rv) {
+                return rv;
+            }
         }
     }
 
-    conf = (proxy_server_conf *) ap_get_module_config(r->server->module_config,
-                                                      &proxy_module);
-
     /* long way - walk the list of aliases, find a match */
-    if (conf->aliases->nelts) {
-        ent = (struct proxy_alias *) conf->aliases->elts;
-        for (i = 0; i < conf->aliases->nelts; i++) {
-            int rv = ap_proxy_trans_match(r, &ent[i], dconf);
+    for (i = 0; i < conf->aliases->nelts; i++) {
+        ent = &((struct proxy_alias *)conf->aliases->elts)[i];
+        enc = (ent->flags & PROXYPASS_MAP_ENCODED) != 0;
+        if (!(pre_trans ^ enc)) {
+            int rv = ap_proxy_trans_match(r, ent, dconf);
             if (DONE != rv) {
                 return rv;
             }
@@ -1054,6 +1057,7 @@ static int proxy_pre_translate_name(request_rec *r)
 {
     return proxy_trans(r, 1);
 }
+
 static int proxy_translate_name(request_rec *r)
 {
     return proxy_trans(r, 0);
@@ -1579,6 +1583,8 @@ static void * create_proxy_config(apr_pool_t *p, server_rec *s)
     ps->forward = NULL;
     ps->reverse = NULL;
     ps->domain = NULL;
+    ps->map_encoded_one = 0;
+    ps->map_encoded_all = 1;
     ps->id = apr_psprintf(p, "p%x", 1); /* simply for storage size */
     ps->viaopt = via_off; /* initially backward compatible with 1.3.1 */
     ps->viaopt_set = 0; /* 0 means default */
@@ -1736,6 +1742,9 @@ static void * merge_proxy_config(apr_pool_t *p, void *basev, void *overridesv)
     ps->forward = overrides->forward ? overrides->forward : base->forward;
     ps->reverse = overrides->reverse ? overrides->reverse : base->reverse;
 
+    ps->map_encoded_one = overrides->map_encoded_one || base->map_encoded_one;
+    ps->map_encoded_all = overrides->map_encoded_all && base->map_encoded_all;
+
     ps->domain = (overrides->domain == NULL) ? base->domain : overrides->domain;
     ps->id = (overrides->id == NULL) ? base->id : overrides->id;
     ps->viaopt = (overrides->viaopt_set == 0) ? base->viaopt : overrides->viaopt;
@@ -1803,7 +1812,6 @@ static void *create_proxy_dir_config(apr_pool_t *p, char *dummy)
     new->add_forwarded_headers_set = 0;
     new->forward_100_continue = 1;
     new->forward_100_continue_set = 0;
-    new->use_original_uri = -1; /* unset (off by default) */
 
     return (void *) new;
 }
@@ -1861,10 +1869,6 @@ static void *merge_proxy_dir_config(apr_pool_t *p, void *basev, void *addv)
                                              : add->forward_100_continue;
     new->forward_100_continue_set = add->forward_100_continue_set
                                     || base->forward_100_continue_set;
-    
-    new->use_original_uri = (add->use_original_uri == -1)
-                                ? base->use_original_uri
-                                : add->use_original_uri;
 
     return new;
 }
@@ -2021,9 +2025,6 @@ static const char *
         else if (!strcasecmp(word,"noquery")) {
             flags |= PROXYPASS_NOQUERY;
         }
-        else if (!strcasecmp(word,"mapping=servlet")) {
-            flags |= PROXYPASS_MAPPING_SERVLET;
-        }
         else {
             char *val = strchr(word, '=');
             if (!val) {
@@ -2042,11 +2043,31 @@ static const char *
                            "in the form 'key=value'.";
                 }
             }
-            else
+            else {
                 *val++ = '\0';
-            apr_table_setn(params, word, val);
+            }
+            if (!strcasecmp(word, "mapping")) {
+                if (!strcasecmp(val, "encoded")) {
+                    flags |= PROXYPASS_MAP_ENCODED;
+                }
+                else if (!strcasecmp(val, "servlet")) {
+                    flags |= PROXYPASS_MAP_SERVLET;
+                }
+                else {
+                    return "unknown mapping";
+                }
+            }
+            else {
+                apr_table_setn(params, word, val);
+            }
         }
-    };
+    }
+    if (flags & PROXYPASS_MAP_ENCODED) {
+        conf->map_encoded_one = 1;
+    }
+    else {
+        conf->map_encoded_all = 0;
+    }
 
     if (r == NULL) {
         return "ProxyPass|ProxyPassMatch needs a path when not defined in a location";
@@ -3034,9 +3055,6 @@ static const command_rec proxy_cmds[] =
     AP_INIT_FLAG("Proxy100Continue", forward_100_continue, NULL, RSRC_CONF|ACCESS_CONF,
      "on if 100-Continue should be forwarded to the origin server, off if the "
      "proxy should handle it by itself"),
-    AP_INIT_FLAG("ProxyUseOriginalURI", ap_set_flag_slot_char,
-     (void*)APR_OFFSETOF(proxy_dir_conf, use_original_uri), RSRC_CONF|ACCESS_CONF,
-     "Whether to use the original/encoded URI-path for mapping"),
     {NULL}
 };
 

--- a/modules/proxy/mod_proxy.c
+++ b/modules/proxy/mod_proxy.c
@@ -17,6 +17,7 @@
 #include "mod_proxy.h"
 #include "mod_core.h"
 #include "apr_optional.h"
+#include "apr_strings.h"
 #include "scoreboard.h"
 #include "mod_status.h"
 #include "proxy_util.h"
@@ -564,10 +565,11 @@ static int alias_match(const char *uri, const char *alias_fakename)
  * Inspired by mod_jk's jk_servlet_normalize().
  */
 static int alias_match_servlet(apr_pool_t *p,
-                               const char *uri,
+                               const char **urip,
                                const char *alias)
 {
     char *map;
+    const char *uri = *urip;
     apr_array_header_t *stack;
     int map_pos, uri_pos, alias_pos, first_pos;
     int alias_depth = 0, depth;
@@ -749,6 +751,8 @@ static int alias_match_servlet(apr_pool_t *p,
     if (alias[alias_pos - 1] != '/' && uri[uri_pos - 1] == '/') {
         uri_pos--;
     }
+
+    *urip = map;
     return uri_pos;
 }
 
@@ -862,6 +866,7 @@ PROXY_DECLARE(int) ap_proxy_trans_match(request_rec *r, struct proxy_alias *ent,
     int mismatch = 0;
     unsigned int nocanon = ent->flags & PROXYPASS_NOCANON;
     const char *use_uri = nocanon ? r->unparsed_uri : r->uri;
+    const char *servlet_uri = NULL;
 
     if (dconf && (dconf->interpolate_env == 1) && (ent->flags & PROXYPASS_INTERPOLATE)) {
         fake = proxy_interpolate(r, ent->fake);
@@ -923,8 +928,9 @@ PROXY_DECLARE(int) ap_proxy_trans_match(request_rec *r, struct proxy_alias *ent,
     }
     else {
         if ((ent->flags & PROXYPASS_MAP_SERVLET) == PROXYPASS_MAP_SERVLET) {
+            servlet_uri = r->uri;
+            len = alias_match_servlet(r->pool, &servlet_uri, fake);
             nocanon = 0; /* ignored since servlet's normalization applies */
-            len = alias_match_servlet(r->pool, r->uri, fake);
         }
         else {
             len = alias_match(r->uri, fake);
@@ -959,7 +965,7 @@ PROXY_DECLARE(int) ap_proxy_trans_match(request_rec *r, struct proxy_alias *ent,
          */
         int rc = proxy_run_check_trans(r, found + 6);
         if (rc != OK && rc != DECLINED) {
-            return DONE;
+            return HTTP_CONTINUE;
         }
 
         r->filename = found;
@@ -973,14 +979,28 @@ PROXY_DECLARE(int) ap_proxy_trans_match(request_rec *r, struct proxy_alias *ent,
             apr_table_setn(r->notes, "proxy-noquery", "1");
         }
 
+        if (servlet_uri) {
+            ap_log_rerror(APLOG_MARK, APLOG_TRACE1, 0, r, APLOGNO(10248)
+                          "Servlet path '%s' (%s) matches proxy handler '%s'",
+                          r->uri, servlet_uri, found);
+            /* Apply servlet normalization to r->uri so that <Location> or any
+             * directory context match does not have to handle path parameters.
+             * We change r->uri in-place so that r->parsed_uri.path is updated
+             * too. Since normalized servlet_uri is necessarily shorter than
+             * the original r->uri, strcpy() is fine.
+             */
+            AP_DEBUG_ASSERT(strlen(r->uri) >= strlen(servlet_uri));
+            strcpy(r->uri, servlet_uri);
+            return DONE;
+        }
+
         ap_log_rerror(APLOG_MARK, APLOG_TRACE1, 0, r, APLOGNO(03464)
                       "URI path '%s' matches proxy handler '%s'", r->uri,
                       found);
-
         return OK;
     }
 
-    return DONE;
+    return HTTP_CONTINUE;
 }
 
 static int proxy_trans(request_rec *r, int pre_trans)
@@ -1032,7 +1052,7 @@ static int proxy_trans(request_rec *r, int pre_trans)
         enc = (dconf->alias->flags & PROXYPASS_MAP_ENCODED) != 0;
         if (!(pre_trans ^ enc)) {
             int rv = ap_proxy_trans_match(r, dconf->alias, dconf);
-            if (DONE != rv) {
+            if (rv != HTTP_CONTINUE) {
                 return rv;
             }
         }
@@ -1044,7 +1064,7 @@ static int proxy_trans(request_rec *r, int pre_trans)
         enc = (ent->flags & PROXYPASS_MAP_ENCODED) != 0;
         if (!(pre_trans ^ enc)) {
             int rv = ap_proxy_trans_match(r, ent, dconf);
-            if (DONE != rv) {
+            if (rv != HTTP_CONTINUE) {
                 return rv;
             }
         }

--- a/modules/proxy/mod_proxy.h
+++ b/modules/proxy/mod_proxy.h
@@ -124,6 +124,7 @@ struct proxy_remote {
 #define PROXYPASS_NOCANON 0x01
 #define PROXYPASS_INTERPOLATE 0x02
 #define PROXYPASS_NOQUERY 0x04
+#define PROXYPASS_MAPPING_SERVLET 0x08
 struct proxy_alias {
     const char  *real;
     const char  *fake;
@@ -244,6 +245,9 @@ typedef struct {
     unsigned int forward_100_continue_set:1;
 
     apr_array_header_t *error_override_codes;
+
+    /** Whether to use original/encoded URI-path or not (default) */
+    signed char use_original_uri;
 } proxy_dir_conf;
 
 /* if we interpolate env vars per-request, we'll need a per-request

--- a/modules/proxy/mod_proxy.h
+++ b/modules/proxy/mod_proxy.h
@@ -1175,7 +1175,11 @@ PROXY_DECLARE(apr_status_t) ap_proxy_sync_balancer(proxy_balancer *b,
  * @param r     request
  * @param ent   proxy_alias record
  * @param dconf per-dir config or NULL
- * @return      DECLINED, DONE or OK if matched
+ * @return      OK if the alias matched,
+ *              DONE if the alias matched and r->uri was normalized so
+ *                   no further transformation should happen on it,
+ *              DECLINED if proxying is disabled for this alias,
+ *              HTTP_CONTINUE if the alias did not match
  */
 PROXY_DECLARE(int) ap_proxy_trans_match(request_rec *r,
                                         struct proxy_alias *ent,

--- a/modules/proxy/mod_proxy.h
+++ b/modules/proxy/mod_proxy.h
@@ -124,7 +124,8 @@ struct proxy_remote {
 #define PROXYPASS_NOCANON 0x01
 #define PROXYPASS_INTERPOLATE 0x02
 #define PROXYPASS_NOQUERY 0x04
-#define PROXYPASS_MAPPING_SERVLET 0x08
+#define PROXYPASS_MAP_ENCODED 0x08
+#define PROXYPASS_MAP_SERVLET 0x18 /* + MAP_ENCODED */
 struct proxy_alias {
     const char  *real;
     const char  *fake;
@@ -201,6 +202,8 @@ typedef struct {
     unsigned int inherit_set:1;
     unsigned int ppinherit:1;
     unsigned int ppinherit_set:1;
+    unsigned int map_encoded_one:1;
+    unsigned int map_encoded_all:1;
 } proxy_server_conf;
 
 typedef struct {
@@ -245,9 +248,6 @@ typedef struct {
     unsigned int forward_100_continue_set:1;
 
     apr_array_header_t *error_override_codes;
-
-    /** Whether to use original/encoded URI-path or not (default) */
-    signed char use_original_uri;
 } proxy_dir_conf;
 
 /* if we interpolate env vars per-request, we'll need a per-request

--- a/server/request.c
+++ b/server/request.c
@@ -192,14 +192,15 @@ AP_DECLARE(int) ap_process_request_internal(request_rec *r)
     int file_req = (r->main && r->filename);
     core_server_config *sconf =
         ap_get_core_module_config(r->server->module_config);
-    unsigned int normalize_flags = 0;
+    unsigned int normalize_flags;
 
+    normalize_flags = AP_NORMALIZE_NOT_ABOVE_ROOT;
+    if (sconf->merge_slashes != AP_CORE_CONFIG_OFF) { 
+        normalize_flags |= AP_NORMALIZE_MERGE_SLASHES;
+    }
     if (file_req) {
         /* File subrequests can have a relative path. */
         normalize_flags |= AP_NORMALIZE_ALLOW_RELATIVE;
-    }
-    if (sconf->merge_slashes != AP_CORE_CONFIG_OFF) { 
-        normalize_flags |= AP_NORMALIZE_MERGE_SLASHES;
     }
 
     if (r->parsed_uri.path) {

--- a/server/request.c
+++ b/server/request.c
@@ -59,6 +59,7 @@
 #define APLOG_MODULE_INDEX AP_CORE_MODULE_INDEX
 
 APR_HOOK_STRUCT(
+    APR_HOOK_LINK(pre_translate_name)
     APR_HOOK_LINK(translate_name)
     APR_HOOK_LINK(map_to_storage)
     APR_HOOK_LINK(check_user_id)
@@ -74,6 +75,8 @@ APR_HOOK_STRUCT(
     APR_HOOK_LINK(force_authn)
 )
 
+AP_IMPLEMENT_HOOK_RUN_FIRST(int,pre_translate_name,
+                            (request_rec *r), (r), DECLINED)
 AP_IMPLEMENT_HOOK_RUN_FIRST(int,translate_name,
                             (request_rec *r), (r), DECLINED)
 AP_IMPLEMENT_HOOK_RUN_FIRST(int,map_to_storage,

--- a/server/request.c
+++ b/server/request.c
@@ -163,6 +163,7 @@ AP_DECLARE(int) ap_some_authn_required(request_rec *r)
 static int walk_location_and_if(request_rec *r)
 {
     int access_status;
+    core_dir_config *d;
 
     if ((access_status = ap_location_walk(r))) {
         return access_status;
@@ -171,12 +172,9 @@ static int walk_location_and_if(request_rec *r)
         return access_status;
     }
 
-    /* Don't set per-dir loglevel if LogLevelOverride is set */
-    if (!r->connection->log) {
-        core_dir_config *d = ap_get_core_module_config(r->per_dir_config);
-        if (d->log)
-            r->log = d->log;
-    }
+    d = ap_get_core_module_config(r->per_dir_config);
+    if (d->log)
+        r->log = d->log;
 
     return OK;
 }

--- a/server/util.c
+++ b/server/util.c
@@ -606,70 +606,9 @@ AP_DECLARE(int) ap_normalize_path(char *path, unsigned int flags)
  */
 AP_DECLARE(void) ap_getparents(char *name)
 {
-    char *next;
-    int l, w, first_dot;
-
-    /* Four paseses, as per RFC 1808 */
-    /* a) remove ./ path segments */
-    for (next = name; *next && (*next != '.'); next++) {
-    }
-
-    l = w = first_dot = next - name;
-    while (name[l] != '\0') {
-        if (name[l] == '.' && IS_SLASH(name[l + 1])
-            && (l == 0 || IS_SLASH(name[l - 1])))
-            l += 2;
-        else
-            name[w++] = name[l++];
-    }
-
-    /* b) remove trailing . path, segment */
-    if (w == 1 && name[0] == '.')
-        w--;
-    else if (w > 1 && name[w - 1] == '.' && IS_SLASH(name[w - 2]))
-        w--;
-    name[w] = '\0';
-
-    /* c) remove all xx/../ segments. (including leading ../ and /../) */
-    l = first_dot;
-
-    while (name[l] != '\0') {
-        if (name[l] == '.' && name[l + 1] == '.' && IS_SLASH(name[l + 2])
-            && (l == 0 || IS_SLASH(name[l - 1]))) {
-            int m = l + 3, n;
-
-            l = l - 2;
-            if (l >= 0) {
-                while (l >= 0 && !IS_SLASH(name[l]))
-                    l--;
-                l++;
-            }
-            else
-                l = 0;
-            n = l;
-            while ((name[n] = name[m]))
-                (++n, ++m);
-        }
-        else
-            ++l;
-    }
-
-    /* d) remove trailing xx/.. segment. */
-    if (l == 2 && name[0] == '.' && name[1] == '.')
-        name[0] = '\0';
-    else if (l > 2 && name[l - 1] == '.' && name[l - 2] == '.'
-             && IS_SLASH(name[l - 3])) {
-        l = l - 4;
-        if (l >= 0) {
-            while (l >= 0 && !IS_SLASH(name[l]))
-                l--;
-            l++;
-        }
-        else
-            l = 0;
-        name[l] = '\0';
-    }
+    (void)ap_normalize_path(name, AP_NORMALIZE_ALLOW_RELATIVE);
 }
+
 AP_DECLARE(void) ap_no2slash_ex(char *name, int is_fs_path)
 {
 

--- a/server/util.c
+++ b/server/util.c
@@ -606,7 +606,10 @@ AP_DECLARE(int) ap_normalize_path(char *path, unsigned int flags)
  */
 AP_DECLARE(void) ap_getparents(char *name)
 {
-    (void)ap_normalize_path(name, AP_NORMALIZE_ALLOW_RELATIVE);
+    if (!ap_normalize_path(name, AP_NORMALIZE_NOT_ABOVE_ROOT |
+                                 AP_NORMALIZE_ALLOW_RELATIVE)) {
+        name[0] = '\0';
+    }
 }
 
 AP_DECLARE(void) ap_no2slash_ex(char *name, int is_fs_path)


### PR DESCRIPTION
back port list:

    r1879074 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879074)
    r1879075 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879075)
    r1879076 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879076)
    r1879077 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879077)
    r1879078 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879078)
    r1879079 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879079)
    r1879080 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879080)
    r1879094 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879094)
    r1879095 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879095)
    r1879110 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879110)
    r1879111 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879111)
    r1879112 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879112)
    r1879114 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879114)
    r1879116 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879116)
    r1879117 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879117)
    r1879137 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879137)
    r1879144 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879144)
    r1879145 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879145)
    r1879147 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879147)
    r1879149 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879149)
    r1879235 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879235)
    r1879360 (https://svn.apache.org/repos/asf/httpd/httpd/trunk@1879360)
