### PR TITLE
mod_ssl: Fix ENGINE use with OpenSSL 3.2, which appears to be broken

### DIFF
--- a/modules/ssl/ssl_engine_init.c
+++ b/modules/ssl/ssl_engine_init.c
@@ -1467,7 +1467,7 @@ static apr_status_t ssl_init_server_certs(server_rec *s,
         if (modssl_is_engine_id(keyfile)) {
             apr_status_t rv;
 
-            if ((rv = modssl_load_engine_keypair(s, ptemp, vhost_id,
+            if ((rv = modssl_load_engine_keypair(s, p, ptemp, vhost_id,
                                                  engine_certfile, keyfile,
                                                  &cert, &pkey))) {
                 return rv;

--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -1089,7 +1089,8 @@ apr_status_t ssl_load_encrypted_pkey(server_rec *, apr_pool_t *, int,
 /* Load public and/or private key from the configured ENGINE. Private
  * key returned as *pkey.  certid can be NULL, in which case *pubkey
  * is not altered.  Errors logged on failure. */
-apr_status_t modssl_load_engine_keypair(server_rec *s, apr_pool_t *p,
+apr_status_t modssl_load_engine_keypair(server_rec *s,
+                                        apr_pool_t *pconf, apr_pool_t *ptemp,
                                         const char *vhostid,
                                         const char *certid, const char *keyid,
                                         X509 **pubkey, EVP_PKEY **privkey);


### PR DESCRIPTION
```
Fix ENGINE use with OpenSSL 3.2, which appears to be broken due to a refcounting issue in mod_ssl.

* modules/ssl/ssl_engine_pphrase.c (modssl_engine_cleanup): New function. (modssl_load_keypair_engine): Take pconf & ptemp arguments, don't call ENGINE_finish() immediately but register the above cleanup. (modssl_load_engine_keypair): Pass through pconf & ptemp.

* modules/ssl/ssl_engine_init.c (ssl_init_server_certs): Pass through pconf and ptemp to modssl_load_engine_keypair.
```