### PR TITLE
Use RESPONSE buckets to send HTTP responses out

### DIFF
--- a/include/mod_core.h
+++ b/include/mod_core.h
@@ -31,6 +31,7 @@
 #include "apr_buckets.h"
 
 #include "httpd.h"
+#include "http_protocol.h"
 #include "util_filter.h"
 
 
@@ -56,6 +57,9 @@ apr_status_t ap_http_filter(ap_filter_t *f, apr_bucket_brigade *b,
 apr_status_t ap_h1_body_in_filter(ap_filter_t *f, apr_bucket_brigade *b,
                                      ap_input_mode_t mode, apr_read_type_e block,
                                      apr_off_t readbytes);
+
+/* HTTP/1.1 response formatting filter. */
+apr_status_t ap_h1_response_out_filter(ap_filter_t *f, apr_bucket_brigade *b);
 
 /* HTTP/1.1 chunked transfer encoding filter. */
 apr_status_t ap_http_chunk_filter(ap_filter_t *f, apr_bucket_brigade *b);
@@ -99,6 +103,14 @@ AP_DECLARE_DATA extern const char *ap_multipart_boundary;
 AP_CORE_DECLARE(void) ap_init_rng(apr_pool_t *p);
 /* Update RNG state in parent after fork */
 AP_CORE_DECLARE(void) ap_random_parent_after_fork(void);
+
+/**
+ * Set the keepalive status for this request based on the response
+ * @param r The current request
+ * @param resp The response being send
+ * @return 1 if keepalive can be set, 0 otherwise
+ */
+AP_CORE_DECLARE(int) ap_h1_set_keepalive(request_rec *r, ap_bucket_response *resp);
 
 #ifdef __cplusplus
 }

