### PR TITLE
mod_ssl: Follow up to r1913815: szCryptoDevice to NULL when !MODSSL_HAVE_ENGINE_API

### DIFF
--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -652,9 +652,7 @@ typedef struct {
      * index), for example the string "vhost.example.com:443:0". */
     apr_hash_t     *tPrivateKey;
 
-#if defined(HAVE_OPENSSL_ENGINE_H) && defined(HAVE_ENGINE_INIT)
-    const char     *szCryptoDevice;
-#endif
+    const char     *szCryptoDevice; /* ENGINE device (if available) */
 
 #ifdef HAVE_OCSP_STAPLING
     const ap_socache_provider_t *stapling_cache;


### PR DESCRIPTION
Latest OpenSSL versions removed the ENGINE API completely, still provide NULL SSLModConfigRec::szCryptoDevice since it's used outside MODSSL_HAVE_ENGINE_API.

SSLModConfigRec is a private struct, so no MMN change.

* modules/ssl/ssl_private(SSLModConfigRec): Provide szCryptoDevice (NULL) even if !MODSSL_HAVE_ENGINE_API.

git-svn-id: https://svn.apache.org/repos/asf/httpd/httpd/trunk@1915889 13f79535-47bb-0310-9956-ffa450edef68 (cherry picked from commit 339cb1b5040dd83ce65f5c098870fabb1cbaf34c)