### PR TITLE
Add WebAssembly MIME type and file extension

### DIFF
--- a/docs/conf/mime.types
+++ b/docs/conf/mime.types
@@ -1212,6 +1212,7 @@ application/vnd.zul				zir zirz
 application/vnd.zzazz.deck+xml			zaz
 application/voicexml+xml			vxml
 # application/vq-rtcpxr
+application/wasm				wasm
 # application/watcherinfo+xml
 # application/whoispp-query
 # application/whoispp-response


### PR DESCRIPTION
Please add the WASM media type to httpd, along with its associated file extension. Many thanks.

* IANA registration: https://www.iana.org/assignments/media-types/application/wasm

See also:

* WASM in CPython: https://github.com/python/cpython/blob/main/Lib/mimetypes.py
* WASM in nginx: https://github.com/nginx/nginx/blob/master/conf/mime.types