### PR TITLE
mod_tls: update rustls-ffi 0.10 -> 0.13

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -241,7 +241,7 @@ jobs:
               APR_VERSION=1.7.4
               APU_VERSION=1.6.3
               APU_CONFIG="--with-crypto"
-              RUSTLS_VERSION="v0.10.0"
+              RUSTLS_VERSION="v0.11.0"
               NO_TEST_FRAMEWORK=1
               TEST_INSTALL=1
               TEST_MOD_TLS=1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -241,7 +241,7 @@ jobs:
               APR_VERSION=1.7.4
               APU_VERSION=1.6.3
               APU_CONFIG="--with-crypto"
-              RUSTLS_VERSION="v0.12.2"
+              RUSTLS_VERSION="v0.13.0"
               NO_TEST_FRAMEWORK=1
               TEST_INSTALL=1
               TEST_MOD_TLS=1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -241,7 +241,7 @@ jobs:
               APR_VERSION=1.7.4
               APU_VERSION=1.6.3
               APU_CONFIG="--with-crypto"
-              RUSTLS_VERSION="v0.11.0"
+              RUSTLS_VERSION="v0.12.2"
               NO_TEST_FRAMEWORK=1
               TEST_INSTALL=1
               TEST_MOD_TLS=1

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,19 @@ Release
 /build/config.sub
 /build/config.guess
 /build/config_vars.sh
+/build/confdefs.h
+/build/config.log
+/build/config.nice
+/build/srclib/
+/build/srclib/pth
+/build/srclib/apr
+/build/srclib/apr-util
+/build/srclib/apr-iconv
+/build/srclib/distcache
+/build/srclib/lua
+/build/srclib/pcre
+/build/srclib/openssl
+/build/srclib/zlib
 
 # /build/pkg/
 /build/pkg/pkginfo

--- a/modules/tls/tls_cert.h
+++ b/modules/tls/tls_cert.h
@@ -193,7 +193,7 @@ void tls_cert_verifiers_clear(
 apr_status_t tls_cert_client_verifiers_get(
     tls_cert_verifiers_t *verifiers,
     const char *store_file,
-    const rustls_client_cert_verifier **pverifier);
+    const rustls_allow_any_authenticated_client_verifier **pverifier);
 
 /**
  * Get the optional client certificate verifier for the
@@ -206,6 +206,6 @@ apr_status_t tls_cert_client_verifiers_get(
 apr_status_t tls_cert_client_verifiers_get_optional(
     tls_cert_verifiers_t *verifiers,
     const char *store_file,
-    const rustls_client_cert_verifier_optional **pverifier);
+    const rustls_allow_any_anonymous_or_authenticated_client_verifier **pverifier);
 
 #endif /* tls_cert_h */

