### PR TITLE
Arrange the bybusyness logic and prevent bad busy values.

### DIFF
--- a/modules/proxy/balancers/mod_lbmethod_bybusyness.c
+++ b/modules/proxy/balancers/mod_lbmethod_bybusyness.c
@@ -29,11 +29,11 @@ static APR_OPTIONAL_FN_TYPE(proxy_balancer_get_best_worker)
 static int is_best_bybusyness(proxy_worker *current, proxy_worker *prev_best, void *baton)
 {
     int *total_factor = (int *)baton;
+    apr_size_t current_busy = getbusy_count(current);
+    apr_size_t prev_best_busy = 0;
 
     current->s->lbstatus += current->s->lbfactor;
     *total_factor += current->s->lbfactor;
-    apr_size_t current_busy = getbusy_count(current);
-    apr_size_t prev_best_busy = 0;
     if (prev_best)
         prev_best_busy = getbusy_count(prev_best);
      

--- a/modules/proxy/balancers/mod_lbmethod_bybusyness.c
+++ b/modules/proxy/balancers/mod_lbmethod_bybusyness.c
@@ -25,18 +25,24 @@ module AP_MODULE_DECLARE_DATA lbmethod_bybusyness_module;
 static APR_OPTIONAL_FN_TYPE(proxy_balancer_get_best_worker)
                             *ap_proxy_balancer_get_best_worker_fn = NULL;
 
+
 static int is_best_bybusyness(proxy_worker *current, proxy_worker *prev_best, void *baton)
 {
     int *total_factor = (int *)baton;
 
     current->s->lbstatus += current->s->lbfactor;
     *total_factor += current->s->lbfactor;
+    apr_size_t current_busy = getbusy_count(current);
+    apr_size_t prev_best_busy = 0;
+    if (prev_best)
+        prev_best_busy = getbusy_count(prev_best);
+     
 
     return (
         !prev_best
-        || (current->s->busy < prev_best->s->busy)
+        || (current_busy < prev_best_busy)
         || (
-            (current->s->busy == prev_best->s->busy)
+            (current_busy == prev_best_busy)
             && (current->s->lbstatus > prev_best->s->lbstatus)
         )
     );
@@ -65,7 +71,7 @@ static apr_status_t reset(proxy_balancer *balancer, server_rec *s)
     worker = (proxy_worker **)balancer->workers->elts;
     for (i = 0; i < balancer->workers->nelts; i++, worker++) {
         (*worker)->s->lbstatus = 0;
-        (*worker)->s->busy = 0;
+        setbusy_count(*worker, 0); 
     }
     return APR_SUCCESS;
 }

--- a/modules/proxy/balancers/mod_lbmethod_bybusyness.c
+++ b/modules/proxy/balancers/mod_lbmethod_bybusyness.c
@@ -15,6 +15,7 @@
  */
 
 #include "mod_proxy.h"
+#include "proxy_util.h"
 #include "scoreboard.h"
 #include "ap_mpm.h"
 #include "apr_version.h"

--- a/modules/proxy/mod_proxy.h
+++ b/modules/proxy/mod_proxy.h
@@ -467,7 +467,7 @@ typedef struct {
     apr_size_t      recv_buffer_size;
     apr_size_t      io_buffer_size;
     apr_size_t      elected;    /* Number of times the worker was elected */
-    volatile apr_size_t      busy;       /* busyness factor */
+    apr_size_t      busy;       /* busyness factor */
     apr_size_t      response_field_size; /* Size of proxy response buffer in bytes. */
     apr_port_t      port;
     apr_off_t       transferred;/* Number of bytes transferred to remote */
@@ -1577,38 +1577,6 @@ PROXY_DECLARE(apr_status_t) ap_proxy_transfer_between_connections(
                                                        int *sent,
                                                        apr_off_t bsize,
                                                        int flags);
-/*
- * Get the busy counter from the shared worker memory
- *
- * @param worker_ Pointer to the worker structure.
- * @return      apr_size_t value atomically read for the worker.
- */
-PROXY_DECLARE(apr_size_t) getbusy_count(void *worker_);
-
-/*
- * Set the busy counter from the shared worker memory
- *
- * @param worker_ Pointer to the worker structure.
- * @param busy value to set the busy counter.
- * @return      void
- */
-PROXY_DECLARE(void) setbusy_count(void *worker_, apr_size_t busy);
-
-/*
- * decrement the busy counter from the shared worker memory
- *
- * @param worker_ Pointer to the worker structure.
- * @return      apr_status_t returns APR_SUCCESS.
- */
-PROXY_DECLARE(apr_status_t) decrement_busy_count(void *worker_);
-
-/*
- * increment the busy counter from the shared worker memory
- *
- * @param worker_ Pointer to the worker structure.
- * @return      void
- */
-PROXY_DECLARE(void) increment_busy_count(void *worker_);
 
 extern module PROXY_DECLARE_DATA proxy_module;
 

--- a/modules/proxy/mod_proxy.h
+++ b/modules/proxy/mod_proxy.h
@@ -467,7 +467,7 @@ typedef struct {
     apr_size_t      recv_buffer_size;
     apr_size_t      io_buffer_size;
     apr_size_t      elected;    /* Number of times the worker was elected */
-    apr_size_t      busy;       /* busyness factor */
+    volatile apr_size_t      busy;       /* busyness factor */
     apr_size_t      response_field_size; /* Size of proxy response buffer in bytes. */
     apr_port_t      port;
     apr_off_t       transferred;/* Number of bytes transferred to remote */
@@ -1577,6 +1577,38 @@ PROXY_DECLARE(apr_status_t) ap_proxy_transfer_between_connections(
                                                        int *sent,
                                                        apr_off_t bsize,
                                                        int flags);
+/*
+ * Get the busy counter from the shared worker memory
+ *
+ * @param worker_ Pointer to the worker structure.
+ * @return      apr_size_t value atomically read for the worker.
+ */
+PROXY_DECLARE(apr_size_t) getbusy_count(void *worker_);
+
+/*
+ * Set the busy counter from the shared worker memory
+ *
+ * @param worker_ Pointer to the worker structure.
+ * @param busy value to set the busy counter.
+ * @return      void
+ */
+PROXY_DECLARE(void) setbusy_count(void *worker_, apr_size_t busy);
+
+/*
+ * decrement the busy counter from the shared worker memory
+ *
+ * @param worker_ Pointer to the worker structure.
+ * @return      apr_status_t returns APR_SUCCESS.
+ */
+PROXY_DECLARE(apr_status_t) decrement_busy_count(void *worker_);
+
+/*
+ * increment the busy counter from the shared worker memory
+ *
+ * @param worker_ Pointer to the worker structure.
+ * @return      void
+ */
+PROXY_DECLARE(void) increment_busy_count(void *worker_);
 
 extern module PROXY_DECLARE_DATA proxy_module;
 

--- a/modules/proxy/mod_proxy_balancer.c
+++ b/modules/proxy/mod_proxy_balancer.c
@@ -17,6 +17,7 @@
 /* Load balancer module for Apache proxy */
 
 #include "mod_proxy.h"
+#include "proxy_util.h"
 #include "scoreboard.h"
 #include "ap_mpm.h"
 #include "apr_version.h"

--- a/modules/proxy/proxy_util.h
+++ b/modules/proxy/proxy_util.h
@@ -40,6 +40,39 @@ extern PROXY_DECLARE_DATA const apr_strmatch_pattern *ap_proxy_strmatch_domain;
  */
 void proxy_util_register_hooks(apr_pool_t *p);
 
+/*
+ * Get the busy counter from the shared worker memory
+ *
+ * @param worker_ Pointer to the worker structure.
+ * @return      apr_size_t value atomically read for the worker.
+ */
+PROXY_DECLARE(apr_size_t) getbusy_count(void *worker_);
+
+/*
+ * Set the busy counter from the shared worker memory
+ *
+ * @param worker_ Pointer to the worker structure.
+ * @param busy value to set the busy counter.
+ * @return      void
+ */
+PROXY_DECLARE(void) setbusy_count(void *worker_, apr_size_t busy);
+
+/*
+ * decrement the busy counter from the shared worker memory
+ *
+ * @param worker_ Pointer to the worker structure.
+ * @return      apr_status_t returns APR_SUCCESS.
+ */
+PROXY_DECLARE(apr_status_t) decrement_busy_count(void *worker_);
+
+/*
+ * increment the busy counter from the shared worker memory
+ *
+ * @param worker_ Pointer to the worker structure.
+ * @return      void
+ */
+PROXY_DECLARE(void) increment_busy_count(void *worker_);
+
 /** @} */
 
 #endif /* PROXY_UTIL_H_ */

--- a/modules/proxy/proxy_util.h
+++ b/modules/proxy/proxy_util.h
@@ -43,22 +43,24 @@ void proxy_util_register_hooks(apr_pool_t *p);
 /*
  * Get the busy counter from the shared worker memory
  *
- * @param worker_ Pointer to the worker structure.
+ * @param worker Pointer to the worker structure.
  * @return      apr_size_t value atomically read for the worker.
  */
-PROXY_DECLARE(apr_size_t) getbusy_count(void *worker_);
+PROXY_DECLARE(apr_size_t) getbusy_count(proxy_worker *worker);
 
 /*
  * Set the busy counter from the shared worker memory
  *
- * @param worker_ Pointer to the worker structure.
- * @param busy value to set the busy counter.
+ * @param worker Pointer to the worker structure.
+ * @param to value to set the busy counter.
  * @return      void
  */
-PROXY_DECLARE(void) setbusy_count(void *worker_, apr_size_t busy);
+PROXY_DECLARE(void) setbusy_count(proxy_worker *worker, apr_size_t to);
 
 /*
  * decrement the busy counter from the shared worker memory
+ * note it is called by apr_pool_cleanup_register()
+ * therfore the void * and apr_status_t.
  *
  * @param worker_ Pointer to the worker structure.
  * @return      apr_status_t returns APR_SUCCESS.
@@ -68,10 +70,10 @@ PROXY_DECLARE(apr_status_t) decrement_busy_count(void *worker_);
 /*
  * increment the busy counter from the shared worker memory
  *
- * @param worker_ Pointer to the worker structure.
+ * @param worker Pointer to the worker structure.
  * @return      void
  */
-PROXY_DECLARE(void) increment_busy_count(void *worker_);
+PROXY_DECLARE(void) increment_busy_count(proxy_worker *worker);
 
 /** @} */
 


### PR DESCRIPTION
Use atomic to prevent busy value increasing and preventing bybusyness balancer working correctly.