### PR TITLE
remove xmlChar

### DIFF
--- a/changes-entries/xml2enc.txt
+++ b/changes-entries/xml2enc.txt
@@ -1,0 +1,2 @@
+  *) mod_xml2enc: Tolerate libxml2 2.12.0 and later.
+     [https://github.com/ttachi]

--- a/modules/filters/mod_xml2enc.c
+++ b/modules/filters/mod_xml2enc.c
@@ -206,11 +206,11 @@ static void sniff_encoding(request_rec* r, xml2ctx* ctx)
             }
         }
     }
-  
+
     /* to sniff, first we look for BOM */
     if (ctx->xml2enc == XML_CHAR_ENCODING_NONE) {
-        ctx->xml2enc = xmlDetectCharEncoding((const xmlChar*)ctx->buf,
-                                             ctx->bytes); 
+        ctx->xml2enc = xmlDetectCharEncoding((const unsigned char*)ctx->buf,
+                                             ctx->bytes);
         if (HAVE_ENCODING(ctx->xml2enc)) {
             ap_log_rerror(APLOG_MARK, APLOG_INFO, 0, r, APLOGNO(01432)
                           "Got charset from XML rules.") ;


### PR DESCRIPTION
Submitted By: https://github.com/ttachi

All the way back to 2.0.0 xmlDetectCharEncoding didn't take xmlChar. Now xmlChar libxml/encoding.h no longer includes the definition, since libxml2 v2.12.0

https://github.com/apache/httpd/pull/393.patch but get CI to run