### PR TITLE
Don't reset the balancer when we create a new child

### DIFF
--- a/modules/proxy/balancers/mod_lbmethod_bytraffic.c
+++ b/modules/proxy/balancers/mod_lbmethod_bytraffic.c
@@ -73,8 +73,6 @@ static apr_status_t reset(proxy_balancer *balancer, server_rec *s)
     proxy_worker **worker;
     worker = (proxy_worker **)balancer->workers->elts;
     for (i = 0; i < balancer->workers->nelts; i++, worker++) {
-        (*worker)->s->lbstatus = 0;
-        (*worker)->s->busy = 0;
         (*worker)->s->transferred = 0;
         (*worker)->s->read = 0;
     }

--- a/modules/proxy/proxy_util.c
+++ b/modules/proxy/proxy_util.c
@@ -1362,8 +1362,6 @@ PROXY_DECLARE(apr_status_t) ap_proxy_initialize_balancer(proxy_balancer *balance
         ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(00921) "slotmem_attach failed");
         return APR_EGENERAL;
     }
-    if (balancer->lbmethod && balancer->lbmethod->reset)
-        balancer->lbmethod->reset(balancer, s);
 
 #if APR_HAS_THREADS
     if (balancer->tmutex == NULL) {


### PR DESCRIPTION
and don't change shared memory the load balancer is not using.