### PR TITLE
Add MPEG-TS file extensions

### DIFF
--- a/docs/conf/mime.types
+++ b/docs/conf/mime.types
@@ -1645,7 +1645,7 @@ model/vnd.gdl					gdl
 # model/vnd.gs.gdl
 model/vnd.gtw					gtw
 # model/vnd.moml+xml
-model/vnd.mts					mts
+# model/vnd.mts
 # model/vnd.opengex
 # model/vnd.parasolid.transmit.binary
 # model/vnd.parasolid.transmit.text
@@ -1784,7 +1784,7 @@ video/jpm					jpm jpgm
 video/mj2					mj2 mjp2
 # video/mp1s
 # video/mp2p
-# video/mp2t
+video/mp2t					ts m2t m2ts mts
 video/mp4					mp4 mp4v mpg4
 # video/mp4v-es
 video/mpeg					mpeg mpg mpe m1v m2v


### PR DESCRIPTION
[Extensions (per FFmpeg)](https://github.com/FFmpeg/FFmpeg/blob/n6.0/libavformat/mpegtsenc.c#L2345)

The mts extension is predominantly used for AVCHD files recorded by camcorders. I cannot find any evidence of `model/vnd.mts` being used for anything and it seems to be for a defunct file format.