### PR TITLE
Fix a possible null pointer dereference in ap_expr_parse()

### DIFF
--- a/server/util_expr_eval.c
+++ b/server/util_expr_eval.c
@@ -592,7 +592,10 @@ AP_DECLARE(const char *) ap_expr_parse(apr_pool_t *pool, apr_pool_t *ptemp,
     ctx.lookup_fn   = lookup_fn ? lookup_fn : ap_expr_lookup_default;
     ctx.at_start    = 1;
 
-    ap_expr_yylex_init(&ctx.scanner);
+    rc = ap_expr_yylex_init(&ctx.scanner);
+    if (rc)
+        return "ap_expr_yylex_init error";
+
     ap_expr_yyset_extra(&ctx, ctx.scanner);
     rc = ap_expr_yyparse(&ctx);
     ap_expr_yylex_destroy(ctx.scanner);


### PR DESCRIPTION
In ap_expr_parse(), ap_expr_yylex_init() will return 1 on failure,
and ctx.scanner will remain NULL. However the return value of
ap_expr_yylex_init() is not checked, and there is a dereference of
ctx.scanner in following function ap_expr_yyset_extra(),
which may lead to NULL pointer dereference.

Fix this bug by adding return value check of ap_expr_yylex_init.