### PR TITLE
mod_ssl: Add support for loading keys from OpenSSL 3.x providers via STORE

### DIFF
--- a/docs/manual/mod/mod_ssl.xml
+++ b/docs/manual/mod/mod_ssl.xml
@@ -2444,9 +2444,10 @@ SSLCryptoDevice ubsec
 </example>
 
 <p>
-With OpenSSL 3.0 or later, specify <code>provider</code> to load keys and
-certificates from a provider using <a href="https://tools.ietf.org/html/rfc7512">PKCS#11 URIs</a>.
-The provider to use must be defined and configured in the OpenSSL config file,
+With OpenSSL 3.0 or later, if no engine is specified but the key or certificate
+is specified using a <a href="https://tools.ietf.org/html/rfc7512">PKCS#11 URIs</a>
+then it is tried to load the key and certificate from an OpenSSL provider.
+The OpenSSL provider to use must be defined and configured in the OpenSSL config file,
 and it must support the <a href="https://www.openssl.org/docs/man3.0/man7/provider-storemgmt.html">STORE method</a>
 for <a href="https://tools.ietf.org/html/rfc7512">PKCS#11 URIs</a>.
 </p>

--- a/docs/manual/mod/mod_ssl.xml
+++ b/docs/manual/mod/mod_ssl.xml
@@ -955,7 +955,7 @@ files, a certificate identifier can be used to identify a certificate
 stored in a token.  Currently, only <a
 href="https://tools.ietf.org/html/rfc7512">PKCS#11 URIs</a> are
 recognized as certificate identifiers, and can be used in conjunction
-with the OpenSSL <code>pkcs11</code> engine.  If <directive
+with the OpenSSL <code>pkcs11</code> engine or provider.  If <directive
 module="mod_ssl">SSLCertificateKeyFile</directive> is omitted, the
 certificate and private key can be loaded through the single
 identifier specified with <directive
@@ -1048,7 +1048,7 @@ key file.</p>
 identifier can be used to identify a private key stored in a
 token.  Currently, only <a href="https://tools.ietf.org/html/rfc7512">PKCS#11 URIs</a> are recognized as private key
 identifiers, and can be used in conjunction with the OpenSSL
-<code>pkcs11</code> engine.</p>
+<code>pkcs11</code> engine or provider.</p>
 
 <example><title>Example</title>
 <highlight language="config">
@@ -2442,6 +2442,14 @@ separate "-engine" releases of OpenSSL 0.9.6 must be used.</p>
 SSLCryptoDevice ubsec
 </highlight>
 </example>
+
+<p>
+With OpenSSL 3.0 or later, specify <code>provider</code> to load keys and
+certificates from a provider using <a href="https://tools.ietf.org/html/rfc7512">PKCS#11 URIs</a>.
+The provider to use must be defined and configured in the OpenSSL config file,
+and it must support the <a href="https://www.openssl.org/docs/man3.0/man7/provider-storemgmt.html">STORE method</a>
+for <a href="https://tools.ietf.org/html/rfc7512">PKCS#11 URIs</a>.
+</p>
 </usage>
 </directivesynopsis>
 

