### PR TITLE
mod_proxy: Bump shared worker name to 384 chars.  PR 53218.

### DIFF
--- a/changes-entries/proxy_shared_name_ex.txt
+++ b/changes-entries/proxy_shared_name_ex.txt
@@ -1,0 +1,1 @@
+  *) mod_proxy: Allow for larger worker name.  PR 53218.  [Yann Ylavic]

--- a/include/ap_mmn.h
+++ b/include/ap_mmn.h
@@ -587,6 +587,7 @@
  * 20120211.120 (2.4.51-dev) Add dav_liveprop_elem structure and
  *                           dav_get_liveprop_element().
  * 20120211.121 (2.4.51-dev) Add ap_post_read_request()
+ * 20120211.122 (2.4.51-dev) Add name_ex to struct proxy_worker_shared
  * 
  */
 
@@ -595,7 +596,7 @@
 #ifndef MODULE_MAGIC_NUMBER_MAJOR
 #define MODULE_MAGIC_NUMBER_MAJOR 20120211
 #endif
-#define MODULE_MAGIC_NUMBER_MINOR 121                 /* 0...n */
+#define MODULE_MAGIC_NUMBER_MINOR 122                 /* 0...n */
 
 /**
  * Determine if the server's current MODULE_MAGIC_NUMBER is at least a

--- a/modules/proxy/balancers/mod_lbmethod_heartbeat.c
+++ b/modules/proxy/balancers/mod_lbmethod_heartbeat.c
@@ -303,7 +303,7 @@ static proxy_worker *find_best_hb(proxy_balancer *balancer,
 
         if (!server) {
             ap_log_rerror(APLOG_MARK, APLOG_DEBUG, rv, r, APLOGNO(01214)
-                      "lb_heartbeat: No server for worker %s", (*worker)->s->name);
+                      "lb_heartbeat: No server for worker %s", (*worker)->s->name_ex);
             continue;
         }
 

--- a/modules/proxy/mod_proxy.c
+++ b/modules/proxy/mod_proxy.c
@@ -3230,7 +3230,7 @@ static int proxy_status_hook(request_rec *r, int flags)
             }
             else {
                 ap_rprintf(r, "ProxyBalancer[%d]Worker[%d]Name: %s\n",
-                           i, n, (*worker)->s->name);
+                           i, n, (*worker)->s->name_ex);
                 ap_rprintf(r, "ProxyBalancer[%d]Worker[%d]Status: %s\n",
                            i, n, ap_proxy_parse_wstatus(r->pool, *worker));
                 ap_rprintf(r, "ProxyBalancer[%d]Worker[%d]Elected: %"
@@ -3311,13 +3311,14 @@ static void child_init(apr_pool_t *p, server_rec *s)
                                    "http://www.apache.org", 0);
             conf->forward = forward;
             PROXY_STRNCPY(conf->forward->s->name,     "proxy:forward");
+            PROXY_STRNCPY(conf->forward->s->name_ex,  "proxy:forward");
             PROXY_STRNCPY(conf->forward->s->hostname, "*"); /* for compatibility */
             PROXY_STRNCPY(conf->forward->s->hostname_ex, "*");
             PROXY_STRNCPY(conf->forward->s->scheme,   "*");
             conf->forward->hash.def = conf->forward->s->hash.def =
-                ap_proxy_hashfunc(conf->forward->s->name, PROXY_HASHFUNC_DEFAULT);
+                ap_proxy_hashfunc(conf->forward->s->name_ex, PROXY_HASHFUNC_DEFAULT);
              conf->forward->hash.fnv = conf->forward->s->hash.fnv =
-                ap_proxy_hashfunc(conf->forward->s->name, PROXY_HASHFUNC_FNV);
+                ap_proxy_hashfunc(conf->forward->s->name_ex, PROXY_HASHFUNC_FNV);
             /* Do not disable worker in case of errors */
             conf->forward->s->status |= PROXY_WORKER_IGNORE_ERRORS;
             /* Mark as the "generic" worker */
@@ -3330,13 +3331,14 @@ static void child_init(apr_pool_t *p, server_rec *s)
             ap_proxy_define_worker(conf->pool, &reverse, NULL, NULL,
                                    "http://www.apache.org", 0);
             PROXY_STRNCPY(reverse->s->name,     "proxy:reverse");
+            PROXY_STRNCPY(reverse->s->name_ex,  "proxy:reverse");
             PROXY_STRNCPY(reverse->s->hostname, "*"); /* for compatibility */
             PROXY_STRNCPY(reverse->s->hostname_ex, "*");
             PROXY_STRNCPY(reverse->s->scheme,   "*");
             reverse->hash.def = reverse->s->hash.def =
-                ap_proxy_hashfunc(reverse->s->name, PROXY_HASHFUNC_DEFAULT);
+                ap_proxy_hashfunc(reverse->s->name_ex, PROXY_HASHFUNC_DEFAULT);
             reverse->hash.fnv = reverse->s->hash.fnv =
