### PR TITLE
H2 pollset impr

### DIFF
--- a/include/ap_mmn.h
+++ b/include/ap_mmn.h
@@ -702,6 +702,9 @@
  *                         and ap_thread_current()
  * 20211221.4 (2.5.1-dev)  Add hook child_stopped to get informed that a child
  *                         has stopped processing any requests.
+ * 20211221.5 (2.5.1-dev)  Add hook create_secondary_connection and method
+ *                         ap_create_secondary_connection() to have connection
+ *                         setup of http2-like connections in core.
  *
  */
 
@@ -710,7 +713,7 @@
 #ifndef MODULE_MAGIC_NUMBER_MAJOR
 #define MODULE_MAGIC_NUMBER_MAJOR 20211221
 #endif
-#define MODULE_MAGIC_NUMBER_MINOR 4             /* 0...n */
+#define MODULE_MAGIC_NUMBER_MINOR 5             /* 0...n */
 
 /**
  * Determine if the server's current MODULE_MAGIC_NUMBER is at least a

--- a/include/http_connection.h
+++ b/include/http_connection.h
@@ -151,6 +151,20 @@ AP_DECLARE_HOOK(int,pre_close_connection,(conn_rec *c))
 AP_DECLARE(int) ap_pre_connection(conn_rec *c, void *csd);
 
 /**
+ * create_secondary_connection is a RUN_FIRST hook which allows modules to create
+ * secondary connections. In general, you should not install filters with the
+ * create_secondary_connection hook. This hook should close the connection
+ * if it encounters a fatal error condition.
+ *
+ * @param p The pool for the secondary connection
+ * @param master The master connection this belongs to.
+ * @param alloc The bucket allocator to use for all bucket/brigade creations
+ * @return An allocated connection record or NULL.
+ */
+AP_DECLARE_HOOK(conn_rec *, create_secondary_connection,
+                (apr_pool_t *p, conn_rec *master, apr_bucket_alloc_t *alloc))
+
+/**
  * Create a new server/incoming or client/outgoing/proxy connection
  * @param p The pool from which to allocate the connection record
  * @param server The server record to create the connection too.
@@ -170,6 +184,17 @@ AP_DECLARE(conn_rec *) ap_create_connection(apr_pool_t *p,
                                             long conn_id, void *sbh,
                                             apr_bucket_alloc_t *alloc,
                                             unsigned int outgoing);
+
+/**
+ * Create a new secondary connection based on a master one.
+ * @param pool  The pool for the secondary connection
+ * @param master The master connection this belongs to.
+ * @param alloc The bucket allocator to use for all bucket/brigade creations
+ * @return An allocated connection record or NULL.
+ */
+AP_DECLARE(conn_rec *) ap_create_secondary_connection(apr_pool_t *pool,
+                                                      conn_rec *master,
+                                                      apr_bucket_alloc_t *alloc);
 
 
 /** End Of Connection (EOC) bucket */

--- a/modules/http2/h2.h
+++ b/modules/http2/h2.h
@@ -59,7 +59,7 @@ struct h2_stream;
  * are used for many consecutive requests where
  * pollsets stay unchanged much longer.
  */
-#define H2_NO_POLL_STREAMS        1
+/*#define H2_NO_POLL_STREAMS        1*/
 #ifdef H2_NO_POLL_STREAMS
 #define H2_POLL_STREAMS           0
 #else

--- a/modules/http2/h2.h
+++ b/modules/http2/h2.h
@@ -59,7 +59,7 @@ struct h2_stream;
  * are used for many consecutive requests where
  * pollsets stay unchanged much longer.
  */
-/*#define H2_NO_POLL_STREAMS        1*/
+#define H2_NO_POLL_STREAMS        1
 #ifdef H2_NO_POLL_STREAMS
 #define H2_POLL_STREAMS           0
 #else

--- a/modules/http2/h2_c2.c
+++ b/modules/http2/h2_c2.c
@@ -131,99 +131,11 @@ int h2_mpm_supported(void)
     return mpm_supported;
 }
 