--- a/modules/tls/tls_cert.h
+++ b/modules/tls/tls_cert.h
@@ -128,7 +128,7 @@ const char *tls_cert_reg_get_id(tls_cert_reg_t *reg, const rustls_certified_key 
  * @param pstore the loaded root store on success
  */
 apr_status_t tls_cert_load_root_store(
-    apr_pool_t *p, const char *store_file, rustls_root_cert_store **pstore);
+    apr_pool_t *p, const char *store_file, const rustls_root_cert_store **pstore);
 
 typedef struct tls_cert_root_stores_t tls_cert_root_stores_t;
 struct tls_cert_root_stores_t {
@@ -157,7 +157,7 @@ void tls_cert_root_stores_clear(tls_cert_root_stores_t *stores);
 apr_status_t tls_cert_root_stores_get(
     tls_cert_root_stores_t *stores,
     const char *store_file,
-    rustls_root_cert_store **pstore);
+    const rustls_root_cert_store **pstore);
 
 typedef struct tls_cert_verifiers_t tls_cert_verifiers_t;
 struct tls_cert_verifiers_t {
@@ -193,7 +193,7 @@ void tls_cert_verifiers_clear(
 apr_status_t tls_cert_client_verifiers_get(
     tls_cert_verifiers_t *verifiers,
     const char *store_file,
-    const rustls_allow_any_authenticated_client_verifier **pverifier);
+    const rustls_client_cert_verifier **pverifier);
 
 /**
  * Get the optional client certificate verifier for the
@@ -206,6 +206,6 @@ apr_status_t tls_cert_client_verifiers_get(
 apr_status_t tls_cert_client_verifiers_get_optional(
     tls_cert_verifiers_t *verifiers,
     const char *store_file,
-    const rustls_allow_any_anonymous_or_authenticated_client_verifier **pverifier);
+    const rustls_client_cert_verifier **pverifier);
 
 #endif /* tls_cert_h */

--- a/modules/tls/tls_core.c
+++ b/modules/tls/tls_core.c
@@ -1119,13 +1119,13 @@ static apr_status_t build_server_connection(rustls_connection **pconnection,
     if (cc->client_auth != TLS_CLIENT_AUTH_NONE) {
         ap_assert(sc->client_ca);  /* checked in server_setup */
         if (cc->client_auth == TLS_CLIENT_AUTH_REQUIRED) {
-            const rustls_client_cert_verifier *verifier;
+            const rustls_allow_any_authenticated_client_verifier *verifier;
             rv = tls_cert_client_verifiers_get(sc->global->verifiers, sc->client_ca, &verifier);
             if (APR_SUCCESS != rv) goto cleanup;
             rustls_server_config_builder_set_client_verifier(builder, verifier);
         }
         else {
-            const rustls_client_cert_verifier_optional *verifier;
+            const rustls_allow_any_anonymous_or_authenticated_client_verifier *verifier;
             rv = tls_cert_client_verifiers_get_optional(sc->global->verifiers, sc->client_ca, &verifier);
             if (APR_SUCCESS != rv) goto cleanup;
             rustls_server_config_builder_set_client_verifier_optional(builder, verifier);

--- a/test/modules/tls/test_08_vars.py
+++ b/test/modules/tls/test_08_vars.py
@@ -59,7 +59,7 @@ class TestVars:
 
     @pytest.mark.parametrize("name, pattern", [
         ("SSL_VERSION_INTERFACE", r'mod_tls/\d+\.\d+\.\d+'),
-        ("SSL_VERSION_LIBRARY", r'rustls-ffi/\d+\.\d+\.\d+/rustls/\d+\.\d+\.\d+'),
+        ("SSL_VERSION_LIBRARY", r'rustls-ffi/\d+\.\d+\.\d+/rustls/\d+\.\d+(\.\d+)?'),
     ])
     def test_tls_08_vars_match(self, env, name: str, pattern: str):
         r = env.tls_get(env.domain_b, f"/vars.py?name={name}")

--- a/test/modules/tls/test_14_proxy_ssl.py
+++ b/test/modules/tls/test_14_proxy_ssl.py
@@ -100,7 +100,7 @@ class TestProxySSL:
 
     @pytest.mark.parametrize("name, pattern", [
         ("SSL_VERSION_INTERFACE", r'mod_tls/\d+\.\d+\.\d+'),
-        ("SSL_VERSION_LIBRARY", r'rustls-ffi/\d+\.\d+\.\d+/rustls/\d+\.\d+\.\d+'),
+        ("SSL_VERSION_LIBRARY", r'rustls-ffi/\d+\.\d+\.\d+/rustls/\d+\.\d+(\.\d+)?'),
     ])
     def test_tls_14_proxy_tsl_vars_match(self, env, name: str, pattern: str):
         if not HttpdTestEnv.has_shared_module("tls"):

--- a/test/travis_run_linux.sh
+++ b/test/travis_run_linux.sh
@@ -266,7 +266,7 @@ fi
 if test -v TEST_MOD_TLS -a $RV -eq 0; then
     # Run mod_tls tests. The underlying librustls was build
     # and installed before we configured the server (see top of file).
-    # This will be replaved once librustls is available as a package.
+    # This will be replaced once librustls is available as a package.
     py.test-3 test/modules/tls
     RV=$?
 fi


### PR DESCRIPTION
To increase review-ability I've broken this changeset into individual commits:

* Some `.gitignore` updates I found useful. I can drop this commit or make a separate PR as preferred.
* A typo fix I noticed while getting my bearings.
* A fix to relax the `SSL_VERSION_LIBRARY` regex for `rustls-ffi` versions that only include the major and minor component in the wrapped rustls version used for the version string. This is required to test rustls-ffi 0.12.x where the rustls version is "0.22" not "0.22.0".
* An update from rustls-ffi 0.10 to [0.11.0](https://github.com/rustls/rustls-ffi/releases/tag/v0.11.0) - this one is fairly minor, mostly type renames. It is a bit of an ugly intermediate state before the rustls-ffi verifier API was tidied up in 0.12.x.
* An update from rustls-ffi 0.11 to [0.12.2](https://github.com/rustls/rustls-ffi/releases/tag/v0.12.2) - this one is the most significant, as it brings in the new builder API for constructing root cert stores, and the unified verifier API (see [0.12.0 release notes](https://github.com/rustls/rustls-ffi/releases/tag/v0.12.0)). The `tls_cert_client_verifiers_get` and `tls_cert_client_verifiers_get_optional` fns can now share their internal logic with a small cleanup.
* An update from rustls-ffi 0.12.2 to [0.13.0](https://github.com/rustls/rustls-ffi/releases/tag/v0.13.0), the latest release at the time of writing - this one is "free", the only breaking API changes were in API surface that `mod-tls` doesn't use.

Probably once this changeset is in good shape we should squash all of the intermediate version updates, jumping straight to 0.13.

I've tried to match the existing style (e.g. checking for `NULL` before using `_free` fns even if they are documented `NULL`-safe), but this is my first time making a significant contribution to HTTPD and so might have missed the mark on style in some places.

Resolves https://bz.apache.org/bugzilla/show_bug.cgi?id=67860

