### PR TITLE
Make using errorlog provider and file at the same time possible

### DIFF
--- a/include/httpd.h
+++ b/include/httpd.h
@@ -1385,12 +1385,16 @@ struct server_rec {
 
     /** The name of the error log */
     char *error_fname;
+    /** true if error log file was set */
+    char errorlog_altered;
     /** A file descriptor that references the error log */
     apr_file_t *error_log;
     /** The log level configuration */
     struct ap_logconf log;
     /** External error log writer provider */
     struct ap_errorlog_provider *errorlog_provider;
+    /** argument supplied to the errorlog provider */
+    const char *errorlog_provider_argument;
     /** Handle to be passed to external log provider's logging method */
     void *errorlog_provider_handle;
 

--- a/modules/loggers/mod_journald.c
+++ b/modules/loggers/mod_journald.c
@@ -159,8 +159,8 @@ static apr_status_t journald_error_log(const ap_errorlog_info *info,
     const server_rec *s = info->s;
     const request_rec *r = info->r;
     apr_pool_t *pool;
-    const char *log_name = (s && s->error_fname && *s->error_fname) ?
-                            s->error_fname : "error_log";
+    const char *log_name = (s && s->errorlog_provider_argument && *s->errorlog_provider_argument)
+                            ? s->errorlog_provider_argument : "error_log";
 
     pool = journald_info_get_pool(info);
     if (!pool) {

--- a/modules/loggers/mod_syslog.c
+++ b/modules/loggers/mod_syslog.c
@@ -106,14 +106,14 @@ static const TRANS facilities[] = {
 
 static void *syslog_error_log_init(apr_pool_t *p, server_rec *s)
 {
-    char *fname = s->error_fname;
+    char *fname = s->errorlog_provider_argument;
     void *success = (void *)p; /* anything non-NULL is success */
 
     if (*fname == '\0') {
         openlog(ap_server_argv0, LOG_NDELAY|LOG_CONS|LOG_PID, LOG_LOCAL7);
     }
     else {
-        /* s->error_fname could be [level]:[tag] (see #60525) */
+        /* s->errorlog_provider_argument could be [level]:[tag] (see #60525) */
         const char *tag;
         apr_size_t flen;
         const TRANS *fac;

--- a/server/config.c
+++ b/server/config.c
@@ -2233,6 +2233,9 @@ static server_rec *init_server_config(process_rec *process, apr_pool_t *p)
     s->server_hostname = NULL;
     s->server_scheme = NULL;
     s->error_fname = DEFAULT_ERRORLOG;
+    s->errorlog_altered = 0;
+    s->errorlog_provider = NULL;
+    s->errorlog_provider_argument = NULL;
     s->log.level = DEFAULT_LOGLEVEL;
     s->log.module_levels = NULL;
     s->limit_req_line = DEFAULT_LIMIT_REQUEST_LINE;


### PR DESCRIPTION
This commit allows user to use errorlog provider and file or pipe to utility at the same time. Previous behaviour of ErrorLog directive is kept intact.