-                ap_proxy_hashfunc(reverse->s->name, PROXY_HASHFUNC_FNV);
+                ap_proxy_hashfunc(reverse->s->name_ex, PROXY_HASHFUNC_FNV);
             /* Do not disable worker in case of errors */
             reverse->s->status |= PROXY_WORKER_IGNORE_ERRORS;
             /* Mark as the "generic" worker */

--- a/modules/proxy/mod_proxy.h
+++ b/modules/proxy/mod_proxy.h
@@ -371,6 +371,7 @@ PROXY_WORKER_HC_FAIL )
 #define PROXY_WORKER_MAX_SECRET_SIZE     64
 
 #define PROXY_RFC1035_HOSTNAME_SIZE	256
+#define PROXY_WORKER_EXT_NAME_SIZE      384
 
 /* RFC-1035 mentions limits of 255 for host-names and 253 for domain-names,
  * dotted together(?) this would fit the below size (+ trailing NUL).
@@ -473,6 +474,7 @@ typedef struct {
     apr_size_t   response_field_size; /* Size of proxy response buffer in bytes. */
     unsigned int response_field_size_set:1;
     char      secret[PROXY_WORKER_MAX_SECRET_SIZE]; /* authentication secret (e.g. AJP13) */
+    char      name_ex[PROXY_WORKER_EXT_NAME_SIZE]; /* Extended name (>96 chars for 2.4.x) */
 } proxy_worker_shared;
 
 #define ALIGNED_PROXY_WORKER_SHARED_SIZE (APR_ALIGN_DEFAULT(sizeof(proxy_worker_shared)))

--- a/modules/proxy/mod_proxy_balancer.c
+++ b/modules/proxy/mod_proxy_balancer.c
@@ -421,7 +421,7 @@ static int rewrite_url(request_rec *r, proxy_worker *worker,
                              NULL));
     }
 
-    *url = apr_pstrcat(r->pool, worker->s->name, path, NULL);
+    *url = apr_pstrcat(r->pool, worker->s->name_ex, path, NULL);
 
     return OK;
 }
@@ -618,7 +618,7 @@ static int proxy_balancer_pre_request(proxy_worker **worker,
     apr_table_setn(r->subprocess_env,
                    "BALANCER_NAME", (*balancer)->s->name);
     apr_table_setn(r->subprocess_env,
-                   "BALANCER_WORKER_NAME", (*worker)->s->name);
+                   "BALANCER_WORKER_NAME", (*worker)->s->name_ex);
     apr_table_setn(r->subprocess_env,
                    "BALANCER_WORKER_ROUTE", (*worker)->s->route);
 
@@ -641,7 +641,7 @@ static int proxy_balancer_pre_request(proxy_worker **worker,
     }
     ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r, APLOGNO(01172)
                   "%s: worker (%s) rewritten to %s",
-                  (*balancer)->s->name, (*worker)->s->name, *url);
+                  (*balancer)->s->name, (*worker)->s->name_ex, *url);
 
     return access_status;
 }
@@ -1722,7 +1722,7 @@ static void balancer_display_page(request_rec *r, proxy_server_conf *conf,
                 ap_rvputs(r, "<tr>\n<td><a href=\"",
                           ap_escape_uri(r->pool, r->uri), "?b=",
                           balancer->s->name + sizeof(BALANCER_PREFIX) - 1, "&amp;w=",
-                          ap_escape_uri(r->pool, worker->s->name),
+                          ap_escape_uri(r->pool, worker->s->name_ex),
                           "&amp;nonce=", balancer->s->nonce,
                           "\">", NULL);
                 ap_rvputs(r, (*worker->s->uds_path ? "<i>" : ""), ap_proxy_worker_name(r->pool, worker),
@@ -1826,7 +1826,7 @@ static void balancer_display_page(request_rec *r, proxy_server_conf *conf,
             }
             ap_rputs("<tr><td colspan='2'><input type=submit value='Submit'></td></tr>\n", r);
             ap_rvputs(r, "</table>\n<input type=hidden name='w' id='w' ",  NULL);
-            ap_rvputs(r, "value=\"", ap_escape_uri(r->pool, wsel->s->name), "\">\n", NULL);
+            ap_rvputs(r, "value=\"", ap_escape_uri(r->pool, wsel->s->name_ex), "\">\n", NULL);
             ap_rvputs(r, "<input type=hidden name='b' id='b' ", NULL);
             ap_rvputs(r, "value=\"", ap_escape_html(r->pool, bsel->s->name + sizeof(BALANCER_PREFIX) - 1),
                       "\">\n", NULL);


### PR DESCRIPTION
This is a backport of r1896253 compatible with 2.4.x, where we can't change the
layout/size of the existing proxy_worker_shared fields, to allow for larger
worker name in <Proxy> and ProxyPass.

This backport adds a "name_ex" field of 384 chars at the end of the struct, the
existing "name" field is still initialized as before for third-parties that
might use it but every internal use is replaced by "name_ex".