### PR TITLE
mod_remoteip: clear incoming RemoteIPProxiesHeader by default

### DIFF
--- a/modules/metadata/mod_remoteip.c
+++ b/modules/metadata/mod_remoteip.c
@@ -563,6 +563,13 @@ static int remoteip_modify_request(request_rec *r)
         return OK;
     }
 
+    /* Clear incoming RemoteIPProxiesHeader by default,
+     * to make sure this header is only set when trusted proxy is found
+     */
+    if (config->proxies_header_name) {
+        apr_table_unset(r->headers_in, config->proxies_header_name);
+    }
+
     if (config->proxymatch_ip) {
         /* This indicates that a RemoteIPInternalProxy, RemoteIPInternalProxyList, RemoteIPTrustedProxy
            or RemoteIPTrustedProxyList directive is configured.


### PR DESCRIPTION
[RemoteIPProxiesHeader](https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html#remoteipproxiesheader) can be used to collect addresses of intermediate trusted proxies. Unfortunately, it is impossible to distinguish, if this header was set by mod_remoteip (can be trusted) or was set in a direct request, which did not pass any trusted proxies.

This change makes sure that RemoteIPProxiesHeader, if configured, is only set by mod_remoteip and is cleared for any requests, that do not come from trusted proxy.