### PR TITLE
  *) mod_http2: use pollset only for main connection and wakeups

### DIFF
--- a/modules/http2/h2.h
+++ b/modules/http2/h2.h
@@ -59,11 +59,10 @@ struct h2_stream;
  * are used for many consecutive requests where
  * pollsets stay unchanged much longer.
  */
-#define H2_NO_POLL_STREAMS        1
-#ifdef H2_NO_POLL_STREAMS
-#define H2_POLL_STREAMS           0
+#ifdef H2_NO_PIPES
+#define H2_USE_PIPES            0
 #else
-#define H2_POLL_STREAMS           (APR_FILES_AS_SOCKETS && APR_VERSION_AT_LEAST(1,6,0))
+#define H2_USE_PIPES            (APR_FILES_AS_SOCKETS && APR_VERSION_AT_LEAST(1,6,0))
 #endif
 
 /**

--- a/modules/http2/h2_c2.c
+++ b/modules/http2/h2_c2.c
@@ -225,12 +225,12 @@ static apr_status_t h2_c2_filter_in(ap_filter_t* f,
                           conn_ctx->id, conn_ctx->stream_id, block, (long)readbytes);
         }
         if (conn_ctx->beam_in) {
-            if (conn_ctx->pipe_in_prod[H2_PIPE_OUT]) {
+            if (conn_ctx->pipe_in[H2_PIPE_OUT]) {
 receive:
                 status = h2_beam_receive(conn_ctx->beam_in, f->c, fctx->bb, APR_NONBLOCK_READ,
                                          conn_ctx->mplx->stream_max_mem);
                 if (APR_STATUS_IS_EAGAIN(status) && APR_BLOCK_READ == block) {
-                    status = h2_util_wait_on_pipe(conn_ctx->pipe_in_prod[H2_PIPE_OUT]);
+                    status = h2_util_wait_on_pipe(conn_ctx->pipe_in[H2_PIPE_OUT]);
                     if (APR_SUCCESS == status) {
                         goto receive;
                     }

--- a/modules/http2/h2_conn_ctx.c
+++ b/modules/http2/h2_conn_ctx.c
@@ -58,11 +58,11 @@ h2_conn_ctx_t *h2_conn_ctx_create_for_c1(conn_rec *c1, server_rec *s, const char
     ctx->server = s;
     ctx->protocol = apr_pstrdup(c1->pool, protocol);
 
-    ctx->pfd_out_prod.desc_type = APR_POLL_SOCKET;
-    ctx->pfd_out_prod.desc.s = ap_get_conn_socket(c1);
-    apr_socket_opt_set(ctx->pfd_out_prod.desc.s, APR_SO_NONBLOCK, 1);
-    ctx->pfd_out_prod.reqevents = APR_POLLIN | APR_POLLERR | APR_POLLHUP;
-    ctx->pfd_out_prod.client_data = ctx;
+    ctx->pfd.desc_type = APR_POLL_SOCKET;
+    ctx->pfd.desc.s = ap_get_conn_socket(c1);
+    ctx->pfd.reqevents = APR_POLLIN | APR_POLLERR | APR_POLLHUP;
+    ctx->pfd.client_data = ctx;
+    apr_socket_opt_set(ctx->pfd.desc.s, APR_SO_NONBLOCK, 1);
 
     return ctx;
 }
@@ -107,14 +107,10 @@ void h2_conn_ctx_set_timeout(h2_conn_ctx_t *conn_ctx, apr_interval_time_t timeou
     if (conn_ctx->beam_out) {
         h2_beam_timeout_set(conn_ctx->beam_out, timeout);
     }
-    if (conn_ctx->pipe_out_prod[H2_PIPE_OUT]) {
-        apr_file_pipe_timeout_set(conn_ctx->pipe_out_prod[H2_PIPE_OUT], timeout);
-    }
-
     if (conn_ctx->beam_in) {
         h2_beam_timeout_set(conn_ctx->beam_in, timeout);
     }
-    if (conn_ctx->pipe_in_prod[H2_PIPE_OUT]) {
-        apr_file_pipe_timeout_set(conn_ctx->pipe_in_prod[H2_PIPE_OUT], timeout);
+    if (conn_ctx->pipe_in[H2_PIPE_OUT]) {
+        apr_file_pipe_timeout_set(conn_ctx->pipe_in[H2_PIPE_OUT], timeout);
     }
 }

--- a/modules/http2/h2_conn_ctx.h
+++ b/modules/http2/h2_conn_ctx.h
@@ -50,10 +50,8 @@ struct h2_conn_ctx_t {
     struct h2_bucket_beam *beam_out; /* c2: data out, created from req_pool */
     struct h2_bucket_beam *beam_in;  /* c2: data in or NULL, borrowed from request stream */
 
-    apr_file_t *pipe_in_prod[2];     /* c2: input produced notification pipe */
-    apr_file_t *pipe_out_prod[2];    /* c2: output produced notification pipe */
-
-    apr_pollfd_t pfd_out_prod;       /* c2: poll pipe_out_prod output */
+    apr_file_t *pipe_in[2];          /* c2: input produced notification pipe */
+    apr_pollfd_t pfd;                /* c1: poll socket input, c2: NUL */
 
     int has_final_response;          /* final HTTP response passed on out */
     apr_status_t last_err;           /* APR_SUCCES or last error encountered in filters */

--- a/modules/http2/h2_mplx.h
+++ b/modules/http2/h2_mplx.h
@@ -86,7 +86,6 @@ struct h2_mplx {
     struct apr_thread_cond_t *join_wait;
     
     apr_pollset_t *pollset;         /* pollset for c1/c2 IO events */
-    apr_array_header_t *streams_to_poll; /* streams to add to the pollset */
     apr_array_header_t *streams_ev_in;
     apr_array_header_t *streams_ev_out;
 


### PR DESCRIPTION
     for events on streams. Provide streams in INPUT pipe when
     needed and supported on the platform.

This is based on feedback by @ylavic on PR #297.