### PR TITLE
feat: Adding mod_wasm v0.10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -387,6 +387,36 @@ jobs:
             - cargo
             - cbindgen
     # -------------------------------------------------------------------------
+    - name: Linux Ubuntu, event MPM, MOD_WASM test suite
+      dist: focal
+      env: CONFIG="--enable-mods-shared=reallyall --with-mpm=event --enable-mpms-shared=event"
+           NO_TEST_FRAMEWORK=1 TEST_INSTALL=1 TEST_MOD_WASM=1
+      addons:
+        apt:
+          sources:
+            - sourceline: 'deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe'
+          packages:
+            - cpanminus
+            - libtool-bin
+            - libapr1-dev
+            - libaprutil1-dev
+            - perl-doc
+            - liblua5.3-dev
+            - libbrotli-dev
+            - libcurl4-openssl-dev
+            - libsystemd-dev
+            - libnghttp2-dev
+            - libjansson-dev
+            - libpcre2-dev
+            - libldap2-dev
+            - ldap-utils
+            - gdb
+            - curl
+            - python3-pytest
+            - nghttp2-client
+            - python3-cryptography
+            - python3-requests
+    # -------------------------------------------------------------------------
     - name: Linux Ubuntu, APR 1.7.0, APR-util 1.6.1, LDAP
       env: APR_VERSION=1.7.0
            APU_VERSION=1.6.1 APU_CONFIG="--with-crypto --with-ldap"

--- a/docs/manual/mod/allmodules.xml
+++ b/docs/manual/mod/allmodules.xml
@@ -133,6 +133,7 @@
   <modulefile>mod_usertrack.xml</modulefile>
   <modulefile>mod_version.xml</modulefile>
   <modulefile>mod_vhost_alias.xml</modulefile>
+  <modulefile>mod_wasm.xml</modulefile>
   <modulefile>mod_watchdog.xml</modulefile>
   <modulefile>mod_xml2enc.xml</modulefile>
   <modulefile>mpm_common.xml</modulefile>

