### PR TITLE
Use AP_DECLARE_MODULE in Developing modules and mod_so guides

### DIFF
--- a/docs/manual/developer/modguide.xml
+++ b/docs/manual/developer/modguide.xml
@@ -94,7 +94,7 @@ that defines a module as <em>a separate entity within Apache</em>:</p>
 
 <!-- BEGIN EXAMPLE CODE -->
 <highlight language="c">
-module AP_MODULE_DECLARE_DATA   example_module =
+AP_DECLARE_MODULE(example) =
 {
     STANDARD20_MODULE_STUFF,
     create_dir_conf, /* Per-directory configuration handler */
@@ -110,11 +110,12 @@ module AP_MODULE_DECLARE_DATA   example_module =
 <p>
 This bit of code lets the server know that we have now registered a new module
 in the system, and that its name is <code>example_module</code>. The name
-of the module is used primarily for two things:<br/>
+of the module is used primarily for three things:<br/>
 </p>
 <ul>
 <li>Letting the server know how to load the module using the LoadModule</li>
 <li>Setting up a namespace for the module to use in configurations</li>
+<li>Allowing the user to distinguish an origin of log messages</li>
 </ul>
 <p>
 For now, we're only concerned with the first purpose of the module name,
@@ -188,7 +189,7 @@ definition will look like this:</p>
 
 <!-- BEGIN EXAMPLE CODE -->
 <highlight language="c">
-module AP_MODULE_DECLARE_DATA   example_module =
+AP_DECLARE_MODULE(example) =
 {
     STANDARD20_MODULE_STUFF,
     NULL,
@@ -795,7 +796,7 @@ static void register_hooks(apr_pool_t *pool)
 
 /* Define our module as an entity and assign a function for registering hooks  */
 
-module AP_MODULE_DECLARE_DATA   example_module =
+AP_DECLARE_MODULE(example) =
 {
     STANDARD20_MODULE_STUFF,
     NULL,            /* Per-directory configuration handler */
@@ -834,7 +835,7 @@ reference to the configuration directives we want to register with the server:
 
 <!-- BEGIN EXAMPLE CODE -->
 <highlight language="c">
-module AP_MODULE_DECLARE_DATA   example_module =
+AP_DECLARE_MODULE(example) =
 {
     STANDARD20_MODULE_STUFF,
     NULL,               /* Per-directory configuration handler */
@@ -1045,7 +1046,7 @@ static void register_hooks(apr_pool_t *pool)
  Our module name tag:
  ==============================================================================
  */
-module AP_MODULE_DECLARE_DATA   example_module =
+AP_DECLARE_MODULE(example) =
 {
     STANDARD20_MODULE_STUFF,
     NULL,               /* Per-directory configuration handler */
@@ -1210,7 +1211,7 @@ per-directory creator and merger function reference in our tag:</p>
 
 <!-- BEGIN EXAMPLE CODE -->
 <highlight language="c">
-module AP_MODULE_DECLARE_DATA   example_module =
+AP_DECLARE_MODULE(example) =
 {
     STANDARD20_MODULE_STUFF,
     create_dir_conf, /* Per-directory configuration handler */
@@ -1408,7 +1409,7 @@ static const command_rec    directives[] =
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
 
-module AP_MODULE_DECLARE_DATA    example_module =
+AP_DECLARE_MODULE(example) =
 {
     STANDARD20_MODULE_STUFF,
     create_dir_conf,    /* Per-directory configuration handler */

--- a/docs/manual/mod/mod_so.xml
+++ b/docs/manual/mod/mod_so.xml
@@ -90,7 +90,7 @@ Windows</compatibility>
     <p>To create a module DLL, a small change is necessary to the
     module's source file: The module record must be exported from
     the DLL (which will be created later; see below). To do this,
-    add the <code>AP_MODULE_DECLARE_DATA</code> (defined in the
+    add the <code>AP_DECLARE_MODULE</code> (defined in the
     Apache httpd header files) to your module's module record definition.
     For example, if your module has:</p>
 
@@ -100,7 +100,7 @@ Windows</compatibility>
 
     <p>Replace the above with:</p>
 <example>
-    module AP_MODULE_DECLARE_DATA foo_module;
+    AP_DECLARE_MODULE(foo);
 </example>
 
     <p>Note that this will only be activated on Windows, so the

--- a/docs/manual/mod/mod_so.xml.fr
+++ b/docs/manual/mod/mod_so.xml.fr
@@ -100,7 +100,7 @@ Windows</title>
     modification à son fichier source : l'enregistrement du module doit
     être exporté depuis la DLL (qui sera elle-même créée plus tard ;
     voir plus loin). Pour ce faire, ajoutez la macro
-    <code>AP_MODULE_DECLARE_DATA</code> (définie dans les fichiers
+    <code>AP_DECLARE_MODULE</code> (définie dans les fichiers
     d'en-têtes d'Apache httpd) à la définition de l'enregistrement de votre
     module. Par exemple, si votre module est déclaré comme suit :</p>
 
@@ -110,7 +110,7 @@ Windows</title>
 
     <p>Remplacez cette ligne par :</p>
 <example>
-    module AP_MODULE_DECLARE_DATA foo_module;
+    AP_DECLARE_MODULE(foo);
 </example>
 
     <p>Notez que cette macro ne sera prise en compte que sous Windows,

--- a/docs/manual/mod/mod_so.xml.ja
+++ b/docs/manual/mod/mod_so.xml.ja
@@ -90,7 +90,7 @@
     モジュールの作成に小さな変更を行なう必要があります。
     つまり、モジュールのレコード (これは後で作成されます。
     以下を参照してください) が DLL からエクスポートされなければなりません。
-    これを行なうには、<code>AP_MODULE_DECLARE_DATA</code> (Apache httpd
+    これを行なうには、<code>AP_DECLARE_MODULE</code> (Apache httpd
     のヘッダファイルで定義されています) をモジュールのモジュールレコード
     定義の部分に追加してください。たとえば、モジュールに</p>
 <example>
@@ -99,7 +99,7 @@
 
     <p>があるとすると、それを次のもので置き換えてください。</p>
 <example>
-    module AP_MODULE_DECLARE_DATA foo_module;
+    AP_DECLARE_MODULE(foo);
 </example>
 
     <p>Unix 上でもこのモジュールを

--- a/docs/manual/mod/mod_so.xml.ko
+++ b/docs/manual/mod/mod_so.xml.ko
@@ -77,7 +77,7 @@
     <p>모듈 DLL을 만들기위해서는 모듈의 소스파일을 조금 수정해야
     한다. DLL은 module record를 export해야 한다. (아래 참고)
     이를 위해 모듈의 module record 정의에 (아파치 헤더파일에
-    정의된) <code>AP_MODULE_DECLARE_DATA</code>를 추가한다.
+    정의된) <code>AP_DECLARE_MODULE</code>를 추가한다.
     예를 들어, 다음과 같은 모듈이 있다면:</p>
 
 <example>
@@ -86,7 +86,7 @@
 
     <p>다음과 같이 수정한다:</p>
 <example>
-    module AP_MODULE_DECLARE_DATA foo_module;
+    AP_DECLARE_MODULE(foo);
 </example>
 
     <p>이 부분은 윈도우즈에서만 사용하기때문에 변경하여도 유닉스에서

--- a/docs/manual/mod/mod_so.xml.tr
+++ b/docs/manual/mod/mod_so.xml.tr
@@ -91,7 +91,7 @@ yeniden başlatılması sırasında yüklenmesini sağlar.</description>
       değişiklik yapmak gerekir: Modül kaydının daha sonra oluşturulacak olan
       DLL’den ihraç edilebilmesi gerekir (aşağıya bakınız). Bunu yapmak için
       modülün modül kaydı tanımına (Apache httpd başlık dosyalarında
-      tanımlanmış olan) <code>AP_MODULE_DECLARE_DATA</code> eklenmelidir.
+      tanımlanmış olan) <code>AP_DECLARE_MODULE</code> eklenmelidir.
       Örneğin, modülünüz</p>
 
     <example>
@@ -101,7 +101,7 @@ yeniden başlatılması sırasında yüklenmesini sağlar.</description>
     <p>diye bir satır içeriyorsa bunu,</p>
 
     <example>
-        module AP_MODULE_DECLARE_DATA foo_module;
+        AP_DECLARE_MODULE(foo);
     </example>
 
     <p>olarak değiştirmelisiniz. Bunun yalnız Windows üzerinde etkili olduğunu


### PR DESCRIPTION
The macro calls `AP_MODULE_DECLARE_DATA` macro that is used currently, but in addition it sets the module name for logging. This should be compatible with versions 2.3.6 (almost 14 years old) and newer so I believe it should be preferred.