--- a/modules/http/http_filters.c
+++ b/modules/http/http_filters.c
@@ -1944,7 +1944,7 @@ AP_CORE_DECLARE_NONSTD(apr_status_t) ap_h1_response_out_filter(ap_filter_t *f,
         else if (!ctx->final_response_sent && strict) {
             /* data buckets before seeing the final response are in error.
              */
-            ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, APLOGNO()
+            ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, APLOGNO(10390)
                           "ap_http1_response_out_filter seeing data before headers, %ld bytes ",
                           (long)e->length);
             rv = AP_FILTER_ERROR;

--- a/server/protocol.c
+++ b/server/protocol.c
@@ -2386,26 +2386,6 @@ typedef struct hdr_ptr {
 } hdr_ptr;
 
  
-#if APR_CHARSET_EBCDIC
-static int send_header(void *data, const char *key, const char *val)
-{
-    char *header_line = NULL;
-    hdr_ptr *hdr = (hdr_ptr*)data;
-
-    header_line = apr_pstrcat(hdr->bb->p, key, ": ", val, CRLF, NULL);
-    ap_xlate_proto_to_ascii(header_line, strlen(header_line));
-    ap_fputs(hdr->f, hdr->bb, header_line);
-    return 1;
-}
-#else
-static int send_header(void *data, const char *key, const char *val)
-{
-     ap_fputstrs(((hdr_ptr*)data)->f, ((hdr_ptr*)data)->bb,
-                 key, ": ", val, CRLF, NULL);
-     return 1;
- }
-#endif
-
 AP_DECLARE(void) ap_set_std_response_headers(request_rec *r)
 {
     const char *server = NULL, *date;
@@ -2440,10 +2420,10 @@ AP_DECLARE(void) ap_set_std_response_headers(request_rec *r)
 
 AP_DECLARE(void) ap_send_interim_response(request_rec *r, int send_headers)
 {
-    hdr_ptr x;
-    char *response_line = NULL;
-    const char *status_line;
     request_rec *rr;
+    apr_bucket *b;
+    apr_bucket_brigade *bb;
+    const char *reason = NULL;
 
     if (r->proto_num < HTTP_VERSION(1,1)) {
         /* don't send interim response to HTTP/1.0 Client */
@@ -2473,26 +2453,26 @@ AP_DECLARE(void) ap_send_interim_response(request_rec *r, int send_headers)
         }
     }
 
-    status_line = r->status_line;
-    if (status_line == NULL) {
-        status_line = ap_get_status_line_ex(r->pool, r->status);
-    }
-    response_line = apr_pstrcat(r->pool,
-                                AP_SERVER_PROTOCOL " ", status_line, CRLF,
-                                NULL);
-    ap_xlate_proto_to_ascii(response_line, strlen(response_line));
-
-    x.f = r->connection->output_filters;
-    x.bb = apr_brigade_create(r->pool, r->connection->bucket_alloc);
-
-    ap_fputs(x.f, x.bb, response_line);
+    ap_log_rerror(APLOG_MARK, APLOG_TRACE2, 0, r,
+                  "ap_send_interim_response: send %d", r->status);
+    bb = apr_brigade_create(r->pool, r->connection->bucket_alloc);
     if (send_headers) {
-        apr_table_do(send_header, &x, r->headers_out, NULL);
+        ap_set_std_response_headers(r);
+    }
+    if (r->status_line && strlen(r->status_line) > 4) {
+        reason = r->status_line + 4;
+    }
+    b = ap_bucket_response_create(r->status, reason,
+                                  send_headers? r->headers_out : NULL,
+                                  r->notes, r->pool, r->connection->bucket_alloc);
+    APR_BRIGADE_INSERT_TAIL(bb, b);
+    if (send_headers) {
         apr_table_clear(r->headers_out);
     }
-    ap_fputs(x.f, x.bb, CRLF_ASCII);
-    ap_fflush(x.f, x.bb);
-    apr_brigade_destroy(x.bb);
+    b = apr_bucket_flush_create(r->connection->bucket_alloc);
+    APR_BRIGADE_INSERT_TAIL(bb, b);
+    ap_pass_brigade(r->proto_output_filters, bb);
+    apr_brigade_destroy(bb);
 }
 
 /*


### PR DESCRIPTION
## Abstract

  * core: use the new RESPONSE buckets to send out response     status, reason, headers and notes through the output filter from general HTTP protocol handling.
 *  mod_http: install a new HTTP1_RESPONSE_OUT output filter that transforms RESPONSE buckets to HTTP/1.1 format.

## Changes

In the core server, there are 2 places where response are written: 

1. `ap_http_header_filter()`: this is the standard output filter. As soon as it sees some data coming its way, it uses the status of the current `request_rec` to write the corresponding HTTP/1.1 response bytes. Irregardless of the actual protocol version in play.
1. `ap_send_interim_response()`: when a response status like 101 needs to be send, this function writes the HTTP/1.1 bytes onto the output stream.

No more. Instead, both places now create a RESPONSE meta bucket and write that to the output filters. How that gets converted into the correct bytes on the connection is the concern of protocol version specific filters. And indeed, for HTTP/1.x requests, there is a new output filter added that does exactly that. HTTP/2 will convert these meta buckets to the binary frames defined by the h2 protocol (not included in this PR).

## Motivation

There are many checks done in HTTP core that are not specific to version 1.1. The current design makes it difficult or impossible to reuse these checks in other protocol versions like h2. This leads to code duplication and a server more complicated than it needs to be.

While the HTTP/2 implementation could switch off the 1. case listed above, the intermediate response always arrived in HTTP/1.1 format. This was problematic, as h2 code need to *parse* output bytes to check if they looked like an intermediate response (it did not look at response bodies - if everything else works correctly - but it was a weakness and highly inefficient at best).

## Further Work

I have the HTTP/2 changes locally and tested but did not want them in this PR for an easier review by everyone interested. Also, the HTTP/1.x focussed parts should go into a new `mod_http1?` so our code structure reflects that we differentiate between pure HTTP and bytes on the wire.

Also outstanding is the use of the new REQUEST buckets for input.

