### PR TITLE
Fix http to https redirect

### DIFF
--- a/modules/ssl/ssl_engine_init.c
+++ b/modules/ssl/ssl_engine_init.c
@@ -708,8 +708,8 @@ static apr_status_t ssl_init_ctx_protocol(server_rec *s,
     }
     else if (protocol == SSL_PROTOCOL_TLSV1_2) {
         method = mctx->pkp ?
-            TLSv1_2_client_method() : /* proxy */
-            TLSv1_2_server_method();  /* server */
+            SSLv23_client_method() : /* proxy */
+            SSLv23_server_method();  /* server */
     }
 #if SSL_HAVE_PROTOCOL_TLSV1_3
     else if (protocol == SSL_PROTOCOL_TLSV1_3) {


### PR DESCRIPTION
I use
ErrorDocument 400 "https://myserver:215"
to achieve redirection to secure connection for anyone who would access my
server with just 'http://myserver:215'. (the port number is arbitrary, bears no meaning)

This works as long as there's
SSLProtocol TLSv1.1 +TLSv1.2
specified in the configuration. However when I change that to just
SSLProtocol TLSv1.2
it stops working and the client gets "The connection was reset
The connection to the server was reset while the page was loading."
in their browser (I use Firefox).

I guess this is because Apache calls different OpenSSL functions based on
the config setting at
https://github.com/apache/httpd/blob/2f0f0d4e31bcf8b151ebc833ddd56c09dbff6462/modules/ssl/ssl_engine_init.c#L643
or
https://github.com/apache/httpd/blob/2f0f0d4e31bcf8b151ebc833ddd56c09dbff6462/modules/ssl/ssl_engine_init.c#L649

The OpenSSL 1.0 manpage (https://docs.oracle.com/cd/E88353_01/html/E37845/ssl-ctx-new-3openssl.html) says the general purpose SSLv23_method(), SSLv23_server_method(), SSLv23_client_method() should be used by most applications and to avoid the version specific methods (TLSv1_2_method(), TLSv1_2_server_method(), TLSv1_2_client_method(), ...).
This gets complicated with OpenSSL 1.1/3.0 (https://www.openssl.org/docs/manmaster/man3/TLSv1_2_client_method.html) where the functions are renamed to TLS_method(), ..., but there the problem doesn't exist. I've tried to rebuild Apache with OpenSSL 3.0 beta1 and the redirect works there just fine. It looks like this part has been unified for all protocols there.

Replacing the TLSv1_2 function calls with the generic ones in this pull request works for me, but I am not well versed in Apache or OpenSSL inner workings to guarantee there's no side effect, so beware.


This is on Solaris 11.4, x86, Apache 2.4.47, OpenSSL 1.0.2y

This has been discussed at the user mailing list at 
https://mail-archives.apache.org/mod_mbox/httpd-users/202106.mbox/%3CCAMeYnzEhcvEYGy-QpAn52nmWpB3azcNd%2BuEgQrZeWfYLWrDQYg%40mail.gmail.com%3E

My simplified config is below:

ServerRoot "/usr/apache2/2.4"

Listen 215

<IfDefine prefork>
LoadModule mpm_prefork_module libexec/mod_mpm_prefork.so
</IfDefine>
<IfDefine worker>
LoadModule mpm_worker_module libexec/mod_mpm_worker.so
</IfDefine>
<IfDefine !prefork>
<IfDefine !worker>
LoadModule mpm_event_module libexec/mod_mpm_event.so
</IfDefine>
</IfDefine>

LoadModule ssl_module libexec/mod_ssl.so
LoadModule authz_core_module libexec/mod_authz_core.so
LoadModule unixd_module libexec/mod_unixd.so

<IfModule unixd_module>
User webservd
Group webservd

</IfModule>


ServerName 127.0.0.1

<Directory />
    AllowOverride none
    Require all denied
</Directory>

DocumentRoot "/var/apache2/2.4/htdocs"
<Directory "/var/apache2/2.4/htdocs">
    Options Indexes FollowSymLinks

    AllowOverride None

    Require all granted
</Directory>

<Files ".ht*">
    Require all denied
</Files>

ErrorLog "/var/apache2/2.4/logs/error_log"

LogLevel warn

<Directory "/var/apache2/2.4/cgi-bin">
    AllowOverride None
    Options None
    Require all granted
</Directory>

<IfModule ssl_module>
SSLRandomSeed startup builtin
SSLRandomSeed connect builtin
</IfModule>

SSLEngine               on
SSLProtocol TLSv1.1 +TLSv1.2
SSLCertificateFile /etc/certs/localhost/host.crt
SSLCertificateKeyFile /etc/certs/localhost/host.key
SSLCACertificateFile /etc/certs/localhost/host-ca/hostca.crt
SSLCertificateChainFile /etc/certs/localhost/host-ca/hostca.crt
ErrorDocument 400 "https://myserver:215"
