### PR TITLE
mpm_event,core: Handle async POLLIN/POLLOUT in CONN_STATE_PROCESS state.

### DIFF
--- a/include/httpd.h
+++ b/include/httpd.h
@@ -1318,16 +1318,21 @@ struct conn_slave_rec {
  * only be set by the MPM. Use CONN_STATE_LINGER outside of the MPM.
  */
 typedef enum  {
-    CONN_STATE_CHECK_REQUEST_LINE_READABLE,
-    CONN_STATE_READ_REQUEST_LINE,
-    CONN_STATE_HANDLER,
-    CONN_STATE_WRITE_COMPLETION,
-    CONN_STATE_SUSPENDED,
-    CONN_STATE_LINGER,          /* connection may be closed with lingering */
-    CONN_STATE_LINGER_NORMAL,   /* MPM has started lingering close with normal timeout */
-    CONN_STATE_LINGER_SHORT,    /* MPM has started lingering close with short timeout */
+    CONN_STATE_KEEPALIVE,           /* Kept alive in the MPM (using KeepAliveTimeout) */
+    CONN_STATE_PROCESS,             /* Handled by process_connection() hooks, may be returned
+                                       to the MPM for POLLIN/POLLOUT (using Timeout) */
+    CONN_STATE_HANDLER,             /* Processed by the modules handlers */
+    CONN_STATE_WRITE_COMPLETION,    /* Flushed by the MPM before entering CONN_STATE_KEEPALIVE */
+    CONN_STATE_SUSPENDED,           /* Suspended in the MPM until ap_run_resume_suspended() */
+    CONN_STATE_LINGER,              /* MPM flushes then closes the connection with lingering */
+    CONN_STATE_LINGER_NORMAL,       /* MPM has started lingering close with normal timeout */
+    CONN_STATE_LINGER_SHORT,        /* MPM has started lingering close with short timeout */
 
-    CONN_STATE_NUM              /* Number of states (keep/kept last) */
+    CONN_STATE_NUM,                 /* Number of states (keep here before aliases) */
+
+    /* Aliases (legacy) */
+    CONN_STATE_CHECK_REQUEST_LINE_READABLE  = CONN_STATE_KEEPALIVE,
+    CONN_STATE_READ_REQUEST_LINE            = CONN_STATE_PROCESS,
 } conn_state_e;
 
 typedef enum  {

--- a/include/scoreboard.h
+++ b/include/scoreboard.h
@@ -144,7 +144,7 @@ struct process_score {
                              * connections (for async MPMs)
                              */
     apr_uint32_t connections;       /* total connections (for async MPMs) */
-    apr_uint32_t write_completion;  /* async connections doing write completion */
+    apr_uint32_t write_completion;  /* async connections in write completion or POLLIN/POLLOUT */
     apr_uint32_t lingering_close;   /* async connections in lingering close */
     apr_uint32_t keep_alive;        /* async connections in keep alive */
     apr_uint32_t suspended;         /* connections suspended by some module */

--- a/modules/http/http_core.c
+++ b/modules/http/http_core.c
@@ -142,9 +142,9 @@ static int ap_process_http_async_connection(conn_rec *c)
     conn_state_t *cs = c->cs;
 
     AP_DEBUG_ASSERT(cs != NULL);
-    AP_DEBUG_ASSERT(cs->state == CONN_STATE_READ_REQUEST_LINE);
+    AP_DEBUG_ASSERT(cs->state == CONN_STATE_PROCESS);
 
-    if (cs->state == CONN_STATE_READ_REQUEST_LINE) {
+    if (cs->state == CONN_STATE_PROCESS) {
         ap_update_child_status_from_conn(c->sbh, SERVER_BUSY_READ, c);
         if (ap_extended_status) {
             ap_set_conn_count(c->sbh, r, c->keepalives);

--- a/modules/http2/h2_c1.c
+++ b/modules/http2/h2_c1.c
@@ -152,20 +152,25 @@ apr_status_t h2_c1_run(conn_rec *c)
             case H2_SESSION_ST_IDLE:
             case H2_SESSION_ST_BUSY:
             case H2_SESSION_ST_WAIT:
-                c->cs->state = CONN_STATE_WRITE_COMPLETION;
-                if (!keepalive) {
+                if (keepalive) {
+                    /* flush then keep-alive */
+                    c->cs->state = CONN_STATE_WRITE_COMPLETION;
+                }
+                else {
                     /* let the MPM know that we are not done and want
                      * the Timeout behaviour instead of a KeepAliveTimeout
                      * See PR 63534. 
                      */
+                    c->cs->state = CONN_STATE_PROCESS;
                     c->cs->sense = CONN_SENSE_WANT_READ;
                 }
                 break;
+
             case H2_SESSION_ST_CLEANUP:
             case H2_SESSION_ST_DONE:
             default:
                 c->cs->state = CONN_STATE_LINGER;
-            break;
+                break;
         }
     }
 

--- a/server/mpm/motorz/motorz.c
+++ b/server/mpm/motorz/motorz.c
@@ -160,7 +160,7 @@ static void *motorz_io_setup_conn(apr_thread_t *thread, void *baton)
                      "motorz_io_setup_conn: connection aborted");
     }
 
-    scon->cs.state = CONN_STATE_READ_REQUEST_LINE;
+    scon->cs.state = CONN_STATE_PROCESS;
     scon->cs.sense = CONN_SENSE_DEFAULT;
 
     status = motorz_io_process(scon);
@@ -374,16 +374,16 @@ static apr_status_t motorz_io_process(motorz_conn_t *scon)
             scon->pfd.reqevents = 0;
         }
 
-        if (scon->cs.state == CONN_STATE_CHECK_REQUEST_LINE_READABLE) {
+        if (scon->cs.state == CONN_STATE_KEEPALIVE) {
             ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, ap_server_conf, APLOGNO(03327)
-                                 "motorz_io_process(): Set to CONN_STATE_READ_REQUEST_LINE");
-            scon->cs.state = CONN_STATE_READ_REQUEST_LINE;
+                                 "motorz_io_process(): Set to CONN_STATE_PROCESS");
+            scon->cs.state = CONN_STATE_PROCESS;
         }
 
 read_request:
-        if (scon->cs.state == CONN_STATE_READ_REQUEST_LINE) {
+        if (scon->cs.state == CONN_STATE_PROCESS) {
             ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, ap_server_conf, APLOGNO(03328)
-                                 "motorz_io_process(): CONN_STATE_READ_REQUEST_LINE");
+                                 "motorz_io_process(): CONN_STATE_PROCESS");
             if (!c->aborted) {
                 ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, ap_server_conf, APLOGNO(03329)
                                      "motorz_io_process(): !aborted");
@@ -438,11 +438,11 @@ read_request:
                 scon->cs.state = CONN_STATE_LINGER;
             }
             else if (ap_run_input_pending(c) == OK) {
-                scon->cs.state = CONN_STATE_READ_REQUEST_LINE;
+                scon->cs.state = CONN_STATE_PROCESS;
                 goto read_request;
             }
             else {
-                scon->cs.state = CONN_STATE_CHECK_REQUEST_LINE_READABLE;
+                scon->cs.state = CONN_STATE_KEEPALIVE;
             }
         }
 
