### PR TITLE
Correct JavaScript MIME types + extensions per RFC 9239

### DIFF
--- a/docs/conf/mime.types
+++ b/docs/conf/mime.types
@@ -142,7 +142,7 @@ application/ipfix				ipfix
 application/java-archive			jar
 application/java-serialized-object		ser
 application/java-vm				class
-application/javascript				js
+# application/javascript
 # application/jose
 # application/jose+json
 # application/jrd+json
@@ -1686,7 +1686,7 @@ text/csv					csv
 # text/fwdred
 # text/grammar-ref-list
 text/html					html htm
-# text/javascript
+text/javascript					js mjs
 # text/jcr-cnd
 # text/markdown
 # text/mizar


### PR DESCRIPTION
This patch updates the MIME type configuration per RFC 9239.
https://www.rfc-editor.org/rfc/rfc9239

First, the recommended MIME type is now `text/javascript`:

> The most widely supported media type in use is `text/javascript`; all
> others are considered historical and obsolete aliases of `text/javascript`.

Second, the `.mjs` extension is now explicitly registered:

> The `.mjs` file extension signals that the file represents a JavaScript
> module. Execution environments that rely on file extensions to
> determine how to process inputs parse `.mjs` files using the Module
> grammar of [ECMA-262].

IANA template: https://www.iana.org/assignments/media-types/text/javascript

Bug: https://bz.apache.org/bugzilla/show_bug.cgi?id=61383