### PR TITLE
  * mod_http2: synchronizes sources with trunk

### DIFF
--- a/modules/http2/h2_alt_svc.c
+++ b/modules/http2/h2_alt_svc.c
@@ -47,14 +47,14 @@ h2_alt_svc *h2_alt_svc_parse(const char *s, apr_pool_t *pool)
 {
     const char *sep = ap_strchr_c(s, '=');
     if (sep) {
-        const char *alpn = apr_pstrmemdup(pool, s, sep - s);
+        const char *alpn = apr_pstrmemdup(pool, s, (apr_size_t)(sep - s));
         const char *host = NULL;
         int port = 0;
         s = sep + 1;
         sep = ap_strchr_c(s, ':');  /* mandatory : */
         if (sep) {
             if (sep != s) {    /* optional host */
-                host = apr_pstrmemdup(pool, s, sep - s);
+                host = apr_pstrmemdup(pool, s, (apr_size_t)(sep - s));
             }
             s = sep + 1;
             if (*s) {          /* must be a port number */

--- a/modules/http2/h2_bucket_eos.c
+++ b/modules/http2/h2_bucket_eos.c
@@ -13,22 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
-/* Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 #include <assert.h>
 #include <stddef.h>

--- a/modules/http2/h2_config.c
+++ b/modules/http2/h2_config.c
@@ -542,7 +542,7 @@ const struct h2_priority *h2_cconfig_get_priority(conn_rec *c, const char *conte
 {
     const h2_config *conf = h2_config_get(c);
     if (content_type && conf->priorities) {
-        size_t len = strcspn(content_type, "; \t");
+        apr_ssize_t len = (apr_ssize_t)strcspn(content_type, "; \t");
         h2_priority *prio = apr_hash_get(conf->priorities, content_type, len);
         return prio? prio : apr_hash_get(conf->priorities, "*", 1);
     }
@@ -711,7 +711,8 @@ static const char *h2_conf_add_push_priority(cmd_parms *cmd, void *_cfg,
     h2_dependency dependency;
     h2_priority *priority;
     int weight;
-    
+ 
+    (void)_cfg;
     if (!*ctype) {
         return "1st argument must be a mime-type, like 'text/css' or '*'";
     }
@@ -730,7 +731,7 @@ static const char *h2_conf_add_push_priority(cmd_parms *cmd, void *_cfg,
     else if (!strcasecmp("BEFORE", sdependency)) {
         dependency = H2_DEPENDANT_BEFORE;
         if (sweight) {
-            return "dependecy 'Before' does not allow a weight";
+            return "dependency 'Before' does not allow a weight";
         }
     } 
     else if (!strcasecmp("INTERLEAVED", sdependency)) {
@@ -754,7 +755,7 @@ static const char *h2_conf_add_push_priority(cmd_parms *cmd, void *_cfg,
     if (!cfg->priorities) {
         cfg->priorities = apr_hash_make(cmd->pool);
     }
-    apr_hash_set(cfg->priorities, ctype, strlen(ctype), priority);
+    apr_hash_set(cfg->priorities, ctype, (apr_ssize_t)strlen(ctype), priority);
     return NULL;
 }
 

--- a/modules/http2/h2_conn.h
+++ b/modules/http2/h2_conn.h
@@ -45,12 +45,17 @@ apr_status_t h2_conn_run(conn_rec *c);
  */
 apr_status_t h2_conn_pre_close(struct h2_ctx *ctx, conn_rec *c);
 
-/* Initialize this child process for h2 connection work,
+/**
+ * Initialize this child process for h2 connection work,
  * to be called once during child init before multi processing
  * starts.
  */
 apr_status_t h2_conn_child_init(apr_pool_t *pool, server_rec *s);
 
+/**
+ * Child is about to be stopped, release unused resources
+ */
+void h2_conn_child_stopping(apr_pool_t *pool, int graceful);
 
 typedef enum {
     H2_MPM_UNKNOWN,

--- a/modules/http2/h2_conn_io.c
+++ b/modules/http2/h2_conn_io.c
@@ -54,16 +54,18 @@
  */
 #define WRITE_SIZE_MAX        (TLS_DATA_MAX) 
 
+#define BUF_REMAIN            ((apr_size_t)(bmax-off))
 
 static void h2_conn_io_bb_log(conn_rec *c, int stream_id, int level, 
                               const char *tag, apr_bucket_brigade *bb)
 {
     char buffer[16 * 1024];
     const char *line = "(null)";
-    apr_size_t bmax = sizeof(buffer)/sizeof(buffer[0]);
+    int bmax = sizeof(buffer)/sizeof(buffer[0]);
     int off = 0;
     apr_bucket *b;
     
+    (void)stream_id;
     if (bb) {
         memset(buffer, 0, bmax--);
         for (b = APR_BRIGADE_FIRST(bb); 
@@ -72,19 +74,19 @@ static void h2_conn_io_bb_log(conn_rec *c, int stream_id, int level,
             
             if (APR_BUCKET_IS_METADATA(b)) {
                 if (APR_BUCKET_IS_EOS(b)) {
-                    off += apr_snprintf(buffer+off, bmax-off, "eos ");
+                    off += apr_snprintf(buffer+off, BUF_REMAIN, "eos ");
                 }
                 else if (APR_BUCKET_IS_FLUSH(b)) {
-                    off += apr_snprintf(buffer+off, bmax-off, "flush ");
+                    off += apr_snprintf(buffer+off, BUF_REMAIN, "flush ");
                 }
                 else if (AP_BUCKET_IS_EOR(b)) {
-                    off += apr_snprintf(buffer+off, bmax-off, "eor ");
+                    off += apr_snprintf(buffer+off, BUF_REMAIN, "eor ");
                 }
                 else if (H2_BUCKET_IS_H2EOS(b)) {
-                    off += apr_snprintf(buffer+off, bmax-off, "h2eos ");
+                    off += apr_snprintf(buffer+off, BUF_REMAIN, "h2eos ");
                 }
                 else {
-                    off += apr_snprintf(buffer+off, bmax-off, "meta(unknown) ");
+                    off += apr_snprintf(buffer+off, BUF_REMAIN, "meta(unknown) ");
                 }
             }
             else {
@@ -116,10 +118,9 @@ static void h2_conn_io_bb_log(conn_rec *c, int stream_id, int level,
                     btype = "pool";
                 }
                 
-                off += apr_snprintf(buffer+off, bmax-off, "%s[%ld] ", 
+                off += apr_snprintf(buffer+off, BUF_REMAIN, "%s[%ld] ", 
                                     btype, 
-                                    (long)(b->length == ((apr_size_t)-1)? 
-                                           -1 : b->length));
+                                    (long)(b->length == ((apr_size_t)-1)? -1UL : b->length));
             }
         }
         line = *buffer? buffer : "(empty)";
@@ -159,7 +160,7 @@ apr_status_t h2_conn_io_init(h2_conn_io *io, conn_rec *c, server_rec *s)
                       "h2_conn_io(%ld): init, buffering=%d, warmup_size=%ld, "
                       "cd_secs=%f", io->c->id, io->buffer_output, 
                       (long)io->warmup_size,
-                      ((float)io->cooldown_usecs/APR_USEC_PER_SEC));
+                      ((double)io->cooldown_usecs/APR_USEC_PER_SEC));
     }
 
     return APR_SUCCESS;
@@ -208,8 +209,8 @@ static apr_status_t read_to_scratch(h2_conn_io *io, apr_bucket *b)
         apr_bucket_file *f = (apr_bucket_file *)b->data;
         apr_file_t *fd = f->fd;
         apr_off_t offset = b->start;
-        apr_size_t len = b->length;
         
+        len = b->length;
         /* file buckets will either mmap (which we do not want) or
          * read 8000 byte chunks and split themself. However, we do
          * know *exactly* how many bytes we need where.
@@ -294,13 +295,13 @@ int h2_conn_io_needs_flush(h2_conn_io *io)
 {
     if (!io->is_flushed) {
         apr_off_t len = h2_brigade_mem_size(io->output);
-        if (len > io->flush_threshold) {
+        if (len > (apr_off_t)io->flush_threshold) {
             return 1;
         }
         /* if we do not exceed flush length due to memory limits,
          * we want at least flush when we have that amount of data. */
         apr_brigade_length(io->output, 0, &len);
-        return len > (4 * io->flush_threshold);
+        return len > (apr_off_t)(4 * io->flush_threshold);
     }
     return 0;
 }

--- a/modules/http2/h2_from_h1.c
+++ b/modules/http2/h2_from_h1.c
@@ -114,65 +114,11 @@ static void fix_vary(request_rec *r)
     }
 }
 
-static void set_basic_http_header(apr_table_t *headers, request_rec *r,
-                                  apr_pool_t *pool)
-{
-    char *date = NULL;
-    const char *proxy_date = NULL;
-    const char *server = NULL;
-    const char *us = ap_get_server_banner();
-    
-    /*
-     * keep the set-by-proxy server and date headers, otherwise
-     * generate a new server header / date header
-     */
-    if (r && r->proxyreq != PROXYREQ_NONE) {
-        proxy_date = apr_table_get(r->headers_out, "Date");
-        if (!proxy_date) {
-            /*
-             * proxy_date needs to be const. So use date for the creation of
-             * our own Date header and pass it over to proxy_date later to
-             * avoid a compiler warning.
-             */
-            date = apr_palloc(pool, APR_RFC822_DATE_LEN);
-            ap_recent_rfc822_date(date, r->request_time);
-        }
-        server = apr_table_get(r->headers_out, "Server");
-    }
-    else {
-        date = apr_palloc(pool, APR_RFC822_DATE_LEN);
-        ap_recent_rfc822_date(date, r? r->request_time : apr_time_now());
-    }
-    
-    apr_table_setn(headers, "Date", proxy_date ? proxy_date : date );
-    if (r) {
-        apr_table_unset(r->headers_out, "Date");
-    }
-    
-    if (!server && *us) {
-        server = us;
-    }
-    if (server) {
-        apr_table_setn(headers, "Server", server);
-        if (r) {
-            apr_table_unset(r->headers_out, "Server");
-        }
-    }
-}
-
-static int copy_header(void *ctx, const char *name, const char *value)
-{
-    apr_table_t *headers = ctx;
-    
-    apr_table_add(headers, name, value);
-    return 1;
-}
-
 static h2_headers *create_response(h2_task *task, request_rec *r)
 {
     const char *clheader;
     const char *ctype;
-    apr_table_t *headers;
+
     /*
      * Now that we are ready to send a response, we need to combine the two
      * header field tables into a single table.  If we don't do this, our
@@ -279,28 +225,24 @@ static h2_headers *create_response(h2_task *task, request_rec *r)
         apr_table_unset(r->headers_out, "Content-Length");
     }
     
-    headers = apr_table_make(r->pool, 10);
-    
-    set_basic_http_header(headers, r, r->pool);
-    if (r->status == HTTP_NOT_MODIFIED) {
-        apr_table_do(copy_header, headers, r->headers_out,
-                     "ETag",
-                     "Content-Location",
-                     "Expires",
-                     "Cache-Control",
-                     "Vary",
-                     "Warning",
-                     "WWW-Authenticate",
-                     "Proxy-Authenticate",
-                     "Set-Cookie",
-                     "Set-Cookie2",
-                     NULL);
+    /*
+     * keep the set-by-proxy server and date headers, otherwise
+     * generate a new server header / date header
+     */
+    if (r->proxyreq != PROXYREQ_RESPONSE
+            || !apr_table_get(r->headers_out, "Date")) {
+        char *date = apr_palloc(r->pool, APR_RFC822_DATE_LEN);
+        ap_recent_rfc822_date(date, r->request_time);
+        apr_table_setn(r->headers_out, "Date", date );
     }
-    else {
-        apr_table_do(copy_header, headers, r->headers_out, NULL);
+    if (r->proxyreq != PROXYREQ_RESPONSE) {
+        const char *us = ap_get_server_banner();
+        if (us) {
+            apr_table_setn(r->headers_out, "Server", us);
+        }
     }
     
-    return h2_headers_rcreate(r, r->status, headers, r->pool);
+    return h2_headers_rcreate(r, r->status, r->headers_out, r->pool);
 }
 
 typedef enum {
@@ -669,10 +611,10 @@ static void make_chunk(h2_task *task, apr_bucket_brigade *bb,
      * to the end of the brigade. */
     char buffer[128];
     apr_bucket *c;
-    int len;
+    apr_size_t len;
     
-    len = apr_snprintf(buffer, H2_ALEN(buffer), 
-                       "%"APR_UINT64_T_HEX_FMT"\r\n", (apr_uint64_t)chunk_len);
+    len = (apr_size_t)apr_snprintf(buffer, H2_ALEN(buffer), 
+                                   "%"APR_UINT64_T_HEX_FMT"\r\n", (apr_uint64_t)chunk_len);
     c = apr_bucket_heap_create(buffer, len, NULL, bb->bucket_alloc);
     APR_BUCKET_INSERT_BEFORE(first, c);
     c = apr_bucket_heap_create("\r\n", 2, NULL, bb->bucket_alloc);

--- a/modules/http2/h2_headers.c
+++ b/modules/http2/h2_headers.c
@@ -113,9 +113,9 @@ apr_bucket *h2_bucket_headers_beam(struct h2_bucket_beam *beam,
 }
 
 
-h2_headers *h2_headers_create(int status, apr_table_t *headers_in, 
-                                apr_table_t *notes, apr_off_t raw_bytes,
-                                apr_pool_t *pool)
+h2_headers *h2_headers_create(int status, const apr_table_t *headers_in, 
+                              const apr_table_t *notes, apr_off_t raw_bytes,
+                              apr_pool_t *pool)
 {
     h2_headers *headers = apr_pcalloc(pool, sizeof(h2_headers));
     headers->status    = status;
@@ -141,7 +141,7 @@ apr_size_t h2_headers_length(h2_headers *headers)
 }
 
 h2_headers *h2_headers_rcreate(request_rec *r, int status,
-                                 apr_table_t *header, apr_pool_t *pool)
+                               const apr_table_t *header, apr_pool_t *pool)
 {
     h2_headers *headers = h2_headers_create(status, header, r->notes, 0, pool);
     if (headers->status == HTTP_FORBIDDEN) {
@@ -172,14 +172,12 @@ h2_headers *h2_headers_rcreate(request_rec *r, int status,
 
 h2_headers *h2_headers_copy(apr_pool_t *pool, h2_headers *h)
 {
-    return h2_headers_create(h->status, apr_table_copy(pool, h->headers), 
-                             apr_table_copy(pool, h->notes), h->raw_bytes, pool);
+    return h2_headers_create(h->status, h->headers, h->notes, h->raw_bytes, pool);
 }
 
 h2_headers *h2_headers_clone(apr_pool_t *pool, h2_headers *h)
 {
-    return h2_headers_create(h->status, apr_table_clone(pool, h->headers), 
-                             apr_table_clone(pool, h->notes), h->raw_bytes, pool);
+    return h2_headers_create(h->status, h->headers, h->notes, h->raw_bytes, pool);
 }
 
 h2_headers *h2_headers_die(apr_status_t type,

--- a/modules/http2/h2_headers.h
+++ b/modules/http2/h2_headers.h
@@ -44,8 +44,8 @@ apr_bucket *h2_bucket_headers_beam(struct h2_bucket_beam *beam,
  * @param raw_bytes the raw network bytes (if known) used to transmit these
  * @param pool the memory pool to use
  */
-h2_headers *h2_headers_create(int status, apr_table_t *header, 
-                              apr_table_t *notes, apr_off_t raw_bytes, 
+h2_headers *h2_headers_create(int status, const apr_table_t *header,
+                              const apr_table_t *notes, apr_off_t raw_bytes,
                               apr_pool_t *pool);
 
 /**
@@ -56,7 +56,7 @@ h2_headers *h2_headers_create(int status, apr_table_t *header,
  * @param pool the memory pool to use
  */
 h2_headers *h2_headers_rcreate(request_rec *r, int status, 
-                                 apr_table_t *header, apr_pool_t *pool);
+                               const apr_table_t *header, apr_pool_t *pool);
 
 /**
  * Copy the headers into another pool. This will not copy any
@@ -72,7 +72,6 @@ h2_headers *h2_headers_clone(apr_pool_t *pool, h2_headers *h);
 
 /**
  * Create the headers for the given error.
- * @param stream_id id of the stream to create the headers for
  * @param type the error code
  * @param req the original h2_request
  * @param pool the memory pool to use

--- a/modules/http2/h2_mplx.c
+++ b/modules/http2/h2_mplx.c
@@ -737,6 +737,12 @@ static h2_task *s_next_stream_task(h2_mplx *m)
             return stream->task;
         }
     }
+    if (m->tasks_active >= m->limit_active && !h2_iq_empty(m->q)) {
+        ap_log_cerror(APLOG_MARK, APLOG_DEBUG, 0, m->c,
+                      "h2_session(%ld): delaying request processing. "
+                      "Current limit is %d and %d workers are in use.",
+                      m->id, m->limit_active, m->tasks_active);
+    }
     return NULL;
 }
 
@@ -948,7 +954,6 @@ static apr_status_t m_unschedule_slow_tasks(h2_mplx *m)
         task->redo = 1;
         h2_task_rst(task, H2_ERR_CANCEL);
     }
-    
     return rv;
 }
 
@@ -1131,14 +1136,36 @@ int h2_mplx_m_awaits_data(h2_mplx *m)
     return waiting;
 }
 
+static int reset_is_acceptable(h2_stream *stream)
+{
+    /* client may terminate a stream via H2 RST_STREAM message at any time.
+     * This is annyoing when we have committed resources (e.g. worker threads)
+     * to it, so our mood (e.g. willingness to commit resources on this
+     * connection in the future) goes down.
+     *
+     * This is a DoS protection. We do not want to make it too easy for
+     * a client to eat up server resources.
+     *
+     * However: there are cases where a RST_STREAM is the only way to end
+     * a request. This includes websockets and server-side-event streams (SSEs).
+     * The responses to such requests continue forever otherwise.
+     *
+     */
+    if (!stream->task) return 1; /* have not started or already ended for us. acceptable. */
+    if (!(stream->id & 0x01)) return 1; /* stream initiated by us. acceptable. */
+    if (!stream->has_response) return 0; /* no response headers produced yet. bad. */
+    if (!stream->out_data_frames) return 0; /* no response body data sent yet. bad. */
+    return 1; /* otherwise, be forgiving */
+}
+
 apr_status_t h2_mplx_m_client_rst(h2_mplx *m, int stream_id)
 {
     h2_stream *stream;
     apr_status_t status = APR_SUCCESS;
-    
+
     H2_MPLX_ENTER_ALWAYS(m);
     stream = h2_ihash_get(m->streams, stream_id);
-    if (stream && stream->task) {
+    if (stream && !reset_is_acceptable(stream)) {
         status = m_be_annoyed(m);
     }
     H2_MPLX_LEAVE(m);

--- a/modules/http2/h2_push.h
+++ b/modules/http2/h2_push.h
@@ -99,7 +99,7 @@ struct h2_push_diary {
  */
 apr_array_header_t *h2_push_collect(apr_pool_t *p, 
                                     const struct h2_request *req, 
-                                    int push_policy, 
+                                    apr_uint32_t push_policy, 
                                     const struct h2_headers *res);
 
 /**

--- a/modules/http2/h2_request.c
+++ b/modules/http2/h2_request.c
@@ -210,12 +210,74 @@ h2_request *h2_request_clone(apr_pool_t *p, const h2_request *src)
     return dst;
 }
 
+#if !AP_MODULE_MAGIC_AT_LEAST(20120211, 106)
+static request_rec *my_ap_create_request(conn_rec *c)
+{
+    apr_pool_t *p;
+    request_rec *r;
+
+    apr_pool_create(&p, c->pool);
+    apr_pool_tag(p, "request");
+    r = apr_pcalloc(p, sizeof(request_rec));
+    AP_READ_REQUEST_ENTRY((intptr_t)r, (uintptr_t)c);
+    r->pool            = p;
+    r->connection      = c;
+    r->server          = c->base_server;
+
+    r->user            = NULL;
+    r->ap_auth_type    = NULL;
+
+    r->allowed_methods = ap_make_method_list(p, 2);
+
+    r->headers_in      = apr_table_make(r->pool, 5);
+    r->trailers_in     = apr_table_make(r->pool, 5);
+    r->subprocess_env  = apr_table_make(r->pool, 25);
+    r->headers_out     = apr_table_make(r->pool, 12);
+    r->err_headers_out = apr_table_make(r->pool, 5);
+    r->trailers_out    = apr_table_make(r->pool, 5);
+    r->notes           = apr_table_make(r->pool, 5);
+
+    r->request_config  = ap_create_request_config(r->pool);
+    /* Must be set before we run create request hook */
+
+    r->proto_output_filters = c->output_filters;
+    r->output_filters  = r->proto_output_filters;
+    r->proto_input_filters = c->input_filters;
+    r->input_filters   = r->proto_input_filters;
+    ap_run_create_request(r);
+    r->per_dir_config  = r->server->lookup_defaults;
+
+    r->sent_bodyct     = 0;                      /* bytect isn't for body */
+
+    r->read_length     = 0;
+    r->read_body       = REQUEST_NO_BODY;
+
+    r->status          = HTTP_OK;  /* Until further notice */
+    r->header_only     = 0;
+    r->the_request     = NULL;
+
+    /* Begin by presuming any module can make its own path_info assumptions,
+     * until some module interjects and changes the value.
+     */
+    r->used_path_info = AP_REQ_DEFAULT_PATH_INFO;
+
+    r->useragent_addr = c->client_addr;
+    r->useragent_ip = c->client_ip;
+    return r;
+}
+#endif
+
 request_rec *h2_request_create_rec(const h2_request *req, conn_rec *c)
 {
     int access_status = HTTP_OK;    
 
+#if AP_MODULE_MAGIC_AT_LEAST(20120211, 106)
     request_rec *r = ap_create_request(c);
+#else
+    request_rec *r = my_ap_create_request(c);
+#endif
 
+#if AP_MODULE_MAGIC_AT_LEAST(20120211, 107)
     ap_run_pre_read_request(r, c);
 
     /* Time to populate r with the data we have. */
@@ -244,6 +306,49 @@ request_rec *h2_request_create_rec(const h2_request *req, conn_rec *c)
         r->status = HTTP_OK;
         goto die;
     }
+#else
+    {
+        const char *s;
+
+        r->headers_in = apr_table_clone(r->pool, req->headers);
+        ap_run_pre_read_request(r, c);
+
+        /* Time to populate r with the data we have. */
+        r->request_time = req->request_time;
+        r->method = apr_pstrdup(r->pool, req->method);
+        /* Provide quick information about the request method as soon as known */
+        r->method_number = ap_method_number_of(r->method);
+        if (r->method_number == M_GET && r->method[0] == 'H') {
+            r->header_only = 1;
+        }
+        ap_parse_uri(r, req->path ? req->path : "");
+        r->protocol = (char*)"HTTP/2.0";
+        r->proto_num = HTTP_VERSION(2, 0);
+        r->the_request = apr_psprintf(r->pool, "%s %s HTTP/2.0",
+                                      r->method, req->path ? req->path : "");
+
+        /* Start with r->hostname = NULL, ap_check_request_header() will get it
+         * form Host: header, otherwise we get complains about port numbers.
+         */
+        r->hostname = NULL;
+        ap_update_vhost_from_headers(r);
+
+         /* we may have switched to another server */
+         r->per_dir_config = r->server->lookup_defaults;
+
+         s = apr_table_get(r->headers_in, "Expect");
+         if (s && s[0]) {
+            if (ap_cstr_casecmp(s, "100-continue") == 0) {
+                r->expecting_100 = 1;
+            }
+            else {
+                r->status = HTTP_EXPECTATION_FAILED;
+                access_status = r->status;
+                goto die;
+            }
+         }
+    }
+#endif
 
     /* we may have switched to another server */
     r->per_dir_config = r->server->lookup_defaults;

--- a/modules/http2/h2_session.h
+++ b/modules/http2/h2_session.h
@@ -188,11 +188,6 @@ void h2_session_close(h2_session *session);
 int h2_session_push_enabled(h2_session *session);
 
 /**
- * Look up the stream in this session with the given id.
- */
-struct h2_stream *h2_session_stream_get(h2_session *session, int stream_id);
-
-/**
  * Submit a push promise on the stream and schedule the new steam for
  * processing..
  * 

--- a/modules/http2/h2_task.c
+++ b/modules/http2/h2_task.c
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+ 
 #include <assert.h>
 #include <stddef.h>
 
@@ -541,6 +541,7 @@ h2_task *h2_task_create(conn_rec *secondary, int stream_id,
 void h2_task_destroy(h2_task *task)
 {
     if (task->output.beam) {
+        h2_beam_log(task->output.beam, task->c, APLOG_TRACE2, "task_destroy");
         h2_beam_destroy(task->output.beam);
         task->output.beam = NULL;
     }
@@ -592,7 +593,7 @@ apr_status_t h2_task_do(h2_task *task, apr_thread_t *thread, int worker_id)
          * configurations by mod_h2 alone. 
          */
         task->c->id = (c->master->id << 8)^worker_id;
-        task->id = apr_psprintf(task->pool, "%ld-%d", c->master->id, 
+        task->id = apr_psprintf(task->pool, "%ld-%d", task->mplx->id,
                                 task->stream_id);
     }
         

--- a/modules/http2/h2_task.h
+++ b/modules/http2/h2_task.h
@@ -21,7 +21,7 @@
 
 /**
  * A h2_task fakes a HTTP/1.1 request from the data in a HTTP/2 stream 
- * (HEADER+CONT.+DATA) the module recieves.
+ * (HEADER+CONT.+DATA) the module receives.
  *
  * In order to answer a HTTP/2 stream, we want all Apache httpd infrastructure
  * to be involved as usual, as if this stream can as a separate HTTP/1.1
@@ -112,7 +112,7 @@ void h2_task_rst(h2_task *task, int error);
 
 void h2_task_register_hooks(void);
 /*
- * One time, post config intialization.
+ * One time, post config initialization.
  */
 apr_status_t h2_task_init(apr_pool_t *pool, server_rec *s);
 

--- a/modules/http2/h2_util.c
+++ b/modules/http2/h2_util.c
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+ 
 #include <assert.h>
 #include <apr_strings.h>
 #include <apr_thread_mutex.h>
@@ -425,7 +425,7 @@ void h2_iq_clear(h2_iqueue *q)
 void h2_iq_sort(h2_iqueue *q, h2_iq_cmp *cmp, void *ctx)
 {
     /* Assume that changes in ordering are minimal. This needs,
-     * best case, q->nelts - 1 comparisions to check that nothing
+     * best case, q->nelts - 1 comparisons to check that nothing
      * changed.
      */
     if (q->nelts > 0) {

--- a/modules/http2/h2_version.h
+++ b/modules/http2/h2_version.h
@@ -27,7 +27,7 @@
  * @macro
  * Version number of the http2 module as c string
  */
-#define MOD_HTTP2_VERSION "1.15.18"
+#define MOD_HTTP2_VERSION "1.15.24-git"
 
 /**
  * @macro
@@ -35,7 +35,7 @@
  * release. This is a 24 bit number with 8 bits for major number, 8 bits
  * for minor and 8 bits for patch. Version 1.2.3 becomes 0x010203.
  */
-#define MOD_HTTP2_VERSION_NUM 0x010f12
+#define MOD_HTTP2_VERSION_NUM 0x010f18
 
 
 #endif /* mod_h2_h2_version_h */

--- a/modules/http2/h2_version.h
+++ b/modules/http2/h2_version.h
@@ -27,7 +27,7 @@
  * @macro
  * Version number of the http2 module as c string
  */
-#define MOD_HTTP2_VERSION "1.15.24-git"
+#define MOD_HTTP2_VERSION "1.15.24"
 
 /**
  * @macro

--- a/modules/http2/h2_workers.h
+++ b/modules/http2/h2_workers.h
@@ -38,11 +38,12 @@ struct h2_workers {
     apr_pool_t *pool;
     
     int next_worker_id;
-    int min_workers;
-    int max_workers;
-    int max_idle_secs;
+    apr_uint32_t max_workers;
+    volatile apr_uint32_t min_workers; /* is changed during graceful shutdown */
+    volatile apr_interval_time_t max_idle_duration; /* is changed during graceful shutdown */
     
     volatile int aborted;
+    volatile int shutdown;
     int dynamic;
 
     apr_threadattr_t *thread_attr;
@@ -79,5 +80,10 @@ apr_status_t h2_workers_register(h2_workers *workers, struct h2_mplx *m);
  * Remove a h2_mplx from the worker registry.
  */
 apr_status_t h2_workers_unregister(h2_workers *workers, struct h2_mplx *m);
+
+/**
+ *  Shut down processing gracefully by terminating all idle workers.
+ */
+void h2_workers_graceful_shutdown(h2_workers *workers);
 
 #endif /* defined(__mod_h2__h2_workers__) */

--- a/modules/http2/mod_http2.c
+++ b/modules/http2/mod_http2.c
@@ -24,6 +24,7 @@
 #include <http_protocol.h>
 #include <http_request.h>
 #include <http_log.h>
+#include <mpm_common.h>
 
 #include "mod_http2.h"
 
@@ -228,7 +229,9 @@ static void h2_hooks(apr_pool_t *pool)
     /* Run once after a child process has been created.
      */
     ap_hook_child_init(h2_child_init, NULL, NULL, APR_HOOK_MIDDLE);
-
+#if AP_MODULE_MAGIC_AT_LEAST(20120211, 110)
+    ap_hook_child_stopping(h2_conn_child_stopping, NULL, NULL, APR_HOOK_MIDDLE);
+#endif
     h2_h2_register_hooks();
     h2_switch_register_hooks();
     h2_task_register_hooks();

--- a/modules/http2/mod_proxy_http2.c
+++ b/modules/http2/mod_proxy_http2.c
@@ -397,18 +397,9 @@ run_connect:
     
     if (!ctx->p_conn->data && ctx->is_ssl) {
         /* New SSL connection: set a note on the connection about what
-         * protocol we want.
-         */
+         * protocol we need. */
         apr_table_setn(ctx->p_conn->connection->notes,
                        "proxy-request-alpn-protos", "h2");
-        if (ctx->p_conn->ssl_hostname) {
-            ap_log_cerror(APLOG_MARK, APLOG_TRACE1, 0, ctx->owner,
-                          "set SNI to %s for (%s)",
-                          ctx->p_conn->ssl_hostname,
-                          ctx->p_conn->hostname);
-            apr_table_setn(ctx->p_conn->connection->notes,
-                           "proxy-request-hostname", ctx->p_conn->ssl_hostname);
-        }
     }
 
     if (ctx->master->aborted) goto cleanup;


### PR DESCRIPTION
Complete synchronisation of sources with trunk version.

  *) mod_http2: when a server is restarted gracefully, any idle h2 worker
     threads are shut down immediately.
     Also, change OpenSSL API use for deprecations in OpenSLL 3.0.

to verify, run

```
> make install
> pytest
```
