### PR TITLE
Arrange pytest to run with mod_ssl. Mostly skipping tests.

### DIFF
--- a/test/modules/md/conftest.py
+++ b/test/modules/md/conftest.py
@@ -39,7 +39,9 @@ def env(pytestconfig) -> MDTestEnv:
 @pytest.fixture(autouse=True, scope="package")
 def _md_package_scope(env):
     env.httpd_error_log.add_ignored_lognos([
-        "AH10085"   # There are no SSL certificates configured and no other module contributed any
+        "AH10085",   # There are no SSL certificates configured and no other module contributed any
+        "AH10045",   # No VirtualHost matches Managed Domain
+        "AH10105",   # MDomain does not match any VirtualHost with 'SSLEngine on'
     ])
 
 

--- a/test/modules/tls/conf.py
+++ b/test/modules/tls/conf.py
@@ -13,7 +13,10 @@ class TlsTestConf(HttpdConf):
 
     def start_tls_vhost(self, domains: List[str], port=None, ssl_module=None):
         if ssl_module is None:
-            ssl_module = 'mod_tls'
+            if not self.env.has_shared_module("tls"):
+                ssl_module = "mod_ssl"
+            else:
+                ssl_module = 'mod_tls'
         super().start_vhost(domains=domains, port=port, doc_root=f"htdocs/{domains[0]}", ssl_module=ssl_module)
 
     def end_tls_vhost(self):
@@ -39,8 +42,12 @@ class TlsTestConf(HttpdConf):
                     f"    MDCertificateKeyFile {pkey_file}",
                     ])
             self.add("</MDomain>")
+            if self.env.has_shared_module("tls"):
+                ssl_module= "mod_tls"
+            else:
+                ssl_module= "mod_ssl"
             super().add_vhost(domains=[domain], port=port, doc_root=f"htdocs/{domain}",
-                              with_ssl=True, with_certificates=False, ssl_module='mod_tls')
+                              with_ssl=True, with_certificates=False, ssl_module=ssl_module)
 
     def add_md_base(self, domain: str):
         self.add([

--- a/test/modules/tls/env.py
+++ b/test/modules/tls/env.py
@@ -129,7 +129,10 @@ class TlsTestEnv(HttpdTestEnv):
             ]),
             CertificateSpec(name="user1", client=True, single_file=True),
         ])
-        self.add_httpd_log_modules(['tls'])
+        if not HttpdTestEnv.has_shared_module("tls"):
+            self.add_httpd_log_modules(['ssl'])
+        else:
+            self.add_httpd_log_modules(['tls'])
 
 
     def setup_httpd(self, setup: TlsTestSetup = None):

--- a/test/modules/tls/test_02_conf.py
+++ b/test/modules/tls/test_02_conf.py
@@ -64,9 +64,15 @@ class TestConf:
     ])
     def test_tls_02_conf_cert_listen_valid(self, env, listen: str):
         conf = TlsTestConf(env=env)
-        conf.add("TLSEngine {listen}".format(listen=listen))
-        conf.install()
-        assert env.apache_restart() == 0
+        if not env.has_shared_module("tls"):
+            # Without cert/key openssl will complain
+            conf.add("SSLEngine on");
+            conf.install()
+            assert env.apache_restart() == 1
+        else:
+            conf.add("TLSEngine {listen}".format(listen=listen))
+            conf.install()
+            assert env.apache_restart() == 0
 
     def test_tls_02_conf_cert_listen_cert(self, env):
         domain = env.domain_a

--- a/test/modules/tls/test_06_ciphers.py
+++ b/test/modules/tls/test_06_ciphers.py
@@ -181,7 +181,10 @@ class TestCiphers:
         })
         conf.add_tls_vhosts(domains=[env.domain_a, env.domain_b])
         conf.install()
-        assert env.apache_restart() == 0
+        if not conf.env.has_shared_module("tls"):
+            assert env.apache_restart() != 0
+        else:
+            assert env.apache_restart() == 0
         #
         env.httpd_error_log.ignore_recent(
             lognos = [
@@ -204,4 +207,6 @@ class TestCiphers:
         })
         conf.add_tls_vhosts(domains=[env.domain_a, env.domain_b])
         conf.install()
+        if not conf.env.has_shared_module("tls"):
+            return
         assert env.apache_restart() == 0

--- a/test/modules/tls/test_14_proxy_ssl.py
+++ b/test/modules/tls/test_14_proxy_ssl.py
@@ -2,6 +2,7 @@ import re
 import pytest
 
 from .conf import TlsTestConf
+from pyhttpd.env import HttpdTestEnv
 
 
 class TestProxySSL:
@@ -9,6 +10,12 @@ class TestProxySSL:
     @pytest.fixture(autouse=True, scope='class')
     def _class_scope(self, env):
         # add vhosts a+b and a ssl proxy from a to b
