### PR TITLE
Add child_stopping hook to core

### DIFF
--- a/changes-entries/core_child_stopping.txt
+++ b/changes-entries/core_child_stopping.txt
@@ -1,0 +1,4 @@
+  * core/mpm: add hook 'child_stopping` that gets called when the MPM is
+    stopping a child process. The additional `graceful` parameter allows
+    registered hooks to free resources early during a graceful shutdown.
+    [Yann Ylavic, Stefan Eissing]

--- a/include/ap_mmn.h
+++ b/include/ap_mmn.h
@@ -673,12 +673,13 @@
  *                         ap_proxy_tunnel_conn_get_transferred() change
  *                         ap_proxy_transfer_between_connections() sent to apr_off_t *.
  * 20210531.0 (2.5.1-dev)  add conn_rec->outgoing and ap_ssl_bind_outgoing()
+ * 20210629.0 (2.5.1-dev)  new hook "child_stopping" in mpm_common.c/ap_mpm.h.
  */
 
 #define MODULE_MAGIC_COOKIE 0x41503235UL /* "AP25" */
 
 #ifndef MODULE_MAGIC_NUMBER_MAJOR
-#define MODULE_MAGIC_NUMBER_MAJOR 20210531
+#define MODULE_MAGIC_NUMBER_MAJOR 20210629
 #endif
 #define MODULE_MAGIC_NUMBER_MINOR 0             /* 0...n */
 

--- a/include/mpm_common.h
+++ b/include/mpm_common.h
@@ -511,6 +511,15 @@ AP_DECLARE_HOOK(void, suspend_connection,
 AP_DECLARE_HOOK(void, resume_connection,
                 (conn_rec *c, request_rec *r))
 
+/**
+ * Notification that the child is stopping. If graceful, ongoing
+ * requests will be served.
+ * @param pchild The child pool
+ * @param graceful != 0 iff this is a graceful shutdown.
+ */
+AP_DECLARE_HOOK(void, child_stopping,
+                (apr_pool_t *pchild, int graceful))
+
 /* mutex type string for accept mutex, if any; MPMs should use the
  * same mutex type for ease of configuration
  */

--- a/server/mpm/event/event.c
+++ b/server/mpm/event/event.c
@@ -654,6 +654,8 @@ static void signal_threads(int mode)
         ap_queue_interrupt_all(worker_queue);
         close_worker_sockets(); /* forcefully kill all current connections */
     }
+
+    ap_run_child_stopping(pchild, mode == ST_GRACEFUL);
 }
 
 static int event_query(int query_code, int *result, apr_status_t *rv)
@@ -753,6 +755,10 @@ static void clean_child_exit(int code) __attribute__ ((noreturn));
 static void clean_child_exit(int code)
 {
     retained->mpm->mpm_state = AP_MPMQ_STOPPING;
+    if (terminate_mode == ST_INIT) {
+        ap_run_child_stopping(pchild, 0);
+    }
+
     if (pchild) {
         apr_pool_destroy(pchild);
     }

--- a/server/mpm/prefork/prefork.c
+++ b/server/mpm/prefork/prefork.c
@@ -219,10 +219,13 @@ static void prefork_note_child_started(int slot, pid_t pid)
 static void clean_child_exit(int code) __attribute__ ((noreturn));
 static void clean_child_exit(int code)
 {
-    retained->mpm->mpm_state = AP_MPMQ_STOPPING;
-
     apr_signal(SIGHUP, SIG_IGN);
     apr_signal(SIGTERM, SIG_IGN);
+
+    retained->mpm->mpm_state = AP_MPMQ_STOPPING;
+    if (code == 0) {
+        ap_run_child_stopping(pchild, 0);
+    }
 
     if (pchild) {
         apr_pool_destroy(pchild);

--- a/server/mpm/worker/worker.c
+++ b/server/mpm/worker/worker.c
@@ -325,6 +325,8 @@ static void signal_threads(int mode)
         ap_queue_interrupt_all(worker_queue);
         close_worker_sockets(); /* forcefully kill all current connections */
     }
+
+    ap_run_child_stopping(pchild, mode == ST_GRACEFUL);
 }
 
 static int worker_query(int query_code, int *result, apr_status_t *rv)
@@ -433,6 +435,10 @@ static void clean_child_exit(int code) __attribute__ ((noreturn));
 static void clean_child_exit(int code)
 {
     retained->mpm->mpm_state = AP_MPMQ_STOPPING;
+    if (terminate_mode == ST_INIT) {
+        ap_run_child_stopping(pchild, 0);
+    }
+
     if (pchild) {
         apr_pool_destroy(pchild);
     }

--- a/server/mpm_common.c
+++ b/server/mpm_common.c
@@ -77,7 +77,8 @@
     APR_HOOK_LINK(output_pending) \
     APR_HOOK_LINK(input_pending) \
     APR_HOOK_LINK(suspend_connection) \
-    APR_HOOK_LINK(resume_connection)
+    APR_HOOK_LINK(resume_connection) \
+    APR_HOOK_LINK(child_stopping)
 
 #if AP_ENABLE_EXCEPTION_HOOK
 APR_HOOK_STRUCT(
@@ -136,6 +137,9 @@ AP_IMPLEMENT_HOOK_VOID(suspend_connection,
 AP_IMPLEMENT_HOOK_VOID(resume_connection,
                        (conn_rec *c, request_rec *r),
                        (c, r))
+AP_IMPLEMENT_HOOK_VOID(child_stopping,
+                       (apr_pool_t *pchild, int graceful),
+                       (pchild, graceful))
 
 /* hooks with no args are implemented last, after disabling APR hook probes */
 #if defined(APR_HOOK_PROBES_ENABLED)


### PR DESCRIPTION
  * core/mpm: add hook 'child_stopping` that gets called when the MPM is
    stopping a child process. The additional `graceful` parameter allows
    registered hooks to free resources early during a graceful shutdown.