### PR TITLE
Fix seperator in mod_session.c

### DIFF
--- a/modules/session/mod_session.c
+++ b/modules/session/mod_session.c
@@ -416,7 +416,7 @@ static apr_status_t session_identity_decode(request_rec * r, session_rec * z)
         const char *psep = "=";
         char *key = apr_strtok(pair, psep, &plast);
         if (key && *key) {
-            char *val = apr_strtok(NULL, sep, &plast);
+            char *val = apr_strtok(NULL, psep, &plast);
             if (!val || !*val) {
                 apr_table_unset(z->entries, key);
             }


### PR DESCRIPTION
In the previous commit fixing CVE-2021-26690 (67bd9bfe6c38831e14fe7122f1d84391472498f8), it introduced a seperator mistake.

https://github.com/apache/httpd/commit/67bd9bfe6c38831e14fe7122f1d84391472498f8

Though there is no exploit on this and it does not impact the functioning, the seperator in line 419 should be psep instead of sep because "=" is the seperator for pair. To prevent further issues, it should be fixed.