### PR TITLE
mod_systemd: if SELinux is available and enabled, log the SELinux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -246,7 +246,8 @@ jobs:
               TEST_INSTALL=1
               TEST_MOD_TLS=1
           - name: Configured w/reduced exports
-            config: --enable-reduced-exports --enable-maintainer-mode
+            config: --enable-reduced-exports --enable-maintainer-mode --enable-systemd
+            pkgs: libsystemd-dev
             env: |
               SKIP_TESTING=1
               TEST_INSTALL=1

--- a/changes-entries/systemd-selinux.patch
+++ b/changes-entries/systemd-selinux.patch
@@ -1,0 +1,2 @@
+  *) mod_systemd: Log the SELinux context at startup if available and
+     enabled.  [Joe Orton]

--- a/modules/arch/unix/config5.m4
+++ b/modules/arch/unix/config5.m4
@@ -25,6 +25,11 @@ APACHE_MODULE(systemd, Systemd support, , , no, [
     AC_MSG_WARN([Your system does not support systemd.])
     enable_systemd="no"
   else
+    AC_CHECK_LIB(selinux, is_selinux_enabled, [
+      AC_DEFINE(HAVE_SELINUX, 1, [Defined if SELinux is supported])
+      APR_ADDTO(MOD_SYSTEMD_LDADD, [-lselinux])
+    ])
+
     APR_ADDTO(MOD_SYSTEMD_LDADD, [$SYSTEMD_LIBS])
   fi
 ])


### PR DESCRIPTION
```
mod_systemd: if SELinux is available and enabled, log the SELinux context at startup, since this may vary when httpd is started via systemd vs being started directly.

* modules/arch/unix/mod_systemd.c (systemd_post_config): Do nothing for the pre-config iteration. Log the SELinux context if available.

* modules/arch/unix/config5.m4: Detect libselinux.
```