-static module *h2_conn_mpm_module(void)
-{
-    check_modules(0);
-    return mpm_module;
-}
-
 apr_status_t h2_c2_child_init(apr_pool_t *pool, server_rec *s)
 {
     check_modules(1);
     return apr_socket_create(&dummy_socket, APR_INET, SOCK_STREAM,
                              APR_PROTO_TCP, pool);
-}
-
-/* APR callback invoked if allocation fails. */
-static int abort_on_oom(int retcode)
-{
-    ap_abort_on_oom();
-    return retcode; /* unreachable, hopefully. */
-}
-
-conn_rec *h2_c2_create(conn_rec *c1, apr_pool_t *parent)
-{
-    apr_allocator_t *allocator;
-    apr_status_t status;
-    apr_pool_t *pool;
-    conn_rec *c2;
-    void *cfg;
-    module *mpm;
-
-    ap_assert(c1);
-    ap_log_cerror(APLOG_MARK, APLOG_TRACE3, 0, c1,
-                  "h2_c2: create for c1(%ld)", c1->id);
-
-    /* We create a pool with its own allocator to be used for
-     * processing a request. This is the only way to have the processing
-     * independent of its parent pool in the sense that it can work in
-     * another thread.
-     */
-    apr_allocator_create(&allocator);
-    apr_allocator_max_free_set(allocator, ap_max_mem_free);
-    status = apr_pool_create_ex(&pool, parent, NULL, allocator);
-    if (status != APR_SUCCESS) {
-        ap_log_cerror(APLOG_MARK, APLOG_ERR, status, c1,
-                      APLOGNO(10004) "h2_c2: create pool");
-        return NULL;
-    }
-    apr_allocator_owner_set(allocator, pool);
-    apr_pool_abort_set(abort_on_oom, pool);
-    apr_pool_tag(pool, "h2_c2_conn");
-
-    c2 = (conn_rec *) apr_palloc(pool, sizeof(conn_rec));
-    memcpy(c2, c1, sizeof(conn_rec));
-
-    c2->master                 = c1;
-    c2->pool                   = pool;
-    c2->conn_config            = ap_create_conn_config(pool);
-    c2->notes                  = apr_table_make(pool, 5);
-    c2->input_filters          = NULL;
-    c2->output_filters         = NULL;
-    c2->keepalives             = 0;
-#if AP_MODULE_MAGIC_AT_LEAST(20180903, 1)
-    c2->filter_conn_ctx        = NULL;
-#endif
-    c2->bucket_alloc           = apr_bucket_alloc_create(pool);
-#if !AP_MODULE_MAGIC_AT_LEAST(20180720, 1)
-    c2->data_in_input_filters  = 0;
-    c2->data_in_output_filters = 0;
-#endif
-    /* prevent mpm_event from making wrong assumptions about this connection,
-     * like e.g. using its socket for an async read check. */
-    c2->clogging_input_filters = 1;
-    c2->log                    = NULL;
-    c2->aborted                = 0;
-    /* We cannot install the master connection socket on the secondary, as
-     * modules mess with timeouts/blocking of the socket, with
-     * unwanted side effects to the master connection processing.
-     * Fortunately, since we never use the secondary socket, we can just install
-     * a single, process-wide dummy and everyone is happy.
-     */
-    ap_set_module_config(c2->conn_config, &core_module, dummy_socket);
-    /* TODO: these should be unique to this thread */
-    c2->sbh = NULL; /*c1->sbh;*/
-    /* TODO: not all mpm modules have learned about secondary connections yet.
-     * copy their config from master to secondary.
-     */
-    if ((mpm = h2_conn_mpm_module()) != NULL) {
-        cfg = ap_get_module_config(c1->conn_config, mpm);
-        ap_set_module_config(c2->conn_config, mpm, cfg);
-    }
-
-    ap_log_cerror(APLOG_MARK, APLOG_TRACE3, 0, c2,
-                  "h2_c2(%s): created", c2->log_id);
-    return c2;
 }
 
 void h2_c2_destroy(conn_rec *c2)

--- a/modules/http2/h2_c2.h
+++ b/modules/http2/h2_c2.h
@@ -45,6 +45,14 @@ conn_rec *h2_c2_create(conn_rec *c1, apr_pool_t *parent);
 void h2_c2_destroy(conn_rec *c2);
 
 /**
+ * Abort the I/O processing of a secondary connection. And
+ * in-/output beams will return errors and c2->aborted is set.
+ * @param c2 the secondary connection to abort
+ * @param from the connection this is invoked from
+ */
+void h2_c2_abort(conn_rec *c2, conn_rec *from);
+
+/**
  * Process a secondary connection for a HTTP/2 stream request.
  */
 apr_status_t h2_c2_process(conn_rec *c, apr_thread_t *thread, int worker_id);

