### PR TITLE
Remove libsystemd dependency from main httpd binary

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -831,7 +831,6 @@ case $host in
       if test "${ac_cv_header_systemd_sd_daemon_h}" = "no"; then
         AC_MSG_WARN([Your system does not support systemd.])
       else
-        APR_ADDTO(HTTPD_LIBS, [$SYSTEMD_LIBS])
         AC_DEFINE(HAVE_SYSTEMD, 1, [Define if systemd is supported])
       fi
    fi

--- a/include/ap_listen.h
+++ b/include/ap_listen.h
@@ -29,6 +29,7 @@
 #include "apr_network_io.h"
 #include "httpd.h"
 #include "http_config.h"
+#include "apr_optional.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -160,6 +161,15 @@ AP_DECLARE_NONSTD(const char *) ap_set_receive_buffer_size(cmd_parms *cmd,
 AP_DECLARE_NONSTD(const char *) ap_set_accept_errors_nonfatal(cmd_parms *cmd,
                                                            void *dummy,
                                                            int flag);
+
+#ifdef HAVE_SYSTEMD
+APR_DECLARE_OPTIONAL_FN(int,
+                        ap_find_systemd_socket, (process_rec *, apr_port_t));
+
+APR_DECLARE_OPTIONAL_FN(int,
+                        ap_systemd_listen_fds, (int));
+#endif
+
 
 #define LISTEN_COMMANDS \
 AP_INIT_TAKE1("ListenBacklog", ap_set_listenbacklog, NULL, RSRC_CONF, \

--- a/server/listen.c
+++ b/server/listen.c
@@ -364,6 +364,7 @@ static const char *set_systemd_listener(process_rec *process, apr_port_t port,
     ap_listen_rec *last, *new;
     apr_status_t rv;
     APR_OPTIONAL_FN_TYPE(ap_find_systemd_socket) *find_systemd_socket;
+    int fd;
 
     find_systemd_socket = APR_RETRIEVE_OPTIONAL_FN(ap_find_systemd_socket);
 
@@ -371,7 +372,7 @@ static const char *set_systemd_listener(process_rec *process, apr_port_t port,
        return "Systemd socket activation is used, but mod_systemd is probably "
                "not loaded";
 
-    int fd = find_systemd_socket(process, port);
+    fd = find_systemd_socket(process, port);
     if (fd < 0) {
         return "Systemd socket activation is used, but this port is not "
                 "configured in systemd";
@@ -1155,9 +1156,6 @@ AP_DECLARE_NONSTD(const char *) ap_set_listenbacklog(cmd_parms *cmd,
 {
     int b;
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
-#ifdef HAVE_SYSTEMD
-    APR_OPTIONAL_FN_TYPE(ap_systemd_listen_fds) *systemd_listen_fds;
-#endif
 
     if (err != NULL) {
         return err;


### PR DESCRIPTION
Until this change httpd was linking libsystemd to the main httpd binary. If you want to run lightweight version of httpd in container, sometimes you just want to install
httpd binary with as little dependencies as possible to make container small in size and do not pull uncencessary dependencies and libraries.

This change will move all systemd library calls from listen.c to mod_systemd module and remove systemd linking from the main httpd bin.