### PR TITLE
2.4.x: mod_xml2enc media type fixes

### DIFF
--- a/changes-entries/pr64339.txt
+++ b/changes-entries/pr64339.txt
@@ -1,0 +1,4 @@
+  *) mod_xml2enc: Update check to accept any text/ media type
+     or any XML media type per RFC 7303, avoiding
+     corruption of Microsoft OOXML formats.  PR 64339.
+     [Joseph Heenan <joseph.heenan fintechlabs.io>, Joe Orton]


### PR DESCRIPTION
```Merge r1884505, r1915625 from trunk:
The Microsoft OOXML format uses xml packaged into a zip file, and has mimetypes like:

application/vnd.openxmlformats-officedocument.spreadsheetml.sheet

This mimetypes contains 'xml', but is unfortunately not an xml file.

xml2enc processes these files (in particular, when mod_proxy_html is used), typically resulting in them being corrupted as it seems to attempt to perform a ISO-8859-1 to UTF-8 conversion on them.

* modules/filters/mod_xml2enc.c (xml2enc_ffunc): Restrict test for XML types to matching "+xml".

Submitted by: Joseph Heenan <joseph.heenan fintechlabs.io>, jorton
PR: 64339
Github: closes #150
```