### PR TITLE
Fix a small error due to the unreleased lock before program exit.

### DIFF
--- a/test/time-sem.c
+++ b/test/time-sem.c
@@ -548,6 +548,7 @@ void main (int argc, char **argv)
             exit (0);
         } else if (pid == -1) {
             perror ("fork");
+            accept_mutex_off ();
             exit (1);
         }
     }
@@ -555,6 +556,7 @@ void main (int argc, char **argv)
     /* a quick test to see that nothing is screwed up */
     if (*shared_counter != 0) {
         puts ("WTF! shared_counter != 0 before the children have been started!");
+        accept_mutex_off ();
         exit (1);
     }
 


### PR DESCRIPTION
Around the fixed codes, when `pid == 0`, there is the  accept_mutex_off(). However, other places are not. We would like to fix a small error due to the unreleased lock before the program exits in the left place.

It is a small, harmless error since the program exits and all of the program resources will be cleaned up by some common OS. However, other OS systems (e.g., embedded systems) do not automatically free some resources at the exit. It is a good manner for resource management. Adding the unlock statement adds symmetry, so the code looks better. Also, the debugger would not warn this case : )