### PR TITLE
mod_ssl: Switch to using SSL_OP_NO_RENEGOTIATION

### DIFF
--- a/changes-entries/modssl-no-reneg.txt
+++ b/changes-entries/modssl-no-reneg.txt
@@ -1,0 +1,2 @@
+  *) mod_ssl: Reject client-initiated renegotiation with a TLS alert
+     (rather than connection closure).  [Joe Orton, Yann Ylavic]

--- a/modules/ssl/ssl_engine_io.c
+++ b/modules/ssl/ssl_engine_io.c
@@ -208,11 +208,13 @@ static int bio_filter_out_write(BIO *bio, const char *in, int inl)
 
     BIO_clear_retry_flags(bio);
 
+#ifndef SSL_OP_NO_RENEGOTIATION
     /* Abort early if the client has initiated a renegotiation. */
     if (outctx->filter_ctx->config->reneg_state == RENEG_ABORT) {
         outctx->rc = APR_ECONNABORTED;
         return -1;
     }
+#endif
 
     ap_log_cerror(APLOG_MARK, APLOG_TRACE6, 0, outctx->c,
                   "bio_filter_out_write: %i bytes", inl);
@@ -473,11 +475,13 @@ static int bio_filter_in_read(BIO *bio, char *in, int inlen)
 
     BIO_clear_retry_flags(bio);
 
+#ifndef SSL_OP_NO_RENEGOTIATION
     /* Abort early if the client has initiated a renegotiation. */
     if (inctx->filter_ctx->config->reneg_state == RENEG_ABORT) {
         inctx->rc = APR_ECONNABORTED;
         return -1;
     }