@@ -452,9 +452,9 @@ read_request:
             ap_lingering_close(c);
         }
 
-        if (scon->cs.state == CONN_STATE_CHECK_REQUEST_LINE_READABLE) {
+        if (scon->cs.state == CONN_STATE_KEEPALIVE) {
             ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, ap_server_conf, APLOGNO(03333)
-                                  "motorz_io_process(): CONN_STATE_CHECK_REQUEST_LINE_READABLE");
+                                  "motorz_io_process(): CONN_STATE_KEEPALIVE");
             motorz_register_timeout(scon,
                                   motorz_io_timeout_cb,
                                   motorz_get_keep_alive_timeout(scon));

--- a/server/mpm/simple/simple_io.c
+++ b/server/mpm/simple/simple_io.c
@@ -79,7 +79,7 @@ static apr_status_t simple_io_process(simple_conn_t * scon)
             scon->pfd.reqevents = 0;
         }
 
-        if (scon->cs.state == CONN_STATE_READ_REQUEST_LINE) {
+        if (scon->cs.state == CONN_STATE_PROCESS) {
             if (!c->aborted) {
                 ap_run_process_connection(c);
                 /* state will be updated upon return
@@ -132,10 +132,10 @@ static apr_status_t simple_io_process(simple_conn_t * scon)
                 scon->cs.state = CONN_STATE_LINGER;
             }
             else if (ap_run_input_pending(c) == OK) {
-                scon->cs.state = CONN_STATE_READ_REQUEST_LINE;
+                scon->cs.state = CONN_STATE_PROCESS;
             }
             else {
-                scon->cs.state = CONN_STATE_CHECK_REQUEST_LINE_READABLE;
+                scon->cs.state = CONN_STATE_KEEPALIVE;
             }
         }
 
@@ -145,7 +145,7 @@ static apr_status_t simple_io_process(simple_conn_t * scon)
             return APR_SUCCESS;
         }
 
-        if (scon->cs.state == CONN_STATE_CHECK_REQUEST_LINE_READABLE) {
+        if (scon->cs.state == CONN_STATE_KEEPALIVE) {
             simple_register_timer(scon->sc,
                                   simple_io_timeout_cb,
                                   scon,
@@ -233,7 +233,7 @@ static void *simple_io_setup_conn(apr_thread_t * thread, void *baton)
                      "simple_io_setup_conn: connection aborted");
     }
 
-    scon->cs.state = CONN_STATE_READ_REQUEST_LINE;
+    scon->cs.state = CONN_STATE_PROCESS;
     scon->cs.sense = CONN_SENSE_DEFAULT;
 
     rv = simple_io_process(scon);


### PR DESCRIPTION
* include/httpd.h: Rename CONN_STATE_CHECK_REQUEST_LINE_READABLE to CONN_STATE_KEEPALIVE and CONN_STATE_READ_REQUEST_LINE to CONN_STATE_PROCESS, keeping the old enums as aliases. Rework comments about each state.

* server/mpm/event/event.c: Use the new states names. Let the process_connection hooks return CONN_STATE_PROCESS for mpm_event to POLLIN or POLLOUT depending on c->cs->sense being CONN_SENSE_WANT_READ or CONN_SENSE_WANT_WRITE respectively. Remove (ab)use of CONN_STATE_WRITE_COMPLETION with CONN_SENSE_WANT_READ to mean poll() for read (and the need for the obscure c->clogging_input_filters to make it work as expected). This is what CONN_STATE_PROCESS is for now. Update the comment about the states that can be returned by process_connection hooks (and their usage). Use the same queue (process_q renamed from write_completion_q) for polling connections in both CONN_STATE_PROCESS and CONN_STATE_WRITE_COMPLETION states since they both use the same (server_rec's) Timeout. This implies that both states are accounted as "write-completion" in mod_status for now.

* server/mpm/motorz/motorz.c, server/mpm/simple/simple_io.c, modules/http/http_core.c: Use the new states names (only).

* include/scoreboard.h: Change comment about process_score->write_completion to note that the counter refers to CONN_STATE_PROCESS connections returned to the MPM too.

* modules/http2/h2_c1.c: Return the c1 connection with the CONN_STATE_PROCESS state rather than CONN_STATE_WRITE_COMPLETION when waiting for a window update (i.e. ask the MPM to poll for read directly). This avoids the transition to CONN_STATE_KEEPALIVE which could kill the connection under high load.