--- a/modules/http2/h2_c2.h
+++ b/modules/http2/h2_c2.h
@@ -41,7 +41,6 @@ int h2_mpm_supported(void);
  */
 apr_status_t h2_c2_child_init(apr_pool_t *pool, server_rec *s);
 
-conn_rec *h2_c2_create(conn_rec *c1, apr_pool_t *parent);
 void h2_c2_destroy(conn_rec *c2);
 
 /**

--- a/modules/http2/h2_conn_ctx.c
+++ b/modules/http2/h2_conn_ctx.c
@@ -16,6 +16,7 @@
  
 #include <assert.h>
 #include <apr_strings.h>
+#include <apr_atomic.h>
 
 #include <httpd.h>
 #include <http_core.h>
@@ -42,6 +43,7 @@ static h2_conn_ctx_t *ctx_create(conn_rec *c, const char *id)
     h2_conn_ctx_t *conn_ctx = apr_pcalloc(c->pool, sizeof(*conn_ctx));
     conn_ctx->id = id;
     conn_ctx->server = c->base_server;
+    apr_atomic_set32(&conn_ctx->started, 1);
     conn_ctx->started_at = apr_time_now();
 
     ap_set_module_config(c->conn_config, &http2_module, conn_ctx);
@@ -89,6 +91,7 @@ apr_status_t h2_conn_ctx_init_for_c2(h2_conn_ctx_t **pctx, conn_rec *c2,
     apr_pool_create(&conn_ctx->req_pool, c2->pool);
     apr_pool_tag(conn_ctx->req_pool, "H2_C2_REQ");
     conn_ctx->request = stream->request;
+    apr_atomic_set32(&conn_ctx->started, 1);
     conn_ctx->started_at = apr_time_now();
     conn_ctx->done = 0;
     conn_ctx->done_at = 0;

--- a/modules/http2/h2_conn_ctx.c
+++ b/modules/http2/h2_conn_ctx.c
@@ -111,22 +111,8 @@ void h2_conn_ctx_clear_for_c2(conn_rec *c2)
         conn_ctx->req_pool = NULL;
         conn_ctx->beam_out = NULL;
     }
-    memset(&conn_ctx->pfd_in_drain, 0, sizeof(conn_ctx->pfd_in_drain));
     memset(&conn_ctx->pfd_out_prod, 0, sizeof(conn_ctx->pfd_out_prod));
     conn_ctx->beam_in = NULL;
-}
-
-void h2_conn_ctx_destroy(conn_rec *c)
-{
-    h2_conn_ctx_t *conn_ctx = h2_conn_ctx_get(c);
-
-    if (conn_ctx) {
-        if (conn_ctx->mplx_pool) {
-            apr_pool_destroy(conn_ctx->mplx_pool);
-            conn_ctx->mplx_pool = NULL;
-        }
-        ap_set_module_config(c->conn_config, &http2_module, NULL);
-    }
 }
 
 void h2_conn_ctx_set_timeout(h2_conn_ctx_t *conn_ctx, apr_interval_time_t timeout)

--- a/modules/http2/h2_conn_ctx.h
+++ b/modules/http2/h2_conn_ctx.h
@@ -22,6 +22,7 @@ struct h2_stream;
 struct h2_mplx;
 struct h2_bucket_beam;
 struct h2_response_parser;
+struct h2_c2_transit;
 
 #define H2_PIPE_OUT     0
 #define H2_PIPE_IN      1
@@ -40,6 +41,7 @@ struct h2_conn_ctx_t {
     const char *protocol;           /* c1: the protocol negotiated */
     struct h2_session *session;     /* c1: the h2 session established */
     struct h2_mplx *mplx;           /* c2: the multiplexer */
+    struct h2_c2_transit *transit;  /* c2: transit pool and bucket_alloc */
 
     int pre_conn_done;               /* has pre_connection setup run? */
     int stream_id;                  /* c1: 0, c2: stream id processed */
@@ -81,9 +83,8 @@ typedef struct h2_conn_ctx_t h2_conn_ctx_t;
 h2_conn_ctx_t *h2_conn_ctx_create_for_c1(conn_rec *c, server_rec *s, const char *protocol);
 
 apr_status_t h2_conn_ctx_init_for_c2(h2_conn_ctx_t **pctx, conn_rec *c,
-                                     struct h2_mplx *mplx, struct h2_stream *stream);
-
-void h2_conn_ctx_clear_for_c2(conn_rec *c2);
+                                     struct h2_mplx *mplx, struct h2_stream *stream,
+                                     struct h2_c2_transit *transit);
 
 void h2_conn_ctx_detach(conn_rec *c);
 