+#endif
 
     if (!inctx->bb) {
         inctx->rc = APR_EOF;

--- a/modules/ssl/ssl_engine_kernel.c
+++ b/modules/ssl/ssl_engine_kernel.c
@@ -2260,7 +2260,7 @@ static void log_tracing_state(const SSL *ssl, conn_rec *c,
 /*
  * This callback function is executed while OpenSSL processes the SSL
  * handshake and does SSL record layer stuff.  It's used to trap
- * client-initiated renegotiations (where SSL_OP_NO_RENEGOTATION is
+ * client-initiated renegotiations (where SSL_OP_NO_RENEGOTIATION is
  * not available), and for dumping everything to the log.
  */
 void ssl_callback_Info(const SSL *ssl, int where, int rc)
@@ -2273,12 +2273,12 @@ void ssl_callback_Info(const SSL *ssl, int where, int rc)
         return;
     }
 
-#ifndef SSL_OP_NO_RENEGOTATION
+#ifndef SSL_OP_NO_RENEGOTIATION
     /* With OpenSSL < 1.1.1 (implying TLS v1.2 or earlier), this
      * callback is used to block client-initiated renegotiation.  With
      * TLSv1.3 it is unnecessary since renegotiation is forbidden at
      * protocol level.  Otherwise (TLSv1.2 with OpenSSL >=1.1.1),
-     * SSL_OP_NO_RENEGOTATION is used to block renegotiation. */
+     * SSL_OP_NO_RENEGOTIATION is used to block renegotiation. */
     {
         SSLConnRec *sslconn;
 

--- a/modules/ssl/ssl_engine_kernel.c
+++ b/modules/ssl/ssl_engine_kernel.c
@@ -992,7 +992,7 @@ static int ssl_hook_Access_classic(request_rec *r, SSLSrvConfigRec *sc, SSLDirCo
 
             /* Toggle the renegotiation state to allow the new
              * handshake to proceed. */
-            sslconn->reneg_state = RENEG_ALLOW;
+            modssl_set_reneg_state(sslconn, RENEG_ALLOW);
 
             SSL_renegotiate(ssl);
             SSL_do_handshake(ssl);
@@ -1019,7 +1019,7 @@ static int ssl_hook_Access_classic(request_rec *r, SSLSrvConfigRec *sc, SSLDirCo
              */
             SSL_peek(ssl, peekbuf, 0);
 
-            sslconn->reneg_state = RENEG_REJECT;
+            modssl_set_reneg_state(sslconn, RENEG_REJECT);
 
             if (!SSL_is_init_finished(ssl)) {
                 ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, APLOGNO(02261)
@@ -1078,7 +1078,7 @@ static int ssl_hook_Access_modern(request_rec *r, SSLSrvConfigRec *sc, SSLDirCon
         (sc->server->auth.verify_mode != SSL_CVERIFY_UNSET)) {
         int vmode_inplace, vmode_needed;
         int change_vmode = FALSE;
-        int old_state, n, rc;
+        int n, rc;
 
         vmode_inplace = SSL_get_verify_mode(ssl);
         vmode_needed = SSL_VERIFY_NONE;
@@ -1180,8 +1180,6 @@ static int ssl_hook_Access_modern(request_rec *r, SSLSrvConfigRec *sc, SSLDirCon
                 return HTTP_FORBIDDEN;
             }
             
-            old_state = sslconn->reneg_state;
-            sslconn->reneg_state = RENEG_ALLOW;
             modssl_set_app_data2(ssl, r);
 
             SSL_do_handshake(ssl);
@@ -1191,7 +1189,6 @@ static int ssl_hook_Access_modern(request_rec *r, SSLSrvConfigRec *sc, SSLDirCon
              */
             SSL_peek(ssl, peekbuf, 0);
 
-            sslconn->reneg_state = old_state;
             modssl_set_app_data2(ssl, NULL);
 
             /*
@@ -2263,8 +2260,8 @@ static void log_tracing_state(const SSL *ssl, conn_rec *c,
 /*
  * This callback function is executed while OpenSSL processes the SSL
  * handshake and does SSL record layer stuff.  It's used to trap
- * client-initiated renegotiations, and for dumping everything to the
- * log.
+ * client-initiated renegotiations (where SSL_OP_NO_RENEGOTATION is
+ * not available), and for dumping everything to the log.
  */
 void ssl_callback_Info(const SSL *ssl, int where, int rc)
 {
@@ -2276,14 +2273,12 @@ void ssl_callback_Info(const SSL *ssl, int where, int rc)
         return;
     }
 
-    /* With TLS 1.3 this callback may be called multiple times on the first
-     * negotiation, so the below logic to detect renegotiations can't work.
-     * Fortunately renegotiations are forbidden starting with TLS 1.3, and
-     * this is enforced by OpenSSL so there's nothing to be done here.
-     */
-#if SSL_HAVE_PROTOCOL_TLSV1_3
-    if (SSL_version(ssl) < TLS1_3_VERSION)
-#endif
+#ifndef SSL_OP_NO_RENEGOTATION
+    /* With OpenSSL < 1.1.1 (implying TLS v1.2 or earlier), this
+     * callback is used to block client-initiated renegotiation.  With
+     * TLSv1.3 it is unnecessary since renegotiation is forbidden at
+     * protocol level.  Otherwise (TLSv1.2 with OpenSSL >=1.1.1),
+     * SSL_OP_NO_RENEGOTATION is used to block renegotiation. */
     {
         SSLConnRec *sslconn;
 
@@ -2308,6 +2303,7 @@ void ssl_callback_Info(const SSL *ssl, int where, int rc)
             sslconn->reneg_state = RENEG_REJECT;
         }
     }
+#endif
 
     s = mySrvFromConn(c);
     if (s && APLOGdebug(s)) {

--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -549,6 +549,16 @@ typedef struct {
     apr_time_t     source_mtime;
 } ssl_asn1_t;
 
+typedef enum {
+    RENEG_INIT = 0, /* Before initial handshake */
+    RENEG_REJECT,   /* After initial handshake; any client-initiated
+                     * renegotiation should be rejected */
+    RENEG_ALLOW,    /* A server-initiated renegotiation is taking
+                     * place (as dictated by configuration) */
+    RENEG_ABORT     /* Renegotiation initiated by client, abort the
+                     * connection */
+} modssl_reneg_state;
+
 /**
  * Define the mod_ssl per-module configuration structure
  * (i.e. the global configuration for each httpd process)
@@ -580,18 +590,13 @@ typedef struct {
         NON_SSL_SET_ERROR_MSG  /* Need to set the error message */
     } non_ssl_request;
 
-    /* Track the handshake/renegotiation state for the connection so
-     * that all client-initiated renegotiations can be rejected, as a
-     * partial fix for CVE-2009-3555. */
-    enum {
-        RENEG_INIT = 0, /* Before initial handshake */
-        RENEG_REJECT,   /* After initial handshake; any client-initiated
-                         * renegotiation should be rejected */
-        RENEG_ALLOW,    /* A server-initiated renegotiation is taking
-                         * place (as dictated by configuration) */
-        RENEG_ABORT     /* Renegotiation initiated by client, abort the
-                         * connection */
-    } reneg_state;
+#ifndef SSL_OP_NO_RENEGOTATION
+    /* For OpenSSL < 1.1.1, track the handshake/renegotiation state
+     * for the connection to block client-initiated renegotiations.
+     * For OpenSSL >=1.1.1, the SSL_OP_NO_RENEGOTATION flag is used in
+     * the SSL * options state with equivalent effect. */
+    modssl_reneg_state reneg_state;
+#endif
 
     server_rec *server;
     SSLDirConfigRec *dc;
@@ -1197,6 +1202,9 @@ int ssl_is_challenge(conn_rec *c, const char *servername,
 /* Returns non-zero if the cert/key filename should be handled through
  * the configured ENGINE. */
 int modssl_is_engine_id(const char *name);
+
+/* Set the renegotation state for connection. */
+void modssl_set_reneg_state(SSLConnRec *sslconn, modssl_reneg_state state);
 
 #endif /* SSL_PRIVATE_H */
 /** @} */

--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -590,10 +590,10 @@ typedef struct {
         NON_SSL_SET_ERROR_MSG  /* Need to set the error message */
     } non_ssl_request;
 
-#ifndef SSL_OP_NO_RENEGOTATION
+#ifndef SSL_OP_NO_RENEGOTIATION
     /* For OpenSSL < 1.1.1, track the handshake/renegotiation state
      * for the connection to block client-initiated renegotiations.
-     * For OpenSSL >=1.1.1, the SSL_OP_NO_RENEGOTATION flag is used in
+     * For OpenSSL >=1.1.1, the SSL_OP_NO_RENEGOTIATION flag is used in
      * the SSL * options state with equivalent effect. */
     modssl_reneg_state reneg_state;
 #endif

--- a/modules/ssl/ssl_util_ssl.c
+++ b/modules/ssl/ssl_util_ssl.c
@@ -615,13 +615,13 @@ cleanup:
 
 void modssl_set_reneg_state(SSLConnRec *sslconn, modssl_reneg_state state)
 {
-#ifdef SSL_OP_NO_RENEGOTATION
+#ifdef SSL_OP_NO_RENEGOTIATION
     switch (state) {
     case RENEG_ALLOW:
-        SSL_clear_options(sslconn->ssl, SSL_OP_NO_RENEGOTATION);
+        SSL_clear_options(sslconn->ssl, SSL_OP_NO_RENEGOTIATION);
         break;
     default:
-        SSL_set_options(sslconn->ssl, SSL_OP_NO_RENEGOTATION);
+        SSL_set_options(sslconn->ssl, SSL_OP_NO_RENEGOTIATION);
         break;
     }
 #else

--- a/modules/ssl/ssl_util_ssl.c
+++ b/modules/ssl/ssl_util_ssl.c
@@ -612,3 +612,19 @@ cleanup:
     }
     return rv;
 }
+
+void modssl_set_reneg_state(SSLConnRec *sslconn, modssl_reneg_state state)
+{
+#ifdef SSL_OP_NO_RENEGOTATION
+    switch (state) {
+    case RENEG_ALLOW:
+        SSL_clear_options(sslconn->ssl, SSL_OP_NO_RENEGOTATION);
+        break;
+    default:
+        SSL_set_options(sslconn->ssl, SSL_OP_NO_RENEGOTATION);
+        break;
+    }
+#else
+    sslconn->reneg_state = state;
+#endif
+}


### PR DESCRIPTION
```
mod_ssl: Switch to using SSL_OP_NO_RENEGOTIATION (where available) to
block client-initiated renegotiation with TLSv1.2 and earlier.

* modules/ssl/ssl_private.h: Define modssl_reneg_state enum, modssl_set_reneg_state function.

* modules/ssl/ssl_engine_io.c (bio_filter_out_write, bio_filter_in_read): #ifdef-out reneg protection if SSL_OP_NO_RENEGOTIATION is defined.

* modules/ssl/ssl_engine_init.c (ssl_init_ctx_protocol): Enable SSL_OP_NO_RENEGOTIATION. (ssl_init_ctx_callbacks): Only enable the "info" callback if debug-level logging *or* OpenSSL doesn't support SSL_OP_NO_RENEGOTIATION.

* modules/ssl/ssl_engine_kernel.c (ssl_hook_Access_classic): Use modssl_set_reneg_state to set the reneg protection mode. (ssl_hook_Access_modern): Drop manipulation of the reneg mode which does nothing for TLSv1.3 already. (ssl_callback_Info): Only enable reneg protection if SSL_OP_NO_RENEGOTIATION is *not* defined.

* modules/ssl/ssl_util_ssl.c (modssl_set_reneg_state): New function.

git-svn-id: https://svn.apache.org/repos/asf/httpd/httpd/trunk@1877397 13f79535-47bb-0310-9956-ffa450edef68 (cherry picked from commit b8155f30da21c8c9dd3efd3d44d81af9e87e4ef3)
```