### PR TITLE
fix the Japanese translation docs of the LimitRequestBody

### DIFF
--- a/docs/manual/mod/core.html.ja.utf8
+++ b/docs/manual/mod/core.html.ja.utf8
@@ -2009,14 +2009,15 @@ the server configuration files</td></tr>
 <tr><th><a href="directive-dict.html#Description">説明:</a></th><td>クライアントから送られる HTTP リクエストのボディの
 総量を制限する</td></tr>
 <tr><th><a href="directive-dict.html#Syntax">構文:</a></th><td><code>LimitRequestBody <var>bytes</var></code></td></tr>
-<tr><th><a href="directive-dict.html#Default">デフォルト:</a></th><td><code>LimitRequestBody 0</code></td></tr>
+<tr><th><a href="directive-dict.html#Default">デフォルト:</a></th><td><code>LimitRequestBody 1073741824</code></td></tr>
 <tr><th><a href="directive-dict.html#Context">コンテキスト:</a></th><td>サーバ設定ファイル, バーチャルホスト, ディレクトリ, .htaccess</td></tr>
 <tr><th><a href="directive-dict.html#Override">上書き:</a></th><td>All</td></tr>
 <tr><th><a href="directive-dict.html#Status">ステータス:</a></th><td>Core</td></tr>
 <tr><th><a href="directive-dict.html#Module">モジュール:</a></th><td>core</td></tr>
+<tr><th><a href="directive-dict.html#Compatibility">互換性:</a></th><td>Apache HTTP Server 2.4.53 以前では、デフォルト値は 0 (無制限)</td></tr>
 </table>
     <p>このディレクティブは、リクエストボディに許されるバイト数、<var>bytes</var>
-    を 0 (無制限を意味します) から 2147483647 (2GB) までの数値で指定します。</p>
+    を 指定します。<var>0</var> は無制限を意味します。</p>
 
     <p><code class="directive">LimitRequestBody</code> ディレクティブは、
     ディレクティブが書かれたコンテキスト

--- a/docs/manual/mod/core.xml.ja
+++ b/docs/manual/mod/core.xml.ja
@@ -1710,15 +1710,17 @@ module="core">Directory</directive></seealso>
 <description>クライアントから送られる HTTP リクエストのボディの
 総量を制限する</description>
 <syntax>LimitRequestBody <var>bytes</var></syntax>
-<default>LimitRequestBody 0</default>
+<default>LimitRequestBody 1073741824</default>
 <contextlist><context>server config</context><context>virtual host</context>
 <context>directory</context><context>.htaccess</context>
 </contextlist>
 <override>All</override>
+<compatibility>Apache HTTP Server 2.4.53 以前では、デフォルト値は 0 (無制限)
+</compatibility>
 
 <usage>
     <p>このディレクティブは、リクエストボディに許されるバイト数、<var>bytes</var>
-    を 0 (無制限を意味します) から 2147483647 (2GB) までの数値で指定します。</p>
+    を 指定します。<var>0</var> は無制限を意味します。</p>
 
     <p><directive>LimitRequestBody</directive> ディレクティブは、
     ディレクティブが書かれたコンテキスト


### PR DESCRIPTION
I fixed the Japanese docs of the LimitRequestBody.

Because it had not been updated, I assumed that the limit of request body was unlimited and wasted several hours.


I would like to correct this so that Japanese engineers do not make the same mistake.

