### PR TITLE
Icing/child stopping

### DIFF
--- a/changes-entries/core_child_stopping.txt
+++ b/changes-entries/core_child_stopping.txt
@@ -1,0 +1,4 @@
+  * core/mpm: add hook 'child_stopping` that gets called when the MPM is
+    stopping a child process. The additional `graceful` parameter allows
+    registered hooks to free resources early during a graceful shutdown.
+    [Yann Ylavic, Stefan Eissing]

--- a/include/ap_mmn.h
+++ b/include/ap_mmn.h
@@ -563,6 +563,8 @@
  * 20120211.107 (2.4.49-dev) Add ap_parse_request_line() and
  *                           ap_check_request_header()
  * 20120211.108 (2.4.49-dev) Add ajp_handle_cping_cpong
+ * 20120211.109 (2.4.49-dev) Add hook child_stopping to get informed that a child
+ *                           is being shut down.
  */
 
 #define MODULE_MAGIC_COOKIE 0x41503234UL /* "AP24" */
@@ -570,7 +572,7 @@
 #ifndef MODULE_MAGIC_NUMBER_MAJOR
 #define MODULE_MAGIC_NUMBER_MAJOR 20120211
 #endif
-#define MODULE_MAGIC_NUMBER_MINOR 108                 /* 0...n */
+#define MODULE_MAGIC_NUMBER_MINOR 109                 /* 0...n */
 
 /**
  * Determine if the server's current MODULE_MAGIC_NUMBER is at least a

--- a/include/mpm_common.h
+++ b/include/mpm_common.h
@@ -452,6 +452,15 @@ AP_DECLARE_HOOK(void, suspend_connection,
 AP_DECLARE_HOOK(void, resume_connection,
                 (conn_rec *c, request_rec *r))
 
+/**
+ * Notification that the child is stopping. If graceful, ongoing
+ * requests will be served.
+ * @param pchild The child pool
+ * @param graceful != 0 iff this is a graceful shutdown.
+ */
+AP_DECLARE_HOOK(void, child_stopping,
+                (apr_pool_t *pchild, int graceful))
+
 /* mutex type string for accept mutex, if any; MPMs should use the
  * same mutex type for ease of configuration
  */

--- a/server/mpm/event/event.c
+++ b/server/mpm/event/event.c
@@ -625,6 +625,8 @@ static void signal_threads(int mode)
         ap_queue_interrupt_all(worker_queue);
         close_worker_sockets(); /* forcefully kill all current connections */
     }
+
+    ap_run_child_stopping(pchild, mode == ST_GRACEFUL);
 }
 
 static int event_query(int query_code, int *result, apr_status_t *rv)
@@ -715,6 +717,10 @@ static void clean_child_exit(int code) __attribute__ ((noreturn));
 static void clean_child_exit(int code)
 {
     retained->mpm->mpm_state = AP_MPMQ_STOPPING;
+    if (terminate_mode == ST_INIT) {
+        ap_run_child_stopping(pchild, 0);
+    }
+
     if (pchild) {
         apr_pool_destroy(pchild);
     }

--- a/server/mpm/prefork/prefork.c
+++ b/server/mpm/prefork/prefork.c
@@ -218,10 +218,13 @@ static void prefork_note_child_started(int slot, pid_t pid)
 static void clean_child_exit(int code) __attribute__ ((noreturn));
 static void clean_child_exit(int code)
 {
-    retained->mpm->mpm_state = AP_MPMQ_STOPPING;
-
     apr_signal(SIGHUP, SIG_IGN);
     apr_signal(SIGTERM, SIG_IGN);
+
+    retained->mpm->mpm_state = AP_MPMQ_STOPPING;
+    if (code == 0) {
+        ap_run_child_stopping(pchild, 0);
+    }
 
     if (pchild) {
         apr_pool_destroy(pchild);

--- a/server/mpm/prefork/prefork.c
+++ b/server/mpm/prefork/prefork.c
@@ -218,10 +218,11 @@ static void prefork_note_child_started(int slot, pid_t pid)
 static void clean_child_exit(int code) __attribute__ ((noreturn));
 static void clean_child_exit(int code)
 {
+    retained->mpm->mpm_state = AP_MPMQ_STOPPING;
+
     apr_signal(SIGHUP, SIG_IGN);
     apr_signal(SIGTERM, SIG_IGN);
 
-    retained->mpm->mpm_state = AP_MPMQ_STOPPING;
     if (code == 0) {
         ap_run_child_stopping(pchild, 0);
     }

--- a/server/mpm/worker/worker.c
+++ b/server/mpm/worker/worker.c
@@ -324,6 +324,8 @@ static void signal_threads(int mode)
         ap_queue_interrupt_all(worker_queue);
         close_worker_sockets(); /* forcefully kill all current connections */
     }
+
+    ap_run_child_stopping(pchild, mode == ST_GRACEFUL);
 }
 
 static int worker_query(int query_code, int *result, apr_status_t *rv)
@@ -432,6 +434,10 @@ static void clean_child_exit(int code) __attribute__ ((noreturn));
 static void clean_child_exit(int code)
 {
     retained->mpm->mpm_state = AP_MPMQ_STOPPING;
+    if (terminate_mode == ST_INIT) {
+        ap_run_child_stopping(pchild, 0);
+    }
+
     if (pchild) {
         apr_pool_destroy(pchild);
     }

--- a/server/mpm_common.c
+++ b/server/mpm_common.c
@@ -72,7 +72,8 @@
     APR_HOOK_LINK(end_generation) \
     APR_HOOK_LINK(child_status) \
     APR_HOOK_LINK(suspend_connection) \
-    APR_HOOK_LINK(resume_connection)
+    APR_HOOK_LINK(resume_connection) \
+    APR_HOOK_LINK(child_stopping)
 
 #if AP_ENABLE_EXCEPTION_HOOK
 APR_HOOK_STRUCT(
@@ -112,6 +113,9 @@ AP_IMPLEMENT_HOOK_VOID(suspend_connection,
 AP_IMPLEMENT_HOOK_VOID(resume_connection,
                        (conn_rec *c, request_rec *r),
                        (c, r))
+AP_IMPLEMENT_HOOK_VOID(child_stopping,
+                       (apr_pool_t *pchild, int graceful),
+                       (pchild, graceful))
 
 /* hooks with no args are implemented last, after disabling APR hook probes */
 #if defined(APR_HOOK_PROBES_ENABLED)


### PR DESCRIPTION
  * core/mpm: add hook 'child_stopping` that gets called when the MPM is
    stopping a child process. The additional `graceful` parameter allows
    registered hooks to free resources early during a graceful shutdown.
    [Yann Ylavic, Stefan Eissing]
