### PR TITLE
Support Handshake TLD's

### DIFF
--- a/server/vhost.c
+++ b/server/vhost.c
@@ -786,7 +786,7 @@ static apr_status_t strict_hostname_check(request_rec *r, char *host)
         /* The top-level domain must start with a letter (RFC 1123 2.1) */
         while (ch > host && *ch != '.')
             ch--;
-        if (ch[0] == '.' && ch[1] != '\0' && !apr_isalpha(ch[1]))
+        if (ch[0] == '.' && ch[1] != '\0' && !apr_isalnum(ch[1]))
             goto bad;
     }
     return APR_SUCCESS;


### PR DESCRIPTION
This solves a problem with people who use apache and are using a TLD on the [handshake protocol](https://handshake.org). On handshake it is perfectly valid for a TLD to start with a number, or even just be a single digit. This change won't break anything for existing ICANN users, but will allow handshake users to use apache.

If you aren't aware of handshake there have been some significant milestones lately that show the growth of handshake such as opera adding support, namecheap buying namebase.io and now selling handshake SLD's on namecheap.com.

Edit: After reading [RFC](https://www.rfc-editor.org/rfc/rfc1123#section-2) it appears my change brings apache up to RFC standards rather than breaking them as I thought.

> One aspect of host name syntax is hereby changed: the
>       restriction on the first character is relaxed to allow either a
>       letter or a digit.  Host software MUST support this more liberal
>       syntax.