### PR TITLE
Add err return about set_allow_opts() in set_override()

### DIFF
--- a/server/core.c
+++ b/server/core.c
@@ -1895,8 +1895,10 @@ static const char *set_override(cmd_parms *cmd, void *d_, const char *l)
         }
         else if (!ap_cstr_casecmp(k, "Options")) {
             d->override |= OR_OPTIONS;
-            if (v)
-                set_allow_opts(cmd, &(d->override_opts), v);
+            if (v) {
+                if ((err = set_allow_opts(cmd, &(d->override_opts), v)) != NULL)
+                    return err;
+	    }
             else
                 d->override_opts = OPT_ALL;
         }


### PR DESCRIPTION
In set_override(), the return value of set_allow_opts() is not considered.

Fix this by adding an error check about set_allow_opts().