### PR TITLE
Fix possible NULL pointer dereference casued by apreq_param_make()

### DIFF
--- a/server/apreq_module_cgi.c
+++ b/server/apreq_module_cgi.c
@@ -560,6 +560,8 @@ static apr_status_t cgi_args(apreq_handle_t *handle,
             if (val == NULL)
                 val = "";
             p = apreq_param_make(handle->pool, name, strlen(name), val, strlen(val));
+            if (p == NULL)
+                return APR_ENOMEM;
             apreq_param_tainted_on(p);
             apreq_value_table_add(&p->v, req->args);
             val = p->v.data;
@@ -638,6 +640,8 @@ static apreq_param_t *cgi_args_get(apreq_handle_t *handle,
             if (val == NULL)
                 return NULL;
             p = apreq_param_make(handle->pool, name, strlen(name), val, strlen(val));
+            if (p == NULL)
+                return NULL;
             apreq_param_tainted_on(p);
             apreq_value_table_add(&p->v, req->args);
             val = p->v.data;
@@ -674,6 +678,8 @@ static apr_status_t cgi_body(apreq_handle_t *handle,
             if (val == NULL)
                 val = "";
             p = apreq_param_make(handle->pool, name, strlen(name), val, strlen(val));
+            if (p == NULL)
+                return APR_ENOMEM;
             apreq_param_tainted_on(p);
             apreq_value_table_add(&p->v, req->body);
             val = p->v.data;
@@ -716,6 +722,8 @@ static apreq_param_t *cgi_body_get(apreq_handle_t *handle,
             if (val == NULL)
                 return NULL;
             p = apreq_param_make(handle->pool, name, strlen(name), val, strlen(val));
+            if (p == NULL)
+                return NULL;
             apreq_param_tainted_on(p);
             apreq_value_table_add(&p->v, req->body);
             val = p->v.data;

--- a/server/apreq_parser.c
+++ b/server/apreq_parser.c
@@ -228,6 +228,8 @@ APREQ_DECLARE_PARSER(apreq_parse_generic)
         ctx->status = GEN_INCOMPLETE;
         ctx->param = apreq_param_make(pool,
                                       "_dummy_", strlen("_dummy_"), "", 0);
+        if (ctx->param == NULL)
+            return APR_ENOMEM;
         ctx->param->upload = apr_brigade_create(pool, parser->bucket_alloc);
         ctx->param->info = apr_table_make(pool, APREQ_DEFAULT_NELTS);
     }

--- a/server/apreq_parser_header.c
+++ b/server/apreq_parser_header.c
@@ -84,6 +84,8 @@ static apr_status_t consume_header_line(apreq_param_t **p,
     int i, eol = 0;
 
     param = apreq_param_make(pool, NULL, nlen, NULL, vlen);
+    if (param == NULL)
+        return APR_ENOMEM;
     *(const apreq_value_t **)&v = &param->v;
 
     arr.pool     = pool;

--- a/server/apreq_parser_multipart.c
+++ b/server/apreq_parser_multipart.c
@@ -472,6 +472,8 @@ APREQ_DECLARE_PARSER(apreq_parse_multipart)
 
                     param = apreq_param_make(pool, name, nlen,
                                              filename, flen);
+                    if (param == NULL)
+                        return APR_ENOMEM;
                     apreq_param_tainted_on(param);
                     param->info = ctx->info;
                     param->upload
@@ -505,6 +507,8 @@ APREQ_DECLARE_PARSER(apreq_parse_multipart)
                 nlen = strlen(name);
                 param = apreq_param_make(pool, name, nlen,
                                          filename, flen);
+                if (param == NULL)
+                    return APR_ENOMEM;
                 apreq_param_tainted_on(param);
                 param->info = ctx->info;
                 param->upload = apr_brigade_create(pool,
@@ -532,6 +536,8 @@ APREQ_DECLARE_PARSER(apreq_parse_multipart)
                 flen = 0;
                 param = apreq_param_make(pool, name, nlen,
                                          filename, flen);
+                if (param == NULL)
+                    return APR_ENOMEM;
                 apreq_param_tainted_on(param);
                 param->info = ctx->info;
                 param->upload = apr_brigade_create(pool,
@@ -569,6 +575,8 @@ APREQ_DECLARE_PARSER(apreq_parse_multipart)
                 param = apreq_param_make(pool, ctx->param_name,
                                          strlen(ctx->param_name),
                                          NULL, len);
+                if (param == NULL)
+                    return APR_ENOMEM;
                 apreq_param_tainted_on(param);
                 param->info = ctx->info;
 

--- a/server/apreq_parser_urlencoded.c
+++ b/server/apreq_parser_urlencoded.c
@@ -64,6 +64,8 @@ static apr_status_t split_urlword(apreq_param_t **p, apr_pool_t *pool,
         return APR_EBADARG;
 
     param = apreq_param_make(pool, NULL, nlen, NULL, vlen);
+    if (param == NULL)
+        return APR_ENOMEM;
     *(const apreq_value_t **)&v = &param->v;
 
     arr.pool     = pool;


### PR DESCRIPTION
The function apreq_param_make() will return NULL on failure. However
NULL check are forgetten before derenference, which could lead to
NULL pointer dereference.

Adding NULL check to all use of apreq_param_make().