### PR TITLE
Fix error:unknown type name 'xmlChar'

### DIFF
--- a/modules/filters/mod_xml2enc.c
+++ b/modules/filters/mod_xml2enc.c
@@ -36,6 +36,7 @@
 
 /* libxml2 */
 #include <libxml/encoding.h>
+#include <libxml/xmlstring.h>
 
 #if defined(__clang__)
 #pragma clang diagnostic pop


### PR DESCRIPTION
When compiling httpd using the latest tag v2.12.6 of libxml2, an error occurs:unknown type name 'xmlChar'.

Compile command:
```
./configure --enable-mods-shared=reallyall --enable-mpms-shared=all
make
```

Detailed error message:
```
mod_xml2enc.c: In function 'sniff_encoding':
mod_xml2enc.c:212:53: error: unknown type name 'xmlChar'
  212 |         ctx->xml2enc = xmlDetectCharEncoding((const xmlChar*)ctx->buf,
      |                                                     ^~~~~~~
make[4]: *** [/home/httpd-2.4.58/build/rules.mk:212: mod_xml2enc.slo] Error 1
make[4]: Leaving directory '/home/httpd-2.4.58/modules/filters'
make[3]: *** [/home/httpd-2.4.58/build/rules.mk:117: shared-build-recursive] Error 1
make[3]: Leaving directory '/home/httpd-2.4.58/modules/filters'
make[2]: *** [/home/httpd-2.4.58/build/rules.mk:117: shared-build-recursive] Error 1
make[2]: Leaving directory '/home/httpd-2.4.58/modules'
make[1]: *** [/home/httpd-2.4.58/build/rules.mk:117: shared-build-recursive] Error 1
make[1]: Leaving directory '/home/httpd-2.4.58'
make: *** [/home/httpd-2.4.58/build/rules.mk:75: all-recursive] Error 1
```

