### PR TITLE
mod_ssl: Fix reading custom DH parameters from CertificateFile with OpenSSL 3.X

### DIFF
--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -102,6 +102,7 @@
 #include <openssl/dh.h>
 #if OPENSSL_VERSION_NUMBER >= 0x30000000
 #include <openssl/core_names.h>
+#include <openssl/decoder.h>
 #endif
 
 /* Avoid tripping over an engine build installed globally and detected


### PR DESCRIPTION
This commit addresses an issue where Apache HTTPD with OpenSSL 3.0 or later is unable to load custom DH parameters specified in the CertificateFile configuration option. PEM_read_bio_Parameters() is unable to extract just the DH parameters and returns NULL when a CertificateFile contains signed certificates, intermediate certificates, and DH parameters all together in one file. A new approach is needed for OpenSSL 3.0. This patch implements a solution using OpenSSL's decoding framework to selectively load only the custom DH parameters from a composite CertificateFile.

Testing confirmed custom DH params can now be properly extracted from CertificateFile as intended.