### PR TITLE
Edit httpd balancer member host and port

### DIFF
--- a/modules/proxy/mod_proxy_hcheck.c
+++ b/modules/proxy/mod_proxy_hcheck.c
@@ -534,7 +534,7 @@ static proxy_worker *hc_get_hcworker(sctx_t *ctx, proxy_worker *worker,
     }
     /* This *could* have changed via the Balancer Manager */
     /* TODO */
-    if (hc->s->method != worker->s->method) {
+    if (hc->s->method != worker->s->method || !strcmp(hc->s->hostname_ex, worker->s->hostname_ex) || hc->s->port != worker->s->port) {
         wctx_t *wctx = hc->context;
         port = (worker->s->port ? worker->s->port
                                 : ap_proxy_port_of_scheme(worker->s->scheme));
@@ -543,6 +543,8 @@ static proxy_worker *hc_get_hcworker(sctx_t *ctx, proxy_worker *worker,
                      worker, worker->s->scheme, worker->s->hostname_ex,
                      (int)port);
         hc->s->method = worker->s->method;
+        hc->s->port = port;
+        strcpy(hc->s->hostname_ex, worker->s->hostname_ex);
         create_hcheck_req(wctx, hc, ctx->p);
     }
     return hc;

--- a/modules/proxy/mod_proxy_hcheck.c
+++ b/modules/proxy/mod_proxy_hcheck.c
@@ -534,7 +534,9 @@ static proxy_worker *hc_get_hcworker(sctx_t *ctx, proxy_worker *worker,
     }
     /* This *could* have changed via the Balancer Manager */
     /* TODO */
-    if (hc->s->method != worker->s->method || !strcmp(hc->s->hostname_ex, worker->s->hostname_ex) || hc->s->port != worker->s->port) {
+    if (hc->s->method != worker->s->method 
+        || strcmp(hc->s->hostname_ex, worker->s->hostname_ex) != 0
+        || hc->s->port != worker->s->port) {
         wctx_t *wctx = hc->context;
         port = (worker->s->port ? worker->s->port
                                 : ap_proxy_port_of_scheme(worker->s->scheme));

--- a/modules/proxy/proxy_util.c
+++ b/modules/proxy/proxy_util.c
@@ -2768,7 +2768,16 @@ ap_proxy_determine_connection(apr_pool_t *p, request_rec *r,
             socket_cleanup(conn);
             conn->close = 0;
         }
-        if (will_reuse) {
+        if (will_reuse) {         
+            if(!strcmp(conn->hostname, worker->s->hostname_ex) || conn->port != worker->s->port) {
+                apr_sockaddr_t *addr;
+                err = apr_sockaddr_info_get(&addr,
+                                            worker->s->hostname_ex, APR_UNSPEC,
+                                            worker->s->port, 0,
+                                            worker->cp->dns_pool);
+                worker->cp->addr = addr;
+            }
+
             /*
              * Looking up the backend address for the worker only makes sense if
              * we can reuse the address.

--- a/modules/proxy/proxy_util.c
+++ b/modules/proxy/proxy_util.c
@@ -2769,7 +2769,7 @@ ap_proxy_determine_connection(apr_pool_t *p, request_rec *r,
             conn->close = 0;
         }
         if (will_reuse) {         
-            if(!strcmp(conn->hostname, worker->s->hostname_ex) || conn->port != worker->s->port) {
+            if(strcmp(conn->hostname, worker->s->hostname_ex) != 0 || conn->port != worker->s->port) {
                 apr_sockaddr_t *addr;
                 err = apr_sockaddr_info_get(&addr,
                                             worker->s->hostname_ex, APR_UNSPEC,


### PR DESCRIPTION
The goal of this pr is to change the balancer member url (host and port) dynamically. 

In order to edit a member, we defined 2 params to pass: 
b_ewyes: a boolean that needs to be set to 1 for the edit to work 
b_ewrkr: the new url for the worker

The UI was updated to account for these 2 fields.