### PR TITLE
Update scoreboard.h

### DIFF
--- a/include/scoreboard.h
+++ b/include/scoreboard.h
@@ -114,7 +114,7 @@ struct worker_score {
 #endif
     char client[32];            /* DEPRECATED: Keep 'em small... */
     char request[64];           /* We just want an idea... */
-    char vhost[32];             /* What virtual host is being accessed? */
+    char vhost[64];             /* What virtual host is being accessed? */
     char protocol[16];          /* What protocol is used on the connection? */
     char client64[64];
     apr_time_t duration;


### PR DESCRIPTION
Update vhost to char 64 to display longer domain names in the scoreboard. When using mod_status extensively, long domain names are truncated to 32 characters. A label in DNS (between the dots) allows up to 63 characters. Although this change might still cause a virtual host name to be trucated to 64 characters many will be displayed in full.