### PR TITLE
mod_xml2enc: remove dependency on xmlstring header

### DIFF
--- a/modules/filters/mod_xml2enc.c
+++ b/modules/filters/mod_xml2enc.c
@@ -209,7 +209,7 @@ static void sniff_encoding(request_rec* r, xml2ctx* ctx)
   
     /* to sniff, first we look for BOM */
     if (ctx->xml2enc == XML_CHAR_ENCODING_NONE) {
-        ctx->xml2enc = xmlDetectCharEncoding((const xmlChar*)ctx->buf,
+        ctx->xml2enc = xmlDetectCharEncoding((const unsigned char*)ctx->buf,
                                              ctx->bytes); 
         if (HAVE_ENCODING(ctx->xml2enc)) {
             ap_log_rerror(APLOG_MARK, APLOG_INFO, 0, r, APLOGNO(01432)


### PR DESCRIPTION
Include of libxml/xmlstring.h was removed from libxml/encoding.h in libxml2 v2.12.0
https://github.com/GNOME/libxml2/commit/7909ff08e2e755e8e7c99c3e12ad7254ef728a1f
