### PR TITLE
  *) mod_http2: fixes 2 regressions in server limit handling.

### DIFF
--- a/change-entries/h2_pr65731_issue212.txt
+++ b/change-entries/h2_pr65731_issue212.txt
@@ -1,0 +1,14 @@
+  *) mod_http2: fixes 2 regressions in server limit handling.
+     1. When reaching server limits, such as MaxRequestsPerChild, the
+        HTTP/2 connection send a GOAWAY frame much too early on new
+        connections, leading to invalid protocol state and a client
+        failing the request. See PR65731.
+        The module now initializes the HTTP/2 protocol correctly and
+        allows the client to submit one request before the shutdown
+        via a GOAWAY frame is being announced.
+     2. A regression in v1.15.24 was fixed that could lead to httpd
+        child processes not being terminated on a graceful reload or
+        when reaching MaxConnectionsPerChild. When unprocessed h2
+        requests were queued at the time, these could stall.
+        See <https://github.com/icing/mod_h2/issues/212>.
+     [Stefan Eissing]

--- a/modules/http2/h2_version.h
+++ b/modules/http2/h2_version.h
@@ -27,7 +27,7 @@
  * @macro
  * Version number of the http2 module as c string
  */
-#define MOD_HTTP2_VERSION "1.15.24"
+#define MOD_HTTP2_VERSION "1.15.26"
 
 /**
  * @macro
@@ -35,7 +35,7 @@
  * release. This is a 24 bit number with 8 bits for major number, 8 bits
  * for minor and 8 bits for patch. Version 1.2.3 becomes 0x010203.
  */
-#define MOD_HTTP2_VERSION_NUM 0x010f18
+#define MOD_HTTP2_VERSION_NUM 0x010f1a
 
 
 #endif /* mod_h2_h2_version_h */

--- a/modules/http2/h2_workers.c
+++ b/modules/http2/h2_workers.c
@@ -479,8 +479,6 @@ apr_status_t h2_workers_unregister(h2_workers *workers, struct h2_mplx *m)
 void h2_workers_graceful_shutdown(h2_workers *workers)
 {
     workers->shutdown = 1;
-    workers->min_workers = 1;
     workers->max_idle_duration = apr_time_from_sec(1);
-    h2_fifo_term(workers->mplxs);
     wake_non_essential_workers(workers);
 }


### PR DESCRIPTION
     1. When reaching server limits, such as MaxRequestsPerChild, the
        HTTP/2 connection send a GOAWAY frame much too early on new
        connections, leading to invalid protocol state and a client
        failing the request. See PR65731.
        The module now initializes the HTTP/2 protocol correctly and
        allows the client to submit one request before the shutdown
        via a GOAWAY frame is being announced.
     2. A regression in v1.15.24 was fixed that could lead to httpd
        child processes not being terminated on a graceful reload or
        when reaching MaxConnectionsPerChild. When unprocessed h2
        requests were queued at the time, these could stall.
        See <https://github.com/icing/mod_h2/issues/212>.