--- a/docs/manual/mod/mod_wasm.xml
+++ b/docs/manual/mod/mod_wasm.xml
@@ -1,0 +1,298 @@
+<?xml version="1.0"?>
+<!DOCTYPE modulesynopsis SYSTEM "../style/modulesynopsis.dtd">
+<?xml-stylesheet type="text/xsl" href="../style/manual.en.xsl"?>
+<!-- $LastChangedRevision: 1895285 $ -->
+
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+
+ <!--
+    More info about the format of the Apache HTTP Server documentation,
+    and the technique used to transform them into html can be found at:
+    https://httpd.apache.org/docs/
+    https://httpd.apache.org/docs/current/style/
+    https://httpd.apache.org/docs-project/docsformat.html
+    https://httpd.apache.org/docs-project/mod_template.txt
+    https://cwiki.apache.org/confluence/display/HTTPD/
+-->
+
+
+<modulesynopsis metafile="mod_wasm.xml.meta">
+
+    <name>mod_wasm</name>
+    <description>Runs WebAssembly (Wasm) binaries
+    </description>
+    <status>Experimental</status>
+    <sourcefile>mod_wasm.c</sourcefile>
+    <identifier>wasm_module</identifier>
+    <compatibility>Available in version 2.4.x and later</compatibility>
+    <summary>
+        <p>
+            <module>mod_wasm</module> offers a secure enclave to run untrusted 3rd party software.
+            It allows <a href="https://webassembly.org/">WebAssembly (Wasm)</a> binaries to be executed within the Apache Server.
+            Code runs in a secure environment at almost native speed.
+            The <em>Wasm Capabilities Model</em> offers a secure-by-design approach to limit access to system resources.
+            No capabilities are enabled by default. To enable such capabilities, new directives are provided for <code>httpd.conf</code>.
+        </p><p>
+            <module>mod_wasm</module>, being written in C, uses the library <code>libwasm_runtime.so</code> to interact with the Wasm engine
+            <a href="https://wasmtime.dev/">Wasmtime</a>, both written in Rust.
+            This provides additional guarantees regarding security, memory safety, and performance.
+            Another module following a similar design is <module>mod_tls</module>.
+        </p><p>
+            WebAssembly is a portable binary code. Therefore, developers can write programs in
+            their favorite programming language (C, C++, C#, Rust, Go, Swift, etc.)
+            and target Wasm format as the output (in the same way you can target x86_64 or aarch64).
+            In addition, a language runtime written in a supported language can be compiled
+            into Wasm (i.e.: PHP, Python, Ruby, Perl, all written in C).
+            And then, run their interpreters within the secure environment that <module>mod_wasm</module> provides.
+        </p><p>
+            <module>mod_wasm</module> implements a <em>content handler</em> that captures the <em>stdout</em> from the Wasm binary, and then it is appended to the HTTP request response.
+        </p>
+    </summary>
+
+    <!-- ******************** Hello Wasm Config Example ****************** -->
+    <section id="minimal_configuration">
+        <title>Minimal Configuration: Running a Wasm Module</title>
+        <p>
+            Below is a minimal configuration sample of the directives needed in <code>httpd.conf</code> to use <module>mod_wasm</module>. 
+        </p><p>
+            Just set the <code>wasm-handler</code> to the desired route, and point to a Wasm module via <directive module="mod_wasm">WasmModule</directive>.
+        </p>
+        <highlight language="config">
+LoadModule wasm_module modules/mod_wasm.so
+
+&lt;Location /hello-world>
+  SetHandler wasm-handler
+  WasmModule /var/www/wasm_modules/hello.wasm
+&lt;/Location>
+        </highlight>
+    </section>
+
+    <!-- ********************** Python Config Example ********************* -->
+    <section id="advanced_configuration">
+        <title>Advanced Configuration: Running a Python-based WebApp</title>
+        <p>
+            Below is an advanced configuration for running a Python-based webapp within <module>mod_wasm</module>.
+        </p><p>
+            The Python language runtime is in Wasm binary format. The Python script to be run is passed as an argument via <directive module="mod_wasm">WasmArg</directive>.
+        </p><p>
+            Python runtime requires both <code>PYTHONHOME</code> and <code>PYTHONPATH</code> environment variables 
+            to be set and point to a directory containing the Python standard library. This can be done using 
+            <directive module="mod_wasm">WasmEnv</directive>.
+        </p><p>
+            Also, such directories must be pre-opened and available in the Wasm context via <directive module="mod_wasm">WasmDir</directive> or <directive module="mod_wasm">WasmMapDir</directive>.
+        </p><p>
+            Finally, CGI mode is activated using <directive module="mod_wasm">WasmEnableCGI</directive>.
+            This way, HTTP headers and body, and URL parameters from the incoming request are passed to the Wasm module
+            as environmental variables and <em>stdin</em>. In this mode, it is expected that responses from the Wasm module
+            start with the HTTP response header (i.e.: <code>Content-Type: text/html</code>).
+        </p>
+        <highlight language="config">
+LoadModule wasm_module modules/mod_wasm.so
+
+&lt;Location /python-app>
+  SetHandler    wasm-handler
+  WasmModule    /var/www/wasm_modules/python3.11.wasm
+  WasmMapDir    /python /usr/lib/python3.11
+  WasmArg       /python/hello.py
+  WasmEnv       PYTHONHOME /python/wasi-python/lib/python3.11
+  WasmEnv       PYTHONPATH /python/wasi-python/lib/python3.11
+  WasmEnableCGI On
+&lt;/Location>
+        </highlight>
+    </section>
+
+    <!-- ************************* Directives List ************************ -->
+    <section id="directives">
+        <title>mod_wasm Directives Index</title>
+        <p>
+            The table below provides a comprehensive list of all directives provided by <module>mod_wasm</module>. 
+        </p>
+            <table>
+                <tr><th>Directive</th></tr>
+                <tr><td><directive module="mod_wasm">WasmModule</directive></td></tr>
+                <tr><td><directive module="mod_wasm">WasmDir</directive></td></tr>
+                <tr><td><directive module="mod_wasm">WasmMapDir</directive></td></tr>
+                <tr><td><directive module="mod_wasm">WasmArg</directive></td></tr>
+                <tr><td><directive module="mod_wasm">WasmEnv</directive></td></tr>
+                <tr><td><directive module="mod_wasm">WasmEnableCGI</directive></td></tr>
+            </table>
+        <p>
+    	</p>
+    </section>
+
+    <!-- ************************** WasmModule **************************** -->
+    <directivesynopsis>
+        <name>WasmModule</name>
+        <description>Define the Wasm module file path.</description>
+        <syntax>WasmModule <em>filename</em></syntax>
+        <contextlist>
+            <context>server config</context>
+        </contextlist>
+        <usage>
+            <p>
+                <code>WasmModule</code> sets the Wasm file to be loaded.
+            </p>
+            <example><title>Example</title>
+                <highlight language="config">
+WasmModule /var/www/wasm_modules/hello.wasm
+                </highlight>
+            </example>
+        </usage>
+    </directivesynopsis>
+
+    <!-- **************************** WasmDir ***************************** -->
+    <directivesynopsis>
+        <name>WasmDir</name>
+        <description>Pre-open a host directory for the Wasm context.</description>
+        <syntax>WasmDir <em>directory</em></syntax>
+        <contextlist>
+            <context>server config</context>
+        </contextlist>
+        <usage>
+            <p>
+                <code>WasmDir</code> pre-opens a directory in the host system to be available in the Wasm context.
+            </p><p>
+                This is a security feature from the <em>Wasm Capabilities Model</em>,
+                in which no directory in the host filesystem is available in the Wasm module context unless is explicitly pre-opened.
+            </p><p>
+                This directive can be used as many times as needed, but only one <em>directory</em> per directive.
+            </p>
+            <example><title>Example</title>
+                <highlight language="config">
+WasmDir /var/www/assets/common
+WasmDir /var/www/htdocs/my-site
+                </highlight>
+            </example>
+        </usage>
+    </directivesynopsis>
+
+    <!-- ************************* WasmMapDir ***************************** -->
+    <directivesynopsis>
+        <name>WasmMapDir</name>
+        <description>Pre-open a host directory for the Wasm context.</description>
+        <syntax>WasmMapDir <em>wasm_directory</em> <em>host_directory</em></syntax>
+        <contextlist>
+            <context>server config</context>
+        </contextlist>
+        <usage>
+            <p>
+                <directive>WasmMapDir</directive> is an extension of <directive module="mod_wasm">WasmDir</directive>.
+            </p><p>
+                In this case, <directive>WasmMapDir</directive> will pre-open the <em>host_directory</em>,
+                and then mount such directory as <em>wasm_directory</em> within the Wasm module context.
+            </p><p>
+                This is a security feature from the <em>Wasm Capabilities Model</em>,
+                in which no directory in the host filesystem is available in the Wasm module context unless is explicitly pre-opened.
+            </p><p>
+                This directive can be used as many times as needed, but only one tuple <em>wasm_directory</em> <em>host_directory</em> per directive.
+            </p>
+            <example><title>Example</title>
+                <highlight language="config">
+WasmMapDir /common /var/www/assets/common
+WasmMapDir /my-site /var/www/htdocs/my-site
+                </highlight>
+            </example>
+        </usage>
+    </directivesynopsis>
+
+    <!-- *************************** WasmArg ****************************** -->
+    <directivesynopsis>
+        <name>WasmArg</name>
+        <description>Set an argument to be passed to the Wasm module context.</description>
+        <syntax>WasmArg <em>argument</em></syntax>
+        <contextlist>
+            <context>server config</context>
+        </contextlist>
+        <usage>
+            <p>            
+                <directive>WasmArg</directive> is related to the well-known <em>argv</em> parameter in the C <code>int main (int argc, *argv[])</code> function declaration.
+            </p><p>
+                This directive allows passing different <em>arguments</em> to the Wasm module as its <em>main</em> function
+                was invoked with such an argument.
+            </p><p>
+                This directive can be used as many times as needed, but only one <em>argument</em> per directive.
+            </p><p>
+                The order is accumulative, this is, the first invocation will become the first argument, and so on.
+            </p>
+            <example><title>Example</title>
+                <highlight language="config">
+WasmArg /my-site/scripts/hello.py
+WasmArg --effusive-mode
+                </highlight>
+            </example>
+        </usage>
+    </directivesynopsis>
+
+    <!-- *************************** WasmEnv ****************************** -->
+    <directivesynopsis>
+        <name>WasmEnv</name>
+        <description>Set an environment variable to be passed to the Wasm module context.</description>
+        <syntax>WasmEnv <em>variable_name</em> <em>variable_value</em></syntax>
+        <contextlist>
+            <context>server config</context>
+        </contextlist>
+        <usage>
+            <p>            
+                <directive>WasmEnv</directive> allows setting environment variables within the Wasm module context.
+            </p><p>
+                This directive can be used as many times as needed, but only one tuple <em>variable_name</em> <em>variable_value</em> per directive.
+            </p>
+            <example><title>Example</title>
+                <highlight language="config">
+WasmEnv WEBAPP_SCRIPTS /my-site/scripts
+WasmEnv WEBAPP_DEBUG false
+                </highlight>
+            </example>
+        </usage>
+    </directivesynopsis>
+
+    <!-- ************************** WasmEnableCGI ************************* -->
+    <directivesynopsis>
+        <name>WasmEnableCGI</name>
+        <description>Enable/Disable CGI emulation mode for HTTP requests.</description>
+        <syntax>WasmEnableCGI <em>On|Off</em></syntax>
+        <contextlist>
+            <context>server config</context>
+        </contextlist>
+        <usage>
+            <p>            
+                <directive>WasmEnableCGI</directive> allows <module>mod_wasm</module> to connect the HTTP requests with the Wasm module in a CGI-like way:
+                <ul>
+                    <li>HTTP headers from the request are passed to the Wasm module as environmental variables.</li>
+                    <li>HTTP request body is passed to the Wasm module as <em>stdin</em>.</li>
+                    <li>URL query parameters are passed as <code>QUERY_STRING</code> environmental variable.</li>
+                    <li>Output from the Wasm module (<em>stdout</em>) will be parsed and headers such as <code>Content-Type:</code> will be
+                    incorporated into the response headers.</li>
+                </ul>
+                Default value is <em>Off</em>.
+            </p>
+            <example><title>Example</title>
+                <highlight language="config">
+WasmEnableCGI On
+                </highlight>
+            </example>
+            <p>
+                HTTP request headers are prefixed with '<code>HTTP_</code>', uppercased, and hyphens '<code>-</code>' are substituted by underscores '<code>_</code>' when transformed into environmental variables.
+            </p><p>
+                As an example, a header like <code>x-custom-header: value</code> will be transformed into an <code>HTTP_X_CUSTOM_HEADER=value</code> environmental variable.
+            </p>
+        </usage>
+    </directivesynopsis>
+
+</modulesynopsis>
+

--- a/modules/wasm/Makefile.in
+++ b/modules/wasm/Makefile.in
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include $(top_srcdir)/build/special.mk

--- a/modules/wasm/config.m4
+++ b/modules/wasm/config.m4
@@ -1,0 +1,180 @@
+dnl Licensed to the Apache Software Foundation (ASF) under one or more
+dnl contributor license agreements.  See the NOTICE file distributed with
+dnl this work for additional information regarding copyright ownership.
+dnl The ASF licenses this file to You under the Apache License, Version 2.0
+dnl (the "License"); you may not use this file except in compliance with
+dnl the License.  You may obtain a copy of the License at
+dnl
+dnl      http://www.apache.org/licenses/LICENSE-2.0
+dnl
+dnl Unless required by applicable law or agreed to in writing, software
+dnl distributed under the License is distributed on an "AS IS" BASIS,
+dnl WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+dnl See the License for the specific language governing permissions and
+dnl limitations under the License.
+
+APACHE_MODPATH_INIT(wasm)
+
+dnl #  list of module object files
+wasm_objs="dnl
+mod_wasm.lo
+"
+
+dnl
+dnl APACHE_CHECK_WASMRUNTIME
+dnl
+dnl Configure for Wasm Runtime, giving preference to
+dnl "--with-wasmruntime=<path>" if it was specified.
+dnl
+AC_DEFUN([APACHE_CHECK_WASMRUNTIME],[
+  AC_CACHE_CHECK([for wasmruntime], [ac_cv_wasmruntime], [
+    dnl initialise the variables we use
+    ac_cv_wasmruntime=no
+    ap_wasmruntime_found=""
+    ap_wasmruntime_base=""
+    ap_wasmruntime_libs=""
+
+    dnl Determine the Wasm Runtime base directory, if any
+    AC_MSG_CHECKING([for user-provided Wasm Runtime base directory])
+    AC_ARG_WITH(
+      wasmruntime,
+      APACHE_HELP_STRING(--with-wasmruntime=PATH, Wasm Runtime installation directory),
+      [
+      dnl If --with-wasmruntime specifies a directory, we use that directory
+      if test "x$withval" != "xyes" -a "x$withval" != "x"; then
+        dnl This ensures $withval is actually a directory and that it is absolute
+        ap_wasmruntime_base="`cd $withval ; pwd`"
+      fi
+    ])
+
+    if test "x$ap_wasmruntime_base" = "x"; then
+      AC_MSG_RESULT(none)
+    else
+      AC_MSG_RESULT()
+    fi
+
+    dnl Run header and version checks
+    saved_CPPFLAGS="$CPPFLAGS"
+    saved_LIBS="$LIBS"
+    saved_LDFLAGS="$LDFLAGS"
+
+    dnl Before doing anything else, load in pkg-config variables
+    if test -n "$PKGCONFIG"; then
+      saved_PKG_CONFIG_PATH="$PKG_CONFIG_PATH"
+      AC_MSG_CHECKING([for pkg-config along $PKG_CONFIG_PATH])
+      if test "x$ap_wasmruntime_base" != "x" ; then
+        if test -f "${ap_wasmruntime_base}/lib/pkgconfig/libwasm_runtime.pc"; then
+          dnl Ensure that the given path is used by pkg-config too, otherwise
+          dnl the system libwasm_runtime.pc might be picked up instead.
+          PKG_CONFIG_PATH="${ap_wasmruntime_base}/lib/pkgconfig${PKG_CONFIG_PATH+:}${PKG_CONFIG_PATH}"
+          export PKG_CONFIG_PATH
+        elif test -f "${ap_wasmruntime_base}/lib64/pkgconfig/libwasm_runtime.pc"; then
+          dnl Ensure that the given path is used by pkg-config too, otherwise
+          dnl the system libwasm_runtime.pc might be picked up instead.
+          PKG_CONFIG_PATH="${ap_wasmruntime_base}/lib64/pkgconfig${PKG_CONFIG_PATH+:}${PKG_CONFIG_PATH}"
+          export PKG_CONFIG_PATH
+        fi
+      fi
+      ap_wasmruntime_libs="`$PKGCONFIG $PKGCONFIG_LIBOPTS --libs-only-l --silence-errors libwasm_runtime`"
+      if test $? -eq 0; then
+        ap_wasmruntime_found="yes"
+        pkglookup="`$PKGCONFIG --cflags-only-I libwasm_runtime`"
+        APR_ADDTO(CPPFLAGS, [$pkglookup])
+        APR_ADDTO(MOD_CFLAGS, [$pkglookup])
+        pkglookup="`$PKGCONFIG $PKGCONFIG_LIBOPTS --libs-only-L libwasm_runtime`"
+        APR_ADDTO(LDFLAGS, [$pkglookup])
+        APR_ADDTO(MOD_LDFLAGS, [$pkglookup])
+        pkglookup="`$PKGCONFIG $PKGCONFIG_LIBOPTS --libs-only-other libwasm_runtime`"
+        APR_ADDTO(LDFLAGS, [$pkglookup])
+        APR_ADDTO(MOD_LDFLAGS, [$pkglookup])
+      fi
+      PKG_CONFIG_PATH="$saved_PKG_CONFIG_PATH"
+    fi
+
+    dnl fall back to the user-supplied directory if not found via pkg-config
+    if test "x$ap_wasmruntime_base" != "x" -a "x$ap_wasmruntime_found" = "x"; then
+      APR_ADDTO(CPPFLAGS, [-I$ap_wasmruntime_base/include])
+      APR_ADDTO(MOD_CFLAGS, [-I$ap_wasmruntime_base/include])
+      APR_ADDTO(LDFLAGS, [-L$ap_wasmruntime_base/target/release])
+      APR_ADDTO(MOD_LDFLAGS, [-L$ap_wasmruntime_base/target/release])
+      if test "x$ap_platform_runtime_link_flag" != "x"; then
+        APR_ADDTO(LDFLAGS, [$ap_platform_runtime_link_flag$ap_wasmruntime_base/target/release])
+        APR_ADDTO(MOD_LDFLAGS, [$ap_platform_runtime_link_flag$ap_wasmruntime_base/target/release])
+      fi
+    fi
+
+    AC_MSG_CHECKING([for libwasm_runtime is available])
+    AC_LANG([C])
+    AC_TRY_COMPILE(
+      [#include "wasm_runtime.h"],
+      [wasm_runtime_init_module();],
+      [AC_MSG_RESULT(OK)
+       ac_cv_wasmruntime=yes],
+      [AC_MSG_RESULT(FAILED)
+       ac_cv_wasmruntime=no]
+    )
+
+    mod_wasm_version_major=`grep MOD_WASM_VERSION_MAJOR modules/wasm/mod_wasm.h | cut -d' ' -f3`
+    mod_wasm_version_minor=`grep MOD_WASM_VERSION_MINOR modules/wasm/mod_wasm.h | cut -d' ' -f3`
+    mod_wasm_version_patch=`grep MOD_WASM_VERSION_PATCH modules/wasm/mod_wasm.h | cut -d' ' -f3`
+    mod_wasm_version="$mod_wasm_version_major"."$mod_wasm_version_minor"."$mod_wasm_version_patch"
+    AC_MSG_CHECKING([for mod_wasm $mod_wasm_version compatibility])
+    AC_LANG([C])
+    AC_RUN_IFELSE(
+      [AC_LANG_PROGRAM(
+        [#include <stdio.h>
+         #include "wasm_runtime.h"],
+        [ printf("\n");
+          printf("\tmod_wasm version is $mod_wasm_version\n");
+          printf("\tlibwasm_runtime version is %s\n", WASM_RUNTIME_VERSION);
+         if ( $mod_wasm_version_major == WASM_RUNTIME_VERSION_MAJOR
+           && $mod_wasm_version_minor <= WASM_RUNTIME_VERSION_MINOR )
+          exit(0);
+         else
+         {
+          printf("\tIncompatible version numbers!\n");
+          exit(1);
+         }
+        ]
+      )],
+      [AC_MSG_RESULT(OK)
+       ac_cv_wasmruntime=yes],
+      [AC_MSG_RESULT(FAILED)
+       ac_cv_wasmruntime=no]
+    )
+
+    dnl restore
+    CPPFLAGS="$saved_CPPFLAGS"
+    LIBS="$saved_LIBS"
+    LDFLAGS="$saved_LDFLAGS"
+  ])
+  if test "x$ac_cv_wasmruntime" = "xyes"; then
+    AC_DEFINE(HAVE_WASMRUNTIME, 1, [Define if Wasm Runtime is available])
+  fi
+])
+
+
+APACHE_MODULE(wasm, [WebAssembly handler module.
+This module requires a libwasm_runtime installation.
+See --with-wasmruntime on how to manage non-standard locations. This module
+is usually linked shared and requires loading. ], $wasm_objs, , most, [
+    APACHE_CHECK_WASMRUNTIME
+    if test "$ac_cv_wasmruntime" = "yes" ; then
+        if test "x$enable_wasm" = "xshared"; then
+           case `uname` in
+             "Darwin")
+                MOD_WASM_LINK_LIBS="-lwasm_runtime -framework Foundation"
+                ;;
+             *)  
+                MOD_WASM_LINK_LIBS="-lwasm_runtime"
+                ;;
+           esac
+
+           APR_ADDTO(MOD_LDFLAGS, [$MOD_WASM_LINK_LIBS])
+        fi
+    else
+        enable_wasm=no
+    fi
+])
+
+APACHE_MODPATH_FINISH

--- a/modules/wasm/mod_wasm.c
+++ b/modules/wasm/mod_wasm.c
@@ -1,0 +1,524 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "httpd.h"
+#include "http_config.h"
+#include "http_core.h"
+#include "http_log.h"
+#include "http_main.h"
+#include "http_protocol.h"
+#include "http_request.h"
+#include "util_script.h"
+#include "http_connection.h"
+#ifdef HAVE_UNIX_SUEXEC
+#include "unixd.h"
+#endif
+#include "scoreboard.h"
+#include "mpm_common.h"
+
+#include "apr_strings.h"
+
+#include <stdio.h>
+
+#include "mod_wasm.h"
+#include "wasm_runtime.h"
+
+/*--------------------------------------------------------------------------*/
+/*                                                                          */
+/* Data declarations.                                                       */
+/*                                                                          */
+/* Here are the static cells and structure declarations private to our      */
+/* module.                                                                  */
+/*                                                                          */
+/*--------------------------------------------------------------------------*/
+
+/*
+ * Maximum number of bytes to allocate the body from an HTTP Request.
+ *
+ * 16KB (16*1024 = 16384)
+ *
+ */
+#define CONFIG_HTTP_REQUEST_BODY_MAX 16384
+
+/*
+ * Configuration record. Used for both per-directory and per-server
+ * configuration data.
+ *
+ * It's perfectly reasonable to have two different structures for the two
+ * different environments.  The same command handlers will be called for
+ * both, though, so the handlers need to be able to tell them apart.  One
+ * possibility is for both structures to start with an int which is 0 for
+ * one and 1 for the other.
+ *
+ * Note that while the per-directory and per-server configuration records are
+ * available to most of the module handlers, they should be treated as
+ * READ-ONLY by all except the command and merge handlers.  Sometimes handlers
+ * are handed a record that applies to the current location by implication or
+ * inheritance, and modifying it will change the rules for other locations.
+ */
+typedef struct x_cfg {
+    int cmode;                                               /* Environment to which record applies
+                                                              * (directory, server, or combination).
+                                                              */
+#define CONFIG_MODE_SERVER 1
+#define CONFIG_MODE_DIRECTORY 2
+#define CONFIG_MODE_COMBO 3                                  /* Shouldn't ever happen. */
+    int bWasmEnableCGI;                                      /* Boolean: whether this module interfaces as if it was a CGI script */
+    char *trace;                                             /* Pointer to trace string. */
+    char *loc;                                               /* Location to which this record applies. */
+} x_cfg;
+
+/*
+ * String pointer to hold the startup trace. No harm working with a global until
+ * the server is (may be) multi-threaded.
+ */
+static const char *trace = NULL;
+
+/*
+ * Declare ourselves so the configuration routines can find and know us.
+ * We'll fill it in at the end of the module.
+ */
+module AP_MODULE_DECLARE_DATA wasm_module;
+
+/*--------------------------------------------------------------------------*/
+/*                                                                          */
+/* These routines are strictly internal to this module, and support its     */
+/* operation.  They are not referenced by any external portion of the       */
+/* server.                                                                  */
+/*                                                                          */
+/*--------------------------------------------------------------------------*/
+
+/*
+ * This function gets called to create a per-directory configuration
+ * record. This will be called for the "default" server environment, and for
+ * each directory for which the parser finds any of our directives applicable.
+ * If a directory doesn't have any of our directives involved (i.e., they
+ * aren't in the .htaccess file, or a <Location>, <Directory>, or related
+ * block), this routine will *not* be called - the configuration for the
+ * closest ancestor is used.
+ *
+ * The return value is a pointer to the created module-specific
+ * structure.
+ */
+static void *create_dir_config(apr_pool_t *p, char *context)
+{
+    x_cfg *cfg;
+
+    /*
+     * Allocate the space for our record from the pool supplied.
+     */
+    cfg = (x_cfg *) apr_pcalloc(p, sizeof(x_cfg));
+    /*
+     * Now fill in the defaults.  If there are any `parent' configuration
+     * records, they'll get merged as part of a separate callback.
+     */
+    cfg->bWasmEnableCGI = 0;
+    cfg->cmode = CONFIG_MODE_DIRECTORY;
+    /*
+     * Finally, add our trace to the callback list.
+     */
+    context = (context != NULL) ? context : "";
+    cfg->loc = apr_pstrcat(p, "DIR(", context, ")", NULL);
+
+    /* creates a new Wasm config for the current context */
+    int ret = wasm_config_create(cfg->loc); 
+    if ( ret != OK )
+        ap_log_perror(APLOG_MARK, APLOG_ERR, ret, p,
+            "wasm_config_create() - ERROR! Couldn't create Wasm config for context '%s' !", cfg->loc);
+
+    return (void *) cfg;
+}
+
+/*
+ * This function gets called to create a per-server configuration
+ * record. It will always be called for the "default" server.
+ *
+ * The return value is a pointer to the created module-specific
+ * structure.
+ */
+static void *create_server_config(apr_pool_t *p, server_rec *s)
+{
+    x_cfg *cfg;
+    char *sname = s->server_hostname;
+
+    /*
+     * As with the create_dir_config() reoutine, we allocate and fill
+     * in an empty record.
+     */
+    cfg = (x_cfg *) apr_pcalloc(p, sizeof(x_cfg));
+    cfg->bWasmEnableCGI = 0;
+    cfg->cmode = CONFIG_MODE_SERVER;
+    /*
+     * Note that we were called in the trace list.
+     */
+    sname = (sname != NULL) ? sname : "";
+    cfg->loc = apr_pstrcat(p, "SVR(", sname, ")", NULL);
+
+    /* creates a new Wasm config for the current context */
+    int ret = wasm_config_create(cfg->loc); 
+    if ( ret != OK )
+        ap_log_perror(APLOG_MARK, APLOG_ERR, ret, p,
+            "wasm_config_create() - ERROR! Couldn't create Wasm config for context '%s' !", cfg->loc);
+
+    return (void *) cfg;
+}
+
+/*
+ * Add the provided key to the Wasm runtime as an environment variable.
+ */
+static int _wasm_executionctx_env_add(void* context, const char *key, const char *value)
+{
+    int ret = wasm_executionctx_env_add((const char*)context, key, value);
+    if ( ret != OK )
+        ap_log_error(APLOG_MARK, APLOG_ERR, ret, NULL,
+            "wasm_executionctx_env_add() - ERROR! Couldn't add env variable '%s = %s' to Wasm execution context!", key, value);
+
+    return 1;
+}
+
+/*
+ * This function reads the HTTP Request Body
+ * 
+ * r: request
+ * rbuff: buffer to where the body will be allocated
+ * size: size of the buffer allocated
+ * 
+ * More info:
+ *  - https://httpd.apache.org/docs/trunk/developer/modguide.html (section: "Reading the request body into memory")
+ *  - https://docstore.mik.ua/orelly/apache_mod/139.htm 
+ */
+static int read_http_request_body(request_rec *r, const char **rbuf, apr_off_t *size)
+{
+    int rc = DECLINED; /* return code ('DECLINED' by default) */
+
+    /* setup the client to allow Apache to read the request body */
+    if ( (rc = ap_setup_client_block(r, REQUEST_CHUNKED_ERROR)) != OK )
+    {
+        return rc;
+    }
+
+    /* can we read or abort? */
+    if ( ap_should_client_block(r) )
+    {
+        char argsbuffer[CONFIG_HTTP_REQUEST_BODY_MAX];
+        apr_off_t rsize, len_read, rpos = 0;
+        apr_off_t length = r->remaining;
+
+        *rbuf = (const char *) apr_pcalloc( r->pool, (apr_size_t)(length + 1) );
+        *size = length;
+        while ( (len_read = ap_get_client_block(r, argsbuffer, sizeof(argsbuffer))) > 0 )
+        {
+            if ( (rpos + len_read) > length ) {
+                rsize = length - rpos;
+            }
+            else {
+                rsize = len_read;
+            }
+
+            memcpy( (char *)*rbuf + rpos, argsbuffer, (size_t)rsize );
+            rpos += rsize;
+        }
+    }
+
+    return rc;
+}
+
+
+/*
+ * Content handler
+ */
+static int content_handler(request_rec *r)
+{
+    /* If it's not for us, get out as soon as possible. */
+    if (strcmp(r->handler, "wasm-handler")) {
+        return DECLINED;
+    }
+
+    /*
+     * If we're only supposed to send header information (HEAD request), we're
+     * already there.
+     */
+    if (r->header_only) {
+        return OK;
+    }
+
+    /* get specific configuration for the given directory/location */
+    x_cfg *dcfg = ap_get_module_config(r->per_dir_config, &wasm_module);
+
+    /* creates a new Wasm execution context */
+    const char* exec_ctx_id = wasm_executionctx_create_from_config(dcfg->loc);
+
+    if (dcfg->bWasmEnableCGI) {
+      /* On CGI mode, we set the request headers as environment variables with an HTTP_ prefix. */
+      ap_add_common_vars(r);
+      ap_add_cgi_vars(r);
+      apr_table_do(_wasm_executionctx_env_add, (void*)exec_ctx_id, r->subprocess_env, NULL);
+
+      /* read HTTP Request body and set it as stdin for the Wasm module */
+      apr_off_t body_size = 0;
+      const char* body_buffer = NULL;
+
+      int ret = read_http_request_body(r, &body_buffer, &body_size);
+      if ( ret != OK ) {
+        ap_log_rerror(APLOG_MARK, APLOG_ERR, ret, r,
+            "content_handler() - ERROR! Couldn't read HTTP Request Body!");
+      }
+      else { /* read_http_request_body() was successfull */
+        ret = wasm_executionctx_stdin_set(exec_ctx_id, body_buffer, body_size);
+        if ( ret != OK )
+            ap_log_rerror(APLOG_MARK, APLOG_ERR, ret, r,
+                "content_handler() - ERROR! Couldn't set HTTP Request Body as stdin!");
+      }
+    }
+    /* run Wasm module */
+    const char* module_response = wasm_executionctx_run(exec_ctx_id);
+
+    if (dcfg->bWasmEnableCGI) {
+      /*
+       * Retrieve the CGI variables and feed our own response with
+       * them; write the response from the module as our own response;
+       * which has the headers already stripped from it.
+       */
+      const char *termch;
+      int termarg;
+      int ret = ap_scan_script_header_err_strs(r, NULL, &termch, &termarg, module_response, NULL);
+      /*
+       * ap_scan_script_header_err_strs can return either:
+       *   - HTTP_OK: success
+       *   - HTTP_INTERNAL_SERVER_ERROR: failure
+       *   - HTTP_NOT_MODIFIED or HTTP_PRECONDITION_FAILED: script
+       *     response does not meet request's conditions
+       * In order to not give the external consumer more information
+       * than what is needed, map all responses to a 500 error.
+       */
+
+      if (ret != OK && ret != HTTP_OK) {
+        if (r->content_type == NULL)
+            ap_log_rerror(APLOG_MARK, APLOG_ERR, ret, r,
+                "content_handler() - ERROR! In WasmEnableCGI mode, HTTP headers are expected (i.e.: \"Content-type: text/html\n\n\")");
+
+        wasm_return_const_char_ownership(module_response);
+        return HTTP_INTERNAL_SERVER_ERROR;
+      }
+      if (termch != NULL) {
+        ap_rprintf(r, "%s", termch);
+      }
+    } else if (module_response != NULL) {
+      ap_rprintf(r, "%s", module_response);
+    }
+
+    /* return module response ownership to avoid leaking memory */
+    wasm_return_const_char_ownership(module_response);
+
+    /* deallocate execution context and return id ownership to avoid leaking memory */
+    int ret = wasm_executionctx_deallocate(exec_ctx_id);
+    if ( ret != OK )
+        ap_log_rerror(APLOG_MARK, APLOG_ERR, ret, r,
+            "content_handler() - ERROR! Couldn't deallocate Wasm execution context: '%s'", exec_ctx_id);
+
+    wasm_return_const_char_ownership(exec_ctx_id);
+
+    return OK;
+}
+
+/*--------------------------------------------------------------------------*/
+/*                                                                          */
+/* Which functions are responsible for which hooks in the server.           */
+/*                                                                          */
+/*--------------------------------------------------------------------------*/
+/*
+ * Each function our module provides to handle a particular hook is
+ * specified here.  The functions are registered using
+ * ap_hook_foo(name, predecessors, successors, position)
+ * where foo is the name of the hook.
+ *
+ * The args are as follows:
+ * name         -> the name of the function to call.
+ * predecessors -> a list of modules whose calls to this hook must be
+ *                 invoked before this module.
+ * successors   -> a list of modules whose calls to this hook must be
+ *                 invoked after this module.
+ * position     -> The relative position of this module.  One of
+ *                 APR_HOOK_FIRST, APR_HOOK_MIDDLE, or APR_HOOK_LAST.
+ *                 Most modules will use APR_HOOK_MIDDLE.  If multiple
+ *                 modules use the same relative position, Apache will
+ *                 determine which to call first.
+ *                 If your module relies on another module to run first,
+ *                 or another module running after yours, use the
+ *                 predecessors and/or successors.
+ *
+ * The number in brackets indicates the order in which the routine is called
+ * during request processing.  Note that not all routines are necessarily
+ * called (such as if a resource doesn't have access restrictions).
+ * The actual delivery of content to the browser [9] is not handled by
+ * a hook; see the handler declarations below.
+ */
+static void register_hooks(apr_pool_t *p)
+{
+    ap_hook_handler(content_handler, NULL, NULL, APR_HOOK_MIDDLE);
+}
+
+#define WASM_DIRECTIVE_WASMMODULE     "WasmModule"
+#define WASM_DIRECTIVE_WASMARG        "WasmArg"
+#define WASM_DIRECTIVE_WASMENV        "WasmEnv"
+#define WASM_DIRECTIVE_WASMDIR        "WasmDir"
+#define WASM_DIRECTIVE_WASMMAPDIR     "WasmMapDir"
+#define WASM_DIRECTIVE_WASMENABLECGI  "WasmEnableCGI"
+
+static const char *wasm_directive_WasmModule(cmd_parms *cmd, void *mconfig, const char *word1)
+{
+    x_cfg *cfg = (x_cfg *) mconfig;
+    int ret;
+
+    /* Wasm module is loaded and cached */
+    ret = wasm_module_load(word1);
+    if ( ret != OK )
+        ap_log_error(APLOG_MARK, APLOG_ERR, ret, NULL,
+            "wasm_directive_WasmModule() - ERROR! Couldn't load Wasm Module '%s'!", word1);
+
+    /* Wasm config is implictly created for the current location and using the loaded module */
+    ret = wasm_config_module_set(cfg->loc, word1);
+    if ( ret != OK )
+        ap_log_error(APLOG_MARK, APLOG_ERR, ret, NULL,
+            "wasm_directive_WasmModule() - ERROR! Couldn't set Wasm Module '%s' to Wasm config '%s'!", word1, cfg->loc);
+
+    return NULL;
+}
+
+static const char *wasm_directive_WasmArg(cmd_parms *cmd, void *mconfig, const char *word1)
+{
+    x_cfg *cfg = (x_cfg *) mconfig;
+    
+    int ret = wasm_config_arg_add(cfg->loc, word1);
+    if ( ret != OK )
+        ap_log_error(APLOG_MARK, APLOG_ERR, ret, NULL,
+            "wasm_directive_WasmArg() - ERROR! Couldn't add arg '%s' to Wasm config '%s'!", word1, cfg->loc);
+
+    return NULL;
+}
+
+static const char *wasm_directive_WasmEnv(cmd_parms *cmd, void *mconfig, const char *word1, const char *word2)
+{
+    x_cfg *cfg = (x_cfg *) mconfig;
+
+    int ret = wasm_config_env_add(cfg->loc, word1, word2);
+    if ( ret != OK )
+        ap_log_error(APLOG_MARK, APLOG_ERR, ret, NULL,
+            "wasm_directive_WasmEnv() - ERROR! Couldn't add env var '%s=%s' to Wasm config '%s'!", word1, word2, cfg->loc);
+
+    return NULL;
+}
+
+static const char *wasm_directive_WasmDir(cmd_parms *cmd, void *mconfig, const char *word1)
+{
+    x_cfg *cfg = (x_cfg *) mconfig;
+
+    int ret = wasm_config_dir_add(cfg->loc, word1);
+    if ( ret != OK )
+        ap_log_error(APLOG_MARK, APLOG_ERR, ret, NULL,
+            "wasm_directive_WasmDir() - ERROR! Couldn't preopen dir '%s' for Wasm config '%s'!", word1, cfg->loc);
+
+    return NULL;
+}
+
+static const char *wasm_directive_WasmMapDir(cmd_parms *cmd, void *mconfig, const char *word1, const char *word2)
+{
+    x_cfg *cfg = (x_cfg *) mconfig;
+
+    int ret = wasm_config_mapdir_add(cfg->loc, word1, word2); 
+    if ( ret != OK )
+        ap_log_error(APLOG_MARK, APLOG_ERR, ret, NULL,
+            "wasm_directive_WasmMapDir() - ERROR! Couldn't preopen dir '%s' with mapping to '%s' for Wasm config '%s'!", word2, word1, cfg->loc);            
+
+    return NULL;
+}
+
+static const char *wasm_directive_WasmEnableCGI(cmd_parms *cmd, void *mconfig, int arg)
+{
+    x_cfg *cfg = (x_cfg *) mconfig;
+    cfg->bWasmEnableCGI = arg;
+    return NULL;
+}
+
+/*
+ * List of directives specific to our module.
+ */
+static const command_rec directives[] =
+{
+    AP_INIT_TAKE1(
+        WASM_DIRECTIVE_WASMMODULE,       /* directive name */
+        wasm_directive_WasmModule,       /* config action routine */
+        NULL,                            /* argument to include in call */
+        OR_OPTIONS,                      /* where available */
+        "Load a Wasm Module from disk"   /* directive description */
+    ),
+    AP_INIT_TAKE1(
+        WASM_DIRECTIVE_WASMARG,
+        wasm_directive_WasmArg,
+        NULL,
+        OR_OPTIONS,
+        "Add arg context for the Wasm Module"
+    ),
+    AP_INIT_TAKE2(
+        WASM_DIRECTIVE_WASMENV,
+        wasm_directive_WasmEnv,
+        NULL,
+        OR_OPTIONS,
+        "Set environtment variable for the Wasm Module"
+    ),
+    AP_INIT_TAKE1(
+        WASM_DIRECTIVE_WASMDIR,
+        wasm_directive_WasmDir,
+        NULL,
+        OR_OPTIONS,
+        "Preopen Dir for the Wasm Module"
+    ),
+    AP_INIT_TAKE2(
+        WASM_DIRECTIVE_WASMMAPDIR,
+        wasm_directive_WasmMapDir,
+        NULL,
+        OR_OPTIONS,
+        "Preopen Dir with Mapping for the Wasm Module"
+    ),
+    AP_INIT_FLAG(
+        WASM_DIRECTIVE_WASMENABLECGI,
+        wasm_directive_WasmEnableCGI,
+        NULL,
+        OR_OPTIONS,
+        "Whether this WebAssembly module behaves as a CGI"
+    ),
+    {NULL}
+};
+
+/*--------------------------------------------------------------------------*/
+/*                                                                          */
+/* Finally, the list of callback routines and data structures that provide  */
+/* the static hooks into our module from the other parts of the server.     */
+/*                                                                          */
+/*--------------------------------------------------------------------------*/
+/*
+ * Module definition for configuration.  If a particular callback is not
+ * needed, replace its routine name below with the word NULL.
+ */
+AP_DECLARE_MODULE(wasm) =
+{
+    STANDARD20_MODULE_STUFF,
+    create_dir_config,      /* per-directory config creator */
+    NULL,                   /* dir config merger */
+    create_server_config,   /* server config creator */
+    NULL,                   /* server config merger */
+    directives,             /* command table */
+    register_hooks,         /* set up other request processing hooks */
+};

--- a/modules/wasm/mod_wasm.h
+++ b/modules/wasm/mod_wasm.h
@@ -1,0 +1,18 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#define MOD_WASM_VERSION_MAJOR 0
+#define MOD_WASM_VERSION_MINOR 10
+#define MOD_WASM_VERSION_PATCH 1

--- a/test/travis_run_linux.sh
+++ b/test/travis_run_linux.sh
@@ -66,6 +66,24 @@ if test -v TEST_MOD_TLS; then
   CONFIG="$CONFIG --with-tls --with-rustls=$PREFIX"
 fi
 
+# Since libwasm_runtime is not a package (yet) on any platform, we
+# build the version we want from source
+if test -v TEST_MOD_WASM; then
+  # Install Rust
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+  source "$HOME/.cargo/env"
+  rustc --version
+  cargo install cbindgen
+  # Download and build libwasm_runtime
+  MOD_WASM_HOME="$HOME/build/mod_wasm"
+  WASM_RUNTIME_HOME="$MOD_WASM_HOME/wasm_runtime"
+  git clone https://github.com/vmware-labs/mod_wasm.git "$MOD_WASM_HOME"
+  pushd "$WASM_RUNTIME_HOME"  
+    make all
+  popd
+  CONFIG="$CONFIG --enable-wasm --with-wasmruntime=$WASM_RUNTIME_HOME"
+fi
+
 if test -v TEST_OPENSSL3; then
     CONFIG="$CONFIG --with-ssl=$HOME/root/openssl3"
     export LD_LIBRARY_PATH=$HOME/root/openssl3/lib:$HOME/root/openssl3/lib64


### PR DESCRIPTION
This PR adds [mod_wasm](https://github.com/vmware-labs/mod_wasm) v0.10.1 to httpd trunk.

* To build the Wasm runtime library: https://github.com/vmware-labs/mod_wasm/tree/main/wasm_runtime
* Building mod_wasm: https://github.com/vmware-labs/mod_wasm/tree/main/mod_wasm
   Basically, add `--enable-wasm` and `--with_wasmruntime=/path/to/wasm_runtime` to `./configure`