--- a/modules/http2/h2_conn_ctx.h
+++ b/modules/http2/h2_conn_ctx.h
@@ -48,12 +48,9 @@ struct h2_conn_ctx_t {
     struct h2_bucket_beam *beam_out; /* c2: data out, created from req_pool */
     struct h2_bucket_beam *beam_in;  /* c2: data in or NULL, borrowed from request stream */
 
-    apr_pool_t *mplx_pool;           /* c2: an mplx child pool for safe use inside mplx lock */
     apr_file_t *pipe_in_prod[2];     /* c2: input produced notification pipe */
-    apr_file_t *pipe_in_drain[2];    /* c2: input drained notification pipe */
     apr_file_t *pipe_out_prod[2];    /* c2: output produced notification pipe */
 
-    apr_pollfd_t pfd_in_drain;       /* c2: poll pipe_in_drain output */
     apr_pollfd_t pfd_out_prod;       /* c2: poll pipe_out_prod output */
 
     int has_final_response;          /* final HTTP response passed on out */
@@ -89,8 +86,6 @@ apr_status_t h2_conn_ctx_init_for_c2(h2_conn_ctx_t **pctx, conn_rec *c,
 void h2_conn_ctx_clear_for_c2(conn_rec *c2);
 
 void h2_conn_ctx_detach(conn_rec *c);
-
-void h2_conn_ctx_destroy(conn_rec *c);
 
 void h2_conn_ctx_set_timeout(h2_conn_ctx_t *conn_ctx, apr_interval_time_t timeout);
 

--- a/modules/http2/h2_conn_ctx.h
+++ b/modules/http2/h2_conn_ctx.h
@@ -58,9 +58,9 @@ struct h2_conn_ctx_t {
     int has_final_response;          /* final HTTP response passed on out */
     apr_status_t last_err;           /* APR_SUCCES or last error encountered in filters */
 
-    apr_uint32_t started;            /* c2: processing was started */
+    /* atomic */ apr_uint32_t started; /* c2: processing was started */
     apr_time_t started_at;           /* c2: when processing started */
-    apr_uint32_t done;               /* c2: processing has finished */
+    /* atomic */ apr_uint32_t done;  /* c2: processing has finished */
     apr_time_t done_at;              /* c2: when processing was done */
 };
 typedef struct h2_conn_ctx_t h2_conn_ctx_t;

--- a/modules/http2/h2_conn_ctx.h
+++ b/modules/http2/h2_conn_ctx.h
@@ -55,10 +55,10 @@ struct h2_conn_ctx_t {
 
     int has_final_response;          /* final HTTP response passed on out */
     apr_status_t last_err;           /* APR_SUCCES or last error encountered in filters */
-    struct h2_response_parser *parser; /* optional parser to catch H1 responses */
 
-    volatile int done;               /* c2: processing has finished */
+    apr_uint32_t started;            /* c2: processing was started */
     apr_time_t started_at;           /* c2: when processing started */
+    apr_uint32_t done;               /* c2: processing has finished */
     apr_time_t done_at;              /* c2: when processing was done */
 };
 typedef struct h2_conn_ctx_t h2_conn_ctx_t;

--- a/modules/http2/h2_mplx.h
+++ b/modules/http2/h2_mplx.h
@@ -83,11 +83,10 @@ struct h2_mplx {
     apr_array_header_t *streams_ev_in;
     apr_array_header_t *streams_ev_out;
 
-#if !H2_POLL_STREAMS
-    apr_thread_mutex_t *poll_lock; /* not the painter */
+    apr_thread_mutex_t *poll_lock; /* protect modifications of queues below */
     struct h2_iqueue *streams_input_read;  /* streams whose input has been read from */
     struct h2_iqueue *streams_output_written; /* streams whose output has been written to */
-#endif
+
     struct h2_workers *workers;     /* h2 workers process wide instance */
 
     request_rec *scratch_r;         /* pseudo request_rec for scoreboard reporting */

--- a/modules/http2/h2_mplx.h
+++ b/modules/http2/h2_mplx.h
@@ -44,6 +44,13 @@ struct h2_iqueue;
 
 #include <apr_queue.h>
 
+typedef struct h2_c2_transit h2_c2_transit;
+
+struct h2_c2_transit {
+    apr_pool_t *pool;
+    apr_bucket_alloc_t *bucket_alloc;
+};
+
 typedef struct h2_mplx h2_mplx;
 
 struct h2_mplx {
@@ -90,6 +97,9 @@ struct h2_mplx {
     struct h2_workers *workers;     /* h2 workers process wide instance */
 
     request_rec *scratch_r;         /* pseudo request_rec for scoreboard reporting */
+
+    apr_size_t max_spare_transits;   /* max number of transit pools idling */
+    apr_array_header_t *c2_transits; /* base pools for running c2 connections */
 };
 
 apr_status_t h2_mplx_c1_child_init(apr_pool_t *pool, server_rec *s);

--- a/modules/http2/h2_stream.c
+++ b/modules/http2/h2_stream.c
@@ -573,11 +573,8 @@ void h2_stream_destroy(h2_stream *stream)
 void h2_stream_rst(h2_stream *stream, int error_code)
 {
     stream->rst_error = error_code;
-    if (stream->input) {
-        h2_beam_abort(stream->input, stream->session->c1);
-    }
-    if (stream->output) {
-        h2_beam_abort(stream->output, stream->session->c1);
+    if (stream->c2) {
+        h2_c2_abort(stream->c2, stream->session->c1);
     }
     ap_log_cerror(APLOG_MARK, APLOG_TRACE1, 0, stream->session->c1,
                   H2_STRM_MSG(stream, "reset, error=%d"), error_code);

--- a/modules/http2/h2_workers.c
+++ b/modules/http2/h2_workers.c
@@ -40,7 +40,7 @@ struct h2_slot {
     apr_thread_t *thread;
     apr_thread_mutex_t *lock;
     apr_thread_cond_t *not_idle;
-    volatile apr_uint32_t timed_out;
+    apr_uint32_t timed_out;
 };
 
 static h2_slot *pop_slot(h2_slot *volatile *phead) 
@@ -99,7 +99,7 @@ static apr_status_t activate_slot(h2_workers *workers, h2_slot *slot)
     /* thread will either immediately start work or add itself
      * to the idle queue */
     apr_atomic_inc32(&workers->worker_count);
-    slot->timed_out = 0;
+    apr_atomic_set32(&slot->timed_out, 0);
     rv = ap_thread_create(&slot->thread, workers->thread_attr,
                           slot_run, slot, workers->pool);
     if (rv != APR_SUCCESS) {
@@ -127,10 +127,9 @@ static void wake_idle_worker(h2_workers *workers)
 {
     h2_slot *slot = pop_slot(&workers->idle);
     if (slot) {
-        int timed_out = 0;
+        int timed_out;
         apr_thread_mutex_lock(slot->lock);
-        timed_out = slot->timed_out;
-        if (!timed_out) {
+        if ((timed_out = apr_atomic_read32(&slot->timed_out)) == 0) {
             apr_thread_cond_signal(slot->not_idle);
         }
         apr_thread_mutex_unlock(slot->lock);
@@ -139,7 +138,7 @@ static void wake_idle_worker(h2_workers *workers)
             wake_idle_worker(workers);
         }
     }
-    else if (workers->dynamic && !workers->shutdown) {
+    else if (workers->dynamic && apr_atomic_read32(&workers->shutdown) == 0) {
         add_worker(workers);
     }
 }
@@ -190,9 +189,10 @@ static int get_next(h2_slot *slot)
     int non_essential = slot->id >= workers->min_workers;
     apr_status_t rv;
 
-    while (!workers->aborted && !slot->timed_out) {
+    while (apr_atomic_read32(&workers->aborted) == 0
+        && apr_atomic_read32(&slot->timed_out) == 0) {
         ap_assert(slot->connection == NULL);
-        if (non_essential && workers->shutdown) {
+        if (non_essential && apr_atomic_read32(&workers->shutdown)) {
             /* Terminate non-essential worker on shutdown */
             break;
         }
@@ -208,14 +208,16 @@ static int get_next(h2_slot *slot)
         join_zombies(workers);
 
         apr_thread_mutex_lock(slot->lock);
-        if (!workers->aborted) {
+        if (apr_atomic_read32(&workers->aborted) == 0) {
+            apr_uint32_t idle_secs;
 
             push_slot(&workers->idle, slot);
-            if (non_essential && workers->max_idle_duration) {
+            if (non_essential
+                && (idle_secs = apr_atomic_read32(&workers->max_idle_secs))) {
                 rv = apr_thread_cond_timedwait(slot->not_idle, slot->lock,
-                                               workers->max_idle_duration);
+                                               apr_time_from_sec(idle_secs));
                 if (APR_TIMEUP == rv) {
-                    slot->timed_out = 1;
+                    apr_atomic_set32(&slot->timed_out, 1);
                 }
             }
             else {
@@ -237,7 +239,8 @@ static void slot_done(h2_slot *slot)
     /* If this worker is the last one exiting and the MPM child is stopping,
      * unblock workers_pool_cleanup().
      */
-    if (!apr_atomic_dec32(&workers->worker_count) && workers->aborted) {
+    if (!apr_atomic_dec32(&workers->worker_count)
+        && apr_atomic_read32(&workers->aborted)) {
         apr_thread_mutex_lock(workers->lock);
         apr_thread_cond_signal(workers->all_done);
         apr_thread_mutex_unlock(workers->lock);
@@ -254,7 +257,7 @@ static void* APR_THREAD_FUNC slot_run(apr_thread_t *thread, void *wctx)
         do {
             ap_assert(slot->connection != NULL);
             h2_c2_process(slot->connection, thread, slot->id);
-            if (!slot->workers->aborted &&
+            if (apr_atomic_read32(&slot->workers->aborted) == 0 &&
                 apr_atomic_read32(&slot->workers->worker_count) < slot->workers->max_workers) {
                 h2_mplx_worker_c2_done(slot->connection, &slot->connection);
             }
@@ -265,7 +268,7 @@ static void* APR_THREAD_FUNC slot_run(apr_thread_t *thread, void *wctx)
         } while (slot->connection);
     }
 
-    if (!slot->timed_out) {
+    if (apr_atomic_read32(&slot->timed_out) == 0) {
         slot_done(slot);
     }
 
@@ -294,8 +297,8 @@ static void workers_abort_idle(h2_workers *workers)
 {
     h2_slot *slot;
 
-    workers->shutdown = 1;
-    workers->aborted = 1;
+    apr_atomic_set32(&workers->shutdown, 1);
+    apr_atomic_set32(&workers->aborted, 1);
     h2_fifo_term(workers->mplxs);
 
     /* abort all idle slots */
@@ -379,12 +382,12 @@ h2_workers *h2_workers_create(server_rec *s, apr_pool_t *pchild,
     workers->pool = pool;
     workers->min_workers = min_workers;
     workers->max_workers = max_workers;
-    workers->max_idle_duration = apr_time_from_sec((idle_secs > 0)? idle_secs : 10);
+    workers->max_idle_secs = (idle_secs > 0)? idle_secs : 10;
 
     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, workers->s,
                  "h2_workers: created with min=%d max=%d idle_timeout=%d sec",
                  workers->min_workers, workers->max_workers,
-                 (int)apr_time_sec(workers->max_idle_duration));
+                 (int)workers->max_idle_secs);
     /* FIXME: the fifo set we use here has limited capacity. Once the
      * set is full, connections with new requests do a wait.
      */
@@ -460,7 +463,7 @@ apr_status_t h2_workers_unregister(h2_workers *workers, struct h2_mplx *m)
 
 void h2_workers_graceful_shutdown(h2_workers *workers)
 {
-    workers->shutdown = 1;
-    workers->max_idle_duration = apr_time_from_sec(1);
+    apr_atomic_set32(&workers->shutdown, 1);
+    apr_atomic_set32(&workers->max_idle_secs, 1);
     wake_non_essential_workers(workers);
 }

--- a/modules/http2/h2_workers.h
+++ b/modules/http2/h2_workers.h
@@ -39,10 +39,10 @@ struct h2_workers {
     int next_worker_id;
     apr_uint32_t max_workers;
     apr_uint32_t min_workers;
-    apr_uint32_t worker_count;
-    apr_uint32_t max_idle_secs;
-    apr_uint32_t aborted;
-    apr_uint32_t shutdown;
+    /* atomic */ apr_uint32_t worker_count;
+    /* atomic */ apr_uint32_t max_idle_secs;
+    /* atomic */ apr_uint32_t aborted;
+    /* atomic */ apr_uint32_t shutdown;
     int dynamic;
 
     apr_threadattr_t *thread_attr;

--- a/modules/http2/h2_workers.h
+++ b/modules/http2/h2_workers.h
@@ -38,19 +38,17 @@ struct h2_workers {
     
     int next_worker_id;
     apr_uint32_t max_workers;
-    volatile apr_uint32_t min_workers; /* is changed during graceful shutdown */
-    volatile apr_interval_time_t max_idle_duration; /* is changed during graceful shutdown */
-    
-    volatile int aborted;
-    volatile int shutdown;
+    apr_uint32_t min_workers;
+    apr_uint32_t worker_count;
+    apr_uint32_t max_idle_secs;
+    apr_uint32_t aborted;
+    apr_uint32_t shutdown;
     int dynamic;
 
     apr_threadattr_t *thread_attr;
     int nslots;
     struct h2_slot *slots;
-    
-    volatile apr_uint32_t worker_count;
-    
+
     struct h2_slot *free;
     struct h2_slot *idle;
     struct h2_slot *zombies;

--- a/server/connection.c
+++ b/server/connection.c
@@ -35,6 +35,7 @@ APR_HOOK_STRUCT(
             APR_HOOK_LINK(process_connection)
             APR_HOOK_LINK(pre_connection)
             APR_HOOK_LINK(pre_close_connection)
+            APR_HOOK_LINK(create_secondary_connection)
 )
 AP_IMPLEMENT_HOOK_RUN_FIRST(conn_rec *,create_connection,
                             (apr_pool_t *p, server_rec *server, apr_socket_t *csd, long conn_id, void *sbh, apr_bucket_alloc_t *alloc),
@@ -42,6 +43,9 @@ AP_IMPLEMENT_HOOK_RUN_FIRST(conn_rec *,create_connection,
 AP_IMPLEMENT_HOOK_RUN_FIRST(int,process_connection,(conn_rec *c),(c),DECLINED)
 AP_IMPLEMENT_HOOK_RUN_ALL(int,pre_connection,(conn_rec *c, void *csd),(c, csd),OK,DECLINED)
 AP_IMPLEMENT_HOOK_RUN_ALL(int,pre_close_connection,(conn_rec *c),(c),OK,DECLINED)
+AP_IMPLEMENT_HOOK_RUN_FIRST(conn_rec *,create_secondary_connection,
+                            (apr_pool_t *p, conn_rec *master, apr_bucket_alloc_t *alloc),
+                            (p, master, alloc), NULL)
 
 AP_DECLARE(conn_rec *) ap_create_connection(apr_pool_t *p,
                                             server_rec *server,
@@ -64,6 +68,13 @@ AP_DECLARE(conn_rec *) ap_create_connection(apr_pool_t *p,
     }
 
     return c;
+}
+
+AP_DECLARE(conn_rec *) ap_create_secondary_connection(apr_pool_t *p,
+                                                      conn_rec *master,
+                                                      apr_bucket_alloc_t *alloc)
+{
+    return ap_run_create_secondary_connection(p, master, alloc);
 }
 
 /*

--- a/server/core.c
+++ b/server/core.c
@@ -5525,7 +5525,7 @@ static conn_rec *core_create_secondary_conn(apr_pool_t *ptrans,
 {
     apr_pool_t *pool;
     conn_config_t *conn_config;
-    conn_rec *c = (conn_rec *) apr_pcalloc(ptrans, sizeof(conn_rec));
+    conn_rec *c = (conn_rec *) apr_pmemdup(ptrans, master, sizeof(*c));
 
     /* Got a connection structure, so initialize what fields we can
      * (the rest are zeroed out by pcalloc).
@@ -5533,8 +5533,7 @@ static conn_rec *core_create_secondary_conn(apr_pool_t *ptrans,
     apr_pool_create(&pool, ptrans);
     apr_pool_tag(pool, "secondary_conn");
 
-    /* first copy everything, then replace what is needed */
-    memcpy(c, master, sizeof(*c));
+    /* we copied everything, now replace what is different */
     c->master = master;
     c->pool = pool;
     c->bucket_alloc = alloc;

--- a/server/core.c
+++ b/server/core.c
@@ -147,6 +147,8 @@ typedef struct {
     struct ap_logconf log;
 } conn_log_config;
 
+static apr_socket_t *dummy_socket;
+
 static void *create_core_dir_config(apr_pool_t *a, char *dir)
 {
     core_dir_config *conf;
@@ -5517,6 +5519,55 @@ static conn_rec *core_create_conn(apr_pool_t *ptrans, server_rec *s,
     return c;
 }
 
+static conn_rec *core_create_secondary_conn(apr_pool_t *ptrans,
+                                            conn_rec *master,
+                                            apr_bucket_alloc_t *alloc)
+{
+    apr_pool_t *pool;
+    conn_config_t *conn_config;
+    conn_rec *c = (conn_rec *) apr_pcalloc(ptrans, sizeof(conn_rec));
+
+    /* Got a connection structure, so initialize what fields we can
+     * (the rest are zeroed out by pcalloc).
+     */
+    apr_pool_create(&pool, ptrans);
+    apr_pool_tag(pool, "secondary_conn");
+
+    /* first copy everything, then replace what is needed */
+    memcpy(c, master, sizeof(*c));
+    c->master = master;
+    c->pool = pool;
+    c->bucket_alloc = alloc;
+    c->conn_config = ap_create_conn_config(pool);
+    c->notes = apr_table_make(pool, 5);
+    c->slaves = apr_array_make(pool, 20, sizeof(conn_slave_rec *));
+    c->requests = apr_array_make(pool, 20, sizeof(request_rec *));
+    c->input_filters = NULL;
+    c->output_filters = NULL;
+    c->filter_conn_ctx = NULL;
+
+    /* prevent mpm_event from making wrong assumptions about this connection,
+     * like e.g. using its socket for an async read check. */
+    c->clogging_input_filters = 1;
+
+    c->log = NULL;
+    c->aborted = 0;
+    c->keepalives = 0;
+
+    /* FIXME: mpms (and maybe other) parts think that there is always
+     * a socket for a connection. We cannot use the master socket for
+     * secondary connections, as this gets modified (closed?) when
+     * the secondary connection terminates.
+     * There seem to be some checks for c->master necessary in other
+     * places.
+     */
+    conn_config = apr_pcalloc(pool, sizeof(*conn_config));
+    conn_config->socket = dummy_socket;
+    ap_set_core_module_config(c->conn_config, conn_config);
+
+    return c;
+}
+
 static int core_pre_connection(conn_rec *c, void *csd)
 {
     conn_config_t *conn_config;
@@ -5670,6 +5721,11 @@ static void core_child_init(apr_pool_t *pchild, server_rec *s)
      */
     proc.pid = getpid();
     apr_random_after_fork(&proc);
+
+    /* needed for secondary connections so people do not change the master
+     * connection socket. */
+    apr_socket_create(&dummy_socket, APR_INET, SOCK_STREAM,
+                      APR_PROTO_TCP, pchild);
 }
 
 static void core_optional_fn_retrieve(void)
@@ -5905,6 +5961,8 @@ static void register_hooks(apr_pool_t *p)
      */
     ap_hook_create_connection(core_create_conn, NULL, NULL,
                               APR_HOOK_REALLY_LAST);
+    ap_hook_create_secondary_connection(core_create_secondary_conn, NULL, NULL,
+                                        APR_HOOK_REALLY_LAST);
     ap_hook_pre_connection(core_pre_connection, NULL, NULL,
                            APR_HOOK_REALLY_LAST);
 

--- a/test/modules/http2/test_711_load_post_cgi.py
+++ b/test/modules/http2/test_711_load_post_cgi.py
@@ -25,7 +25,7 @@ class TestLoadCgi:
         assert 0 == r.results["h2load"]["status"]["5xx"]
     
     # test POST on cgi, where input is read
-    def test_h2_711_10(self, env):
+    def test_h2_711_10(self, env, repeat):
         url = env.mkurl("https", "test1", "/echo.py")
         n = 100
         m = 5
@@ -40,7 +40,7 @@ class TestLoadCgi:
         self.check_h2load_ok(env, r, n)
 
     # test POST on cgi via http/1.1 proxy, where input is read
-    def test_h2_711_11(self, env):
+    def test_h2_711_11(self, env, repeat):
         url = env.mkurl("https", "test1", "/proxy/echo.py")
         n = 100
         m = 5
@@ -55,7 +55,7 @@ class TestLoadCgi:
         self.check_h2load_ok(env, r, n)
 
     # test POST on cgi via h2proxy, where input is read
-    def test_h2_711_12(self, env):
+    def test_h2_711_12(self, env, repeat):
         url = env.mkurl("https", "test1", "/h2proxy/echo.py")
         n = 100
         m = 5


### PR DESCRIPTION
 * `core`: add hook `create_secondary_connection` and method to core, since the implementation details for those connections to a master one belong there.
 *  `mod_http2`: use new hook and also recycle transit pools/bucket_alloc for those connections.
 *  `mod_http2`: improvements in pollset handling for secondary connections.
 