### PR TITLE
h2: 64k initial window size

### DIFF
--- a/modules/http2/h2_config.c
+++ b/modules/http2/h2_config.c
@@ -90,7 +90,7 @@ typedef struct h2_dir_config {
 static h2_config defconf = {
     "default",
     100,                    /* max_streams */
-    H2_INITIAL_WINDOW_SIZE, /* window_size */
+    64 * 1024,              /* window_size */
     -1,                     /* min workers */
     -1,                     /* max workers */
     10 * 60,                /* max workers idle secs */


### PR DESCRIPTION
h2: 64k initial window size

change from RFC 7540 default 65535 (64k-1)

avoid some degenerative WINDOW_UPDATE behaviors in the wild
nghttp2/nghttp2#1722

Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>

---

Note: this patch changes the default initial window size for HTTP/2 streams, though this is configurable in Apache httpd and, if required for yet-as-unseen conditions, could be configured in httpd.conf back to the 65535 value specified by RFC 7540.

---

Related:
https://github.com/nghttp2/nghttp2/issues/1722
https://github.com/curl/curl/pull/8965
https://github.com/haproxy/haproxy/pull/1732
https://www.mail-archive.com/haproxy@formilux.org/msg42418.html