### PR TITLE
Make DirectorySlash always output a relative value.

### DIFF
--- a/modules/mappers/mod_dir.c
+++ b/modules/mappers/mod_dir.c
@@ -292,8 +292,8 @@ static int fixup_dir(request_rec *r)
                                 "/", NULL);
         }
 
-        apr_table_setn(r->headers_out, "Location",
-                       ap_construct_url(r->pool, ifile, r));
+        apr_table_setn(r->headers_out, "Location", ifile);
+
         return HTTP_MOVED_PERMANENTLY;
     }
 


### PR DESCRIPTION
Issue #61355: This causes DirectorySlash to create a relative Location
response header rather than an absolute one. Thus, httpd won’t
inadvertently downgrade TLS-secured connections to non-TLS connections
when it operates behind a (TLS-terminating) proxy.