### PR TITLE
Fix minor time-of-check/time-of-use 'bugs'

### DIFF
--- a/modules/http2/h2_from_h1.c
+++ b/modules/http2/h2_from_h1.c
@@ -232,7 +232,7 @@ static h2_headers *create_response(h2_task *task, request_rec *r)
     if (r->proxyreq != PROXYREQ_RESPONSE
             || !apr_table_get(r->headers_out, "Date")) {
         char *date = apr_palloc(r->pool, APR_RFC822_DATE_LEN);
-        ap_recent_rfc822_date(date, r? r->request_time : apr_time_now());
+        ap_recent_rfc822_date(date, r->request_time);
         apr_table_setn(r->headers_out, "Date", date );
     }
     if (r->proxyreq != PROXYREQ_RESPONSE) {

--- a/modules/md/md_acme.c
+++ b/modules/md/md_acme.c
@@ -388,10 +388,10 @@ static apr_status_t md_acme_req_send(md_acme_req_t *req)
     
     if (req->req_json) {
         body = apr_pcalloc(req->p, sizeof(*body));
-        body->data = md_json_writep(req->req_json, req->p, MD_JSON_FMT_INDENT);
         if (!body) {
             rv = APR_EINVAL; goto leave;
         }
+        body->data = md_json_writep(req->req_json, req->p, MD_JSON_FMT_INDENT);
         body->len = strlen(body->data);
     }
 


### PR DESCRIPTION
Hi,

This PR will fix two minor instances of "time-of-check vs time-of-use"-problems.

The problems are found with a tool detecting when pointers are checked against NULL after they have been dereferenced.

There are two instances found in this project:

---

### 1) [modules/http2/h2_from_h1.c](https://github.com/apache/httpd/blob/trunk/modules/http2/h2_from_h1.c#L232)

Problem:  pointer 'r' is checked against NULL (@ line 235: 'r ? r->request_time : apr_time_now()'), but has already been dereferenced
Suggestion: remove conditional as 'r' cannot be NULL here. Line 235 then becomes:

```C
235         ap_recent_rfc822_date(date, r->request_time);
```

.... in 

```C
232    if (r->proxyreq != PROXYREQ_RESPONSE
233            || !apr_table_get(r->headers_out, "Date")) {
234        char *date = apr_palloc(r->pool, APR_RFC822_DATE_LEN);
235        ap_recent_rfc822_date(date, r? r->request_time : apr_time_now()); // r cannot be NULL here, otherwise r->... at line 232 would have SEGFAULTed
236        apr_table_setn(r->headers_out, "Date", date );
237    }
```

---

### 2) [modules/md/md_acme.c](https://github.com/apache/httpd/blob/trunk/modules/md/md_acme.c#L391)

Problem:  pointer 'body' is checked against NULL (@ line 392: `if(!body)`), but has already been dereferenced at line 391 (`body->data = ...`)
Suggestion: move check before dereference. So this code :

```C
389    if (req->req_json) {
390        body = apr_pcalloc(req->p, sizeof(*body));
391        body->data = md_json_writep(req->req_json, req->p, MD_JSON_FMT_INDENT);
392        if (!body) { // <-- checks 'body' against NULL, but 'body' was already dereferenced above
393            rv = APR_EINVAL; goto leave;
394        }
395        body->len = strlen(body->data);
396    }
```

... becomes something like this:

```C
389    if (req->req_json) {
390        body = apr_pcalloc(req->p, sizeof(*body));
391        if (!body) { // <-- check 'body' against NULL before it is dereferenced
392            rv = APR_EINVAL; goto leave;
393        }
394        body->data = md_json_writep(req->req_json, req->p, MD_JSON_FMT_INDENT);
395        body->len = strlen(body->data);
396    }
```