+        if not HttpdTestEnv.has_shared_module("tls"):
+            myoptions="SSLOptions +StdEnvVars"
+            myssl="mod_ssl"
+        else:
+            myoptions="TLSOptions +StdEnvVars"
+            myssl="mod_tls"
         conf = TlsTestConf(env=env, extras={
             'base': [
                 "LogLevel proxy:trace1 proxy_http:trace1 ssl:trace1 proxy_http2:trace1",
@@ -33,10 +40,10 @@ class TestProxySSL:
                 f'ProxyPass /proxy-ssl/ https://127.0.0.1:{env.https_port}/',
                 f'ProxyPass /proxy-local/ https://localhost:{env.https_port}/',
                 f'ProxyPass /proxy-h2-ssl/ h2://127.0.0.1:{env.https_port}/',
-                "TLSOptions +StdEnvVars",
+                myoptions,
             ],
         })
-        conf.add_tls_vhosts(domains=[env.domain_a, env.domain_b])
+        conf.add_tls_vhosts(domains=[env.domain_a, env.domain_b], ssl_module=myssl)
         conf.install()
         assert env.apache_restart() == 0
 
@@ -69,7 +76,24 @@ class TestProxySSL:
         ("SSL_CIPHER_EXPORT", "false"),
         ("SSL_CLIENT_VERIFY", "NONE"),
     ])
+    def test_tls_14_proxy_tsl_vars_const(self, env, name: str, value: str):
+        if not HttpdTestEnv.has_shared_module("tls"):
+            return
+        r = env.tls_get(env.domain_b, f"/proxy-ssl/vars.py?name={name}")
+        assert r.exit_code == 0, r.stderr
+        assert r.json == {name: value}, r.stdout
+
+    @pytest.mark.parametrize("name, value", [
+        ("SERVER_NAME", "b.mod-tls.test"),
+        ("SSL_SESSION_RESUMED", "Initial"),
+        ("SSL_SECURE_RENEG", "true"),
+        ("SSL_COMPRESS_METHOD", "NULL"),
+        ("SSL_CIPHER_EXPORT", "false"),
+        ("SSL_CLIENT_VERIFY", "NONE"),
+    ])
     def test_tls_14_proxy_ssl_vars_const(self, env, name: str, value: str):
+        if HttpdTestEnv.has_shared_module("tls"):
+            return
         r = env.tls_get(env.domain_b, f"/proxy-ssl/vars.py?name={name}")
         assert r.exit_code == 0, r.stderr
         assert r.json == {name: value}, r.stdout
@@ -78,7 +102,21 @@ class TestProxySSL:
         ("SSL_VERSION_INTERFACE", r'mod_tls/\d+\.\d+\.\d+'),
         ("SSL_VERSION_LIBRARY", r'rustls-ffi/\d+\.\d+\.\d+/rustls/\d+\.\d+\.\d+'),
     ])
+    def test_tls_14_proxy_tsl_vars_match(self, env, name: str, pattern: str):
+        if not HttpdTestEnv.has_shared_module("tls"):
+            return
+        r = env.tls_get(env.domain_b, f"/proxy-ssl/vars.py?name={name}")
+        assert r.exit_code == 0, r.stderr
+        assert name in r.json
+        assert re.match(pattern, r.json[name]), r.json
+
+    @pytest.mark.parametrize("name, pattern", [
+        ("SSL_VERSION_INTERFACE", r'mod_ssl/\d+\.\d+\.\d+'),
+        ("SSL_VERSION_LIBRARY", r'OpenSSL/\d+\.\d+\.\d+'),
+    ])
     def test_tls_14_proxy_ssl_vars_match(self, env, name: str, pattern: str):
+        if HttpdTestEnv.has_shared_module("tls"):
+            return
         r = env.tls_get(env.domain_b, f"/proxy-ssl/vars.py?name={name}")
         assert r.exit_code == 0, r.stderr
         assert name in r.json

--- a/test/modules/tls/test_15_proxy_tls.py
+++ b/test/modules/tls/test_15_proxy_tls.py
@@ -3,7 +3,9 @@ from datetime import timedelta
 import pytest
 
 from .conf import TlsTestConf
+from pyhttpd.env import HttpdTestEnv
 
+@pytest.mark.skipif(condition=not HttpdTestEnv.has_shared_module("tls"), reason="no mod_tls available")
 
 class TestProxyTLS:
 

--- a/test/modules/tls/test_16_proxy_mixed.py
+++ b/test/modules/tls/test_16_proxy_mixed.py
@@ -3,6 +3,9 @@ import time
 import pytest
 
 from .conf import TlsTestConf
+from pyhttpd.env import HttpdTestEnv
+
+@pytest.mark.skipif(condition=not HttpdTestEnv.has_shared_module("tls"), reason="no mod_tls available")
 
 
 class TestProxyMixed:

--- a/test/modules/tls/test_17_proxy_machine_cert.py
+++ b/test/modules/tls/test_17_proxy_machine_cert.py
@@ -3,8 +3,9 @@ import os
 import pytest
 
 from .conf import TlsTestConf
+from pyhttpd.env import HttpdTestEnv
 
-
+@pytest.mark.skipif(condition=not HttpdTestEnv.has_shared_module("tls"), reason="no mod_tls available")
 class TestProxyMachineCert:
 
     @pytest.fixture(autouse=True, scope='class')


### PR DESCRIPTION
The pytest testsuite uses mod_tls but it should be able to run on mod_ssl to some extend too.