### PR TITLE
The $base was already stripped of suffix in typical case.

### DIFF
--- a/support/apxs.in
+++ b/support/apxs.in
@@ -538,7 +538,7 @@ if ($opt_i or $opt_e) {
                 }
             }
             if ($name eq '') {
-                if ($base =~ m|.*mod_([a-zA-Z0-9_]+)\..+|) {
+                if ($base =~ m/.*mod_([a-zA-Z0-9_]+)(\..+|$)/) {
                     $name = "$1";
                     $filename = $base;
                     $filename =~ s|^[^/]+/||;


### PR DESCRIPTION
I was filed https://github.com/adelton/mod_authnz_pam/issues/15 reporting that `apxs` could not figure out the bootstrap symbol name. That was weird because the man page says

> for option -i the apxs tool tries to determine the name from the source or  (as a fallback) at least by guessing it from the filename.

and the source file in question is named `mod_authnz_pam.c` so it should have worked fine. Except, the
```
$base =~ s|\.[^.]+$||;
```
line already stripped the suffix so unless the source file has two dots in its name, the guess based on filename would not work.

This small change fixes that problem.