### PR TITLE
On Linux use the real thread id via gettid() in error logging rather

### DIFF
--- a/changes-entries/linux-log-tid.txt
+++ b/changes-entries/linux-log-tid.txt
@@ -1,0 +1,1 @@
+ *) core: On Linux, log the real thread ID in error logs.  [Joe Orton]

--- a/configure.in
+++ b/configure.in
@@ -562,6 +562,12 @@ pid_t t = syscall(SYS_gettid); return t == -1 ? 1 : 0; },
   fi
 fi
 
+case ${host}X${ac_cv_func_gettid}X${ap_cv_gettid} in
+*linux-*XyesX* | *linux-*XnoXyes)
+     AC_DEFINE(DEFAULT_LOG_TID, ["g"], [Define as default argument for thread id in error logging])
+     ;;
+esac
+
 dnl ## Check for the tm_gmtoff field in struct tm to get the timezone diffs
 AC_CACHE_CHECK([for tm_gmtoff in struct tm], ac_cv_struct_tm_gmtoff,
 [AC_TRY_COMPILE([#include <sys/types.h>

--- a/server/log.c
+++ b/server/log.c
@@ -69,6 +69,10 @@
 #undef APLOG_MODULE_INDEX
 #define APLOG_MODULE_INDEX AP_CORE_MODULE_INDEX
 
+#ifndef DEFAULT_LOG_TID
+#define DEFAULT_LOG_TID NULL
+#endif
+
 typedef struct {
     const char *t_name;
     int t_val;
@@ -907,7 +911,7 @@ static int do_errorlog_default(const ap_errorlog_info *info, char *buf,
 #if APR_HAS_THREADS
         field_start = len;
         len += cpystrn(buf + len, ":tid ", buflen - len);
-        item_len = log_tid(info, NULL, buf + len, buflen - len);
+        item_len = log_tid(info, DEFAULT_LOG_TID, buf + len, buflen - len);
         if (!item_len)
             len = field_start;
         else


### PR DESCRIPTION
than the (meaningless) pthread_self()-as-integer interpretation:

* configure.in: Define DEFAULT_LOG_TID on Linux.

* server/log.c: Define DEFAULT_LOG_TID as NULL by default.
  (do_errorlog_default): Use DEFAULT_LOG_TID as the argument to log_tid().