--- a/modules/ssl/ssl_engine_config.c
+++ b/modules/ssl/ssl_engine_config.c
@@ -689,11 +689,6 @@ const char *ssl_cmd_SSLCryptoDevice(cmd_parms *cmd,
     if (strcEQ(arg, "builtin")) {
         mc->szCryptoDevice = NULL;
     }
-#if MODSSL_HAVE_OPENSSL_STORE
-    else if (strcEQ(arg, "provider")) {
-        mc->szCryptoDevice = arg;
-    }
-#endif
 #if MODSSL_HAVE_ENGINE_API
     else if ((e = ENGINE_by_id(arg))) {
         mc->szCryptoDevice = arg;
@@ -702,11 +697,7 @@ const char *ssl_cmd_SSLCryptoDevice(cmd_parms *cmd,
 #endif
     else {
         err = "SSLCryptoDevice: Invalid argument; must be one of: "
-              "'builtin' (none)"
-#if MODSSL_HAVE_OPENSSL_STORE
-              ", 'provider' (use OpenSSL >= 3.0 provider STORE)"
-#endif
-              ;
+              "'builtin' (none)";
 #if MODSSL_HAVE_ENGINE_API
         e = ENGINE_get_first();
         while (e) {

--- a/modules/ssl/ssl_engine_config.c
+++ b/modules/ssl/ssl_engine_config.c
@@ -689,6 +689,11 @@ const char *ssl_cmd_SSLCryptoDevice(cmd_parms *cmd,
     if (strcEQ(arg, "builtin")) {
         mc->szCryptoDevice = NULL;
     }
+#if MODSSL_HAVE_OPENSSL_STORE
+    else if (strcEQ(arg, "provider")) {
+        mc->szCryptoDevice = arg;
+    }
+#endif
 #if MODSSL_HAVE_ENGINE_API
     else if ((e = ENGINE_by_id(arg))) {
         mc->szCryptoDevice = arg;
@@ -697,7 +702,11 @@ const char *ssl_cmd_SSLCryptoDevice(cmd_parms *cmd,
 #endif
     else {
         err = "SSLCryptoDevice: Invalid argument; must be one of: "
-              "'builtin' (none)";
+              "'builtin' (none)"
+#if MODSSL_HAVE_OPENSSL_STORE
+              ", 'provider' (use OpenSSL >= 3.0 provider STORE)"
+#endif
+              ;
 #if MODSSL_HAVE_ENGINE_API
         e = ENGINE_get_first();
         while (e) {

--- a/modules/ssl/ssl_engine_init.c
+++ b/modules/ssl/ssl_engine_init.c
@@ -506,7 +506,11 @@ apr_status_t ssl_init_Engine(server_rec *s, apr_pool_t *p)
     SSLModConfigRec *mc = myModConfig(s);
     ENGINE *e;
 
+#if MODSSL_HAVE_OPENSSL_STORE
+    if (mc->szCryptoDevice && !strcEQ(mc->szCryptoDevice, "provider")) {
+#else
     if (mc->szCryptoDevice) {
+#endif
         if (!(e = ENGINE_by_id(mc->szCryptoDevice))) {
             ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s, APLOGNO(01888)
                          "Init: Failed to load Crypto Device API `%s'",
@@ -1476,8 +1480,8 @@ static apr_status_t ssl_init_server_certs(server_rec *s,
             if (cert) {
                 if (SSL_CTX_use_certificate(mctx->ssl_ctx, cert) < 1) {
                     ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s, APLOGNO(10137)
-                                 "Failed to configure engine certificate %s, check %s",
-                                 key_id, certfile);
+                                 "Failed to configure certificate %s from %s, check %s",
+                                 key_id, mc->szCryptoDevice, certfile);
                     ssl_log_ssl_error(SSLLOG_MARK, APLOG_EMERG, s);
                     return APR_EGENERAL;
                 }
@@ -1488,8 +1492,8 @@ static apr_status_t ssl_init_server_certs(server_rec *s,
             
             if (SSL_CTX_use_PrivateKey(mctx->ssl_ctx, pkey) < 1) {
                 ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s, APLOGNO(10130)
-                             "Failed to configure private key %s from engine",
-                             keyfile);
+                             "Failed to configure private key %s from %s",
+                             keyfile, mc->szCryptoDevice);
                 ssl_log_ssl_error(SSLLOG_MARK, APLOG_EMERG, s);
                 return APR_EGENERAL;
             }

--- a/modules/ssl/ssl_engine_init.c
+++ b/modules/ssl/ssl_engine_init.c
@@ -506,11 +506,7 @@ apr_status_t ssl_init_Engine(server_rec *s, apr_pool_t *p)
     SSLModConfigRec *mc = myModConfig(s);
     ENGINE *e;
 
-#if MODSSL_HAVE_OPENSSL_STORE
-    if (mc->szCryptoDevice && !strcEQ(mc->szCryptoDevice, "provider")) {
-#else
     if (mc->szCryptoDevice) {
-#endif
         if (!(e = ENGINE_by_id(mc->szCryptoDevice))) {
             ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s, APLOGNO(01888)
                          "Init: Failed to load Crypto Device API `%s'",
@@ -1481,7 +1477,9 @@ static apr_status_t ssl_init_server_certs(server_rec *s,
                 if (SSL_CTX_use_certificate(mctx->ssl_ctx, cert) < 1) {
                     ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s, APLOGNO(10137)
                                  "Failed to configure certificate %s from %s, check %s",
-                                 key_id, mc->szCryptoDevice, certfile);
+                                 key_id, mc->szCryptoDevice ?
+                                             mc->szCryptoDevice : "provider",
+                                 certfile);
                     ssl_log_ssl_error(SSLLOG_MARK, APLOG_EMERG, s);
                     return APR_EGENERAL;
                 }
@@ -1493,7 +1491,8 @@ static apr_status_t ssl_init_server_certs(server_rec *s,
             if (SSL_CTX_use_PrivateKey(mctx->ssl_ctx, pkey) < 1) {
                 ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s, APLOGNO(10130)
                              "Failed to configure private key %s from %s",
-                             keyfile, mc->szCryptoDevice);
+                             keyfile, mc->szCryptoDevice ?
+                                          mc->szCryptoDevice : "provider");
                 ssl_log_ssl_error(SSLLOG_MARK, APLOG_EMERG, s);
                 return APR_EGENERAL;
             }

--- a/modules/ssl/ssl_engine_pphrase.c
+++ b/modules/ssl/ssl_engine_pphrase.c
@@ -982,7 +982,7 @@ apr_status_t modssl_load_engine_keypair(server_rec *s, apr_pool_t *p,
 #if MODSSL_HAVE_OPENSSL_STORE
     SSLModConfigRec *mc = myModConfig(s);
 
-    if (strcEQ(mc->szCryptoDevice, "provider"))
+    if (!mc->szCryptoDevice)
         return modssl_load_keypair_store(s, p, vhostid, certid, keyid,
                                          pubkey, privkey);
 #endif

--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -118,6 +118,15 @@
 #define MODSSL_HAVE_ENGINE_API 0
 #endif
 
+/* Use OpenSSL 3.x STORE for loading URI keys and certificates starting with
+ * OpenSSL 3.0
+ */
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+#define MODSSL_HAVE_OPENSSL_STORE 1
+#else
+#define MODSSL_HAVE_OPENSSL_STORE 0
+#endif
+
 #if (OPENSSL_VERSION_NUMBER < 0x0090801f)
 #error mod_ssl requires OpenSSL 0.9.8a or later
 #endif

--- a/modules/ssl/ssl_util.c
+++ b/modules/ssl/ssl_util.c
@@ -500,7 +500,7 @@ void ssl_util_thread_setup(apr_pool_t *p)
 
 int modssl_is_engine_id(const char *name)
 {
-#if MODSSL_HAVE_ENGINE_API
+#if MODSSL_HAVE_ENGINE_API || MODSSL_HAVE_OPENSSL_STORE
     /* ### Can handle any other special ENGINE key names here? */
     return strncmp(name, "pkcs11:", 7) == 0;
 #else


### PR DESCRIPTION
The mod_ssl module has support for loading keys and certificates from OpenSSL engines via PKCS#11 URIs at SSLCertificateFile and SSLCertificateKeyFile, e.g. using the PKCS#11 engine part of libp11 (https://github.com/OpenSC/libp11).

This works fine, but with OpenSSL 3.0 engines got deprecated, and a new provider concept is used. OpenSSL 1.1.1 is no longer supported by the OpenSSL organization (https://www.openssl.org/blog/blog/2023/09/11/eol-111/), and newer distributions all have OpenSSL 3.x included. Currently, engines do still work, bit since they are deprecated, they will at some point in time no longer be working.

With OpenSSL 3.x providers one can implements loading of keys and certificates by implementing a STORE method. With this, keys and certificates can be loaded for example from PKCS#11 modules via PKCS#11 URIs, just like it was possible with an PKCS#11 engine.

This commit contains code changes required to support loading the server private key and certificates from a PKCS#11 provider using OpenSSL STORE providers.

The usage is very similar to how it was with engines. You can specify a PKCS#11 URI with SSLCertificateFile and SSLCertificateKeyFile, exactly how it is with engines. The only difference is that you must specify 'SSLCryptoDevice provider' as crypto device, instead of specifying the engine name.

That way, the code continues to support working with engines. So SSLCryptoDevice accepts either 'builtin' or an engine name as before, but now also 'provider' to enable the OpenSSL provider STORE API. Instead of choosing this approach, we could just replace the engine support by the provider support, but this might break existing installations that are still using engines.

The provider(s) to be used with httpd must be configured via the OpenSSL config file in the provider section. Most providers need additional, provider specific settings that can only be supplied via the OpenSSL config file.

If one does not like to configure the providers globally, one can have a separate OpenSSL config file and use environment variable OPENSSL_CONF to specify the config file to use. That way one can have an OpenSSL config file just for httpd.

Currently there exist 2 PKCS#11 provider projects:
- https://github.com/latchset/pkcs11-provider
- https://github.com/opencryptoki/openssl-pkcs11-sign-provider

Both do support loading keys via PKCS#11 URI via their STORE support, but the code below is not limited to just those two.
Any provider that supports a STORE implementation for URIs with the 'pkcs11' scheme can be used.