### PR TITLE
  *) mod_ssl: when a proxy connection had handled a request using SSL…

### DIFF
--- a/changes-entries/ssl_proxy_bind.txt
+++ b/changes-entries/ssl_proxy_bind.txt
@@ -1,0 +1,5 @@
+  *) mod_ssl: when a proxy connection had handled a request using SSL, an
+     error was logged when "SSLProxyEngine" was only configured in the
+     location/proxy section and not the overall server. The connection
+     continued to work, the error log was in error. Fixed PR66190.
+     [Stefan Eissing]

--- a/modules/ssl/mod_ssl.c
+++ b/modules/ssl/mod_ssl.c
@@ -548,6 +548,13 @@ static int ssl_hook_ssl_bind_outgoing(conn_rec *c,
     int status;
 
     sslconn = ssl_init_connection_ctx(c, per_dir_config, 1);
+    if (sslconn->ssl) {
+        /* we are already bound to this connection. We have rebound
+         * or removed the reference to a previous per_dir_config,
+         * there is nothing more to do. */
+        return OK;
+    }
+
     status = ssl_engine_status(c, sslconn);
     if (enable_ssl) {
         if (status != OK) {

--- a/test/modules/proxy/test_01_http.py
+++ b/test/modules/proxy/test_01_http.py
@@ -71,7 +71,6 @@ class TestProxyHttp:
         assert r.response["status"] == 200
         assert r.json['host'] == seen
 
-    @pytest.mark.skip(reason="needs backport of r1903167")
     def test_proxy_01_003(self, env):
         domain = f"test1.{env.http_tld}"
         conf = HttpdConf(env)


### PR DESCRIPTION
…, an

     error was logged when "SSLProxyEngine" was only configured in the
     location/proxy section and not the overall server. The connection
     continued to work, the error log was in error. Fixed PR66190.