### PR TITLE
Backport to 2.4.x: mod_h2 to return c1 to mpm_event

### DIFF
--- a/include/ap_mmn.h
+++ b/include/ap_mmn.h
@@ -605,6 +605,7 @@
  * 20120211.134 (2.4.60-dev) AP_SLASHES and AP_IS_SLASH
  * 20120211.135 (2.4.59-dev) Add CONN_STATE_KEEPALIVE and CONN_STATE_PROCESSING
  * 20120211.136 (2.4.59-dev) Add processing field struct process_score
+ * 20120211.137 (2.4.59-dev) Add AGAIN, AP_MPMQ_CAN_AGAIN.
  */
 
 #define MODULE_MAGIC_COOKIE 0x41503234UL /* "AP24" */
@@ -612,7 +613,7 @@
 #ifndef MODULE_MAGIC_NUMBER_MAJOR
 #define MODULE_MAGIC_NUMBER_MAJOR 20120211
 #endif
-#define MODULE_MAGIC_NUMBER_MINOR 136                 /* 0...n */
+#define MODULE_MAGIC_NUMBER_MINOR 137                 /* 0...n */
 
 /**
  * Determine if the server's current MODULE_MAGIC_NUMBER is at least a

--- a/include/ap_mmn.h
+++ b/include/ap_mmn.h
@@ -603,6 +603,7 @@
  *                           and AP_REQUEST_TRUSTED_CT BNOTE.
  * 20120211.133 (2.4.60-dev) Add ap_proxy_fixup_uds_filename()
  * 20120211.134 (2.4.60-dev) AP_SLASHES and AP_IS_SLASH
+ * 20120211.135 (2.4.59-dev) Add CONN_STATE_KEEPALIVE and CONN_STATE_PROCESS
  */
 
 #define MODULE_MAGIC_COOKIE 0x41503234UL /* "AP24" */

--- a/include/ap_mmn.h
+++ b/include/ap_mmn.h
@@ -603,7 +603,8 @@
  *                           and AP_REQUEST_TRUSTED_CT BNOTE.
  * 20120211.133 (2.4.60-dev) Add ap_proxy_fixup_uds_filename()
  * 20120211.134 (2.4.60-dev) AP_SLASHES and AP_IS_SLASH
- * 20120211.135 (2.4.59-dev) Add CONN_STATE_KEEPALIVE and CONN_STATE_PROCESS
+ * 20120211.135 (2.4.59-dev) Add CONN_STATE_KEEPALIVE and CONN_STATE_PROCESSING
+ * 20120211.136 (2.4.59-dev) Add processing field struct process_score
  */
 
 #define MODULE_MAGIC_COOKIE 0x41503234UL /* "AP24" */
@@ -611,7 +612,7 @@
 #ifndef MODULE_MAGIC_NUMBER_MAJOR
 #define MODULE_MAGIC_NUMBER_MAJOR 20120211
 #endif
-#define MODULE_MAGIC_NUMBER_MINOR 134                 /* 0...n */
+#define MODULE_MAGIC_NUMBER_MINOR 136                 /* 0...n */
 
 /**
  * Determine if the server's current MODULE_MAGIC_NUMBER is at least a

--- a/include/ap_mmn.h
+++ b/include/ap_mmn.h
@@ -603,9 +603,10 @@
  *                           and AP_REQUEST_TRUSTED_CT BNOTE.
  * 20120211.133 (2.4.60-dev) Add ap_proxy_fixup_uds_filename()
  * 20120211.134 (2.4.60-dev) AP_SLASHES and AP_IS_SLASH
- * 20120211.135 (2.4.59-dev) Add CONN_STATE_KEEPALIVE and CONN_STATE_PROCESSING
- * 20120211.136 (2.4.59-dev) Add processing field struct process_score
- * 20120211.137 (2.4.59-dev) Add AGAIN, AP_MPMQ_CAN_AGAIN.
+ * 20120211.135 (2.4.59-dev) Add CONN_STATE_ASYNC_WAITIO, CONN_STATE_KEEPALIVE
+ *                           and CONN_STATE_PROCESSING
+ * 20120211.136 (2.4.59-dev) Add wait_io field to struct process_score
+ * 20120211.137 (2.4.59-dev) Add AP_MPMQ_CAN_WAITIO
  */
 
 #define MODULE_MAGIC_COOKIE 0x41503234UL /* "AP24" */

--- a/include/ap_mpm.h
+++ b/include/ap_mpm.h
@@ -178,6 +178,8 @@ AP_DECLARE(apr_status_t) ap_os_create_privileged_process(
 #define AP_MPMQ_GENERATION           15
 /** MPM can drive serf internally  */
 #define AP_MPMQ_HAS_SERF             16
+/** MPM reacts to AGAIN response */
+#define AP_MPMQ_CAN_AGAIN            19
 /** @} */
 
 /**

--- a/include/ap_mpm.h
+++ b/include/ap_mpm.h
@@ -178,8 +178,9 @@ AP_DECLARE(apr_status_t) ap_os_create_privileged_process(
 #define AP_MPMQ_GENERATION           15
 /** MPM can drive serf internally  */
 #define AP_MPMQ_HAS_SERF             16
-/** MPM reacts to AGAIN response */
-#define AP_MPMQ_CAN_AGAIN            19
+/* 17-18 are trunk only */
+/** MPM supports CONN_STATE_ASYNC_WAITIO */
+#define AP_MPMQ_CAN_WAITIO           19
 /** @} */
 
 /**

--- a/include/httpd.h
+++ b/include/httpd.h
@@ -453,13 +453,16 @@ AP_DECLARE(const char *) ap_get_server_built(void);
 
 /* non-HTTP status codes returned by hooks */
 
-#define OK 0                    /**< Module has handled this stage. */
-#define DECLINED -1             /**< Module declines to handle */
-#define DONE -2                 /**< Module has served the response completely
-                                 *  - it's safe to die() with no more output
-                                 */
-#define SUSPENDED -3 /**< Module will handle the remainder of the request.
-                      * The core will never invoke the request again, */
+#define OK           0  /**< Module has handled this stage. */
+#define DECLINED    -1  /**< Module declines to handle */
+#define DONE        -2  /**< Module has served the response completely
+                         *   - it's safe to die() with no more output
+                         */
+#define SUSPENDED   -3  /**< Module will handle the remainder of the request.
+                         *   The core will never invoke the request again */
+#define AGAIN       -4  /**< Module wants to be called again when more
+                         *   data is available.
+                         */
 
 /** Returned by the bottom-most filter if no data was written.
  *  @see ap_pass_brigade(). */
@@ -1257,8 +1260,11 @@ struct conn_rec {
  */
 typedef enum  {
     CONN_STATE_KEEPALIVE,           /* Kept alive in the MPM (using KeepAliveTimeout) */
-    CONN_STATE_PROCESSING,          /* Handled by process_connection() hooks, may be returned
-                                       to the MPM for POLLIN/POLLOUT (using Timeout) */
+    CONN_STATE_PROCESSING,          /* Processed by process_connection() hooks, returning
+                                     * AGAIN to the MPM in this state will make it wait for
+                                     * the connection to be readable or writable according to
+                                     * CONN_SENSE_WANT_READ or CONN_SENSE_WANT_WRITE respectively,
+                                     * where Timeout applies */
     CONN_STATE_HANDLER,             /* Processed by the modules handlers */
     CONN_STATE_WRITE_COMPLETION,    /* Flushed by the MPM before entering CONN_STATE_KEEPALIVE */
     CONN_STATE_SUSPENDED,           /* Suspended in the MPM until ap_run_resume_suspended() */

--- a/include/httpd.h
+++ b/include/httpd.h
@@ -460,9 +460,6 @@ AP_DECLARE(const char *) ap_get_server_built(void);
                          */
 #define SUSPENDED   -3  /**< Module will handle the remainder of the request.
                          *   The core will never invoke the request again */
-#define AGAIN       -4  /**< Module wants to be called again when more
-                         *   data is available.
-                         */
 
 /** Returned by the bottom-most filter if no data was written.
  *  @see ap_pass_brigade(). */
@@ -1260,17 +1257,18 @@ struct conn_rec {
  */
 typedef enum  {
     CONN_STATE_KEEPALIVE,           /* Kept alive in the MPM (using KeepAliveTimeout) */
-    CONN_STATE_PROCESSING,          /* Processed by process_connection() hooks, returning
-                                     * AGAIN to the MPM in this state will make it wait for
-                                     * the connection to be readable or writable according to
-                                     * CONN_SENSE_WANT_READ or CONN_SENSE_WANT_WRITE respectively,
-                                     * where Timeout applies */
+    CONN_STATE_PROCESSING,          /* Processed by process_connection hooks */
     CONN_STATE_HANDLER,             /* Processed by the modules handlers */
     CONN_STATE_WRITE_COMPLETION,    /* Flushed by the MPM before entering CONN_STATE_KEEPALIVE */
     CONN_STATE_SUSPENDED,           /* Suspended in the MPM until ap_run_resume_suspended() */
     CONN_STATE_LINGER,              /* MPM flushes then closes the connection with lingering */
     CONN_STATE_LINGER_NORMAL,       /* MPM has started lingering close with normal timeout */
     CONN_STATE_LINGER_SHORT,        /* MPM has started lingering close with short timeout */
+
+    CONN_STATE_ASYNC_WAITIO,        /* Returning this state to the MPM will make it wait for
+                                     * the connection to be readable or writable according to
+                                     * c->cs->sense (resp. CONN_SENSE_WANT_READ or _WRITE),
+                                     * using the configured Timeout */
 
     CONN_STATE_NUM,                 /* Number of states (keep here before aliases) */
 

--- a/include/httpd.h
+++ b/include/httpd.h
@@ -1257,7 +1257,7 @@ struct conn_rec {
  */
 typedef enum  {
     CONN_STATE_KEEPALIVE,           /* Kept alive in the MPM (using KeepAliveTimeout) */
-    CONN_STATE_PROCESS,             /* Handled by process_connection() hooks, may be returned
+    CONN_STATE_PROCESSING,          /* Handled by process_connection() hooks, may be returned
                                        to the MPM for POLLIN/POLLOUT (using Timeout) */
     CONN_STATE_HANDLER,             /* Processed by the modules handlers */
     CONN_STATE_WRITE_COMPLETION,    /* Flushed by the MPM before entering CONN_STATE_KEEPALIVE */
@@ -1270,7 +1270,7 @@ typedef enum  {
 
     /* Aliases (legacy) */
     CONN_STATE_CHECK_REQUEST_LINE_READABLE  = CONN_STATE_KEEPALIVE,
-    CONN_STATE_READ_REQUEST_LINE            = CONN_STATE_PROCESS,
+    CONN_STATE_READ_REQUEST_LINE            = CONN_STATE_PROCESSING,
 } conn_state_e;
 
 typedef enum  {

--- a/include/httpd.h
+++ b/include/httpd.h
@@ -1256,16 +1256,21 @@ struct conn_rec {
  * only be set by the MPM. Use CONN_STATE_LINGER outside of the MPM.
  */
 typedef enum  {
-    CONN_STATE_CHECK_REQUEST_LINE_READABLE,
-    CONN_STATE_READ_REQUEST_LINE,
-    CONN_STATE_HANDLER,
-    CONN_STATE_WRITE_COMPLETION,
-    CONN_STATE_SUSPENDED,
-    CONN_STATE_LINGER,          /* connection may be closed with lingering */
-    CONN_STATE_LINGER_NORMAL,   /* MPM has started lingering close with normal timeout */
-    CONN_STATE_LINGER_SHORT,    /* MPM has started lingering close with short timeout */
+    CONN_STATE_KEEPALIVE,           /* Kept alive in the MPM (using KeepAliveTimeout) */
+    CONN_STATE_PROCESS,             /* Handled by process_connection() hooks, may be returned
+                                       to the MPM for POLLIN/POLLOUT (using Timeout) */
+    CONN_STATE_HANDLER,             /* Processed by the modules handlers */
+    CONN_STATE_WRITE_COMPLETION,    /* Flushed by the MPM before entering CONN_STATE_KEEPALIVE */
+    CONN_STATE_SUSPENDED,           /* Suspended in the MPM until ap_run_resume_suspended() */
+    CONN_STATE_LINGER,              /* MPM flushes then closes the connection with lingering */
+    CONN_STATE_LINGER_NORMAL,       /* MPM has started lingering close with normal timeout */
+    CONN_STATE_LINGER_SHORT,        /* MPM has started lingering close with short timeout */
 
-    CONN_STATE_NUM              /* Number of states (keep/kept last) */
+    CONN_STATE_NUM,                 /* Number of states (keep here before aliases) */
+
+    /* Aliases (legacy) */
+    CONN_STATE_CHECK_REQUEST_LINE_READABLE  = CONN_STATE_KEEPALIVE,
+    CONN_STATE_READ_REQUEST_LINE            = CONN_STATE_PROCESS,
 } conn_state_e;
 
 typedef enum  {

--- a/include/scoreboard.h
+++ b/include/scoreboard.h
@@ -151,8 +151,7 @@ struct process_score {
     int bucket;  /* Listener bucket used by this child; this field is DEPRECATED
                   * and no longer updated by the MPMs (i.e. always zero).
                   */
-    apr_uint32_t processing;        /* async connections in processing (returned
-                                       to the MPM for POLLIN/POLLOUT) */
+    apr_uint32_t wait_io;           /* async connections waiting an IO in the MPM */
 };
 
 /* Scoreboard is now in 'local' memory, since it isn't updated once created,

--- a/include/scoreboard.h
+++ b/include/scoreboard.h
@@ -144,7 +144,7 @@ struct process_score {
                              * connections (for async MPMs)
                              */
     apr_uint32_t connections;       /* total connections (for async MPMs) */
-    apr_uint32_t write_completion;  /* async connections doing write completion */
+    apr_uint32_t write_completion;  /* async connections in write completion or POLLIN/POLLOUT */
     apr_uint32_t lingering_close;   /* async connections in lingering close */
     apr_uint32_t keep_alive;        /* async connections in keep alive */
     apr_uint32_t suspended;         /* connections suspended by some module */

--- a/include/scoreboard.h
+++ b/include/scoreboard.h
@@ -144,13 +144,15 @@ struct process_score {
                              * connections (for async MPMs)
                              */
     apr_uint32_t connections;       /* total connections (for async MPMs) */
-    apr_uint32_t write_completion;  /* async connections in write completion or POLLIN/POLLOUT */
+    apr_uint32_t write_completion;  /* async connections in write completion */
     apr_uint32_t lingering_close;   /* async connections in lingering close */
     apr_uint32_t keep_alive;        /* async connections in keep alive */
     apr_uint32_t suspended;         /* connections suspended by some module */
     int bucket;  /* Listener bucket used by this child; this field is DEPRECATED
                   * and no longer updated by the MPMs (i.e. always zero).
                   */
+    apr_uint32_t processing;        /* async connections in processing (returned
+                                       to the MPM for POLLIN/POLLOUT) */
 };
 
 /* Scoreboard is now in 'local' memory, since it isn't updated once created,

--- a/modules/generators/mod_status.c
+++ b/modules/generators/mod_status.c
@@ -573,7 +573,7 @@ static int status_handler(request_rec *r)
                          "<th rowspan=\"2\">Stopping</th>"
                          "<th colspan=\"2\">Connections</th>\n"
                          "<th colspan=\"2\">Threads</th>"
-                         "<th colspan=\"3\">Async connections</th></tr>\n"
+                         "<th colspan=\"4\">Async connections</th></tr>\n"
                      "<tr><th>total</th><th>accepting</th>"
                          "<th>busy</th><th>graceful</th><th>idle</th>"
                          "<th>wait-io</th><th>writing</th><th>keep-alive</th>"

--- a/modules/generators/mod_status.c
+++ b/modules/generators/mod_status.c
@@ -564,7 +564,7 @@ static int status_handler(request_rec *r)
         ap_rputs("</dl>", r);
 
     if (is_async) {
-        int processing, write_completion = 0, lingering_close = 0, keep_alive = 0,
+        int processing = 0, write_completion = 0, lingering_close = 0, keep_alive = 0,
             connections = 0, stopping = 0, procs = 0;
         if (!short_report)
             ap_rputs("\n\n<table rules=\"all\" cellpadding=\"1%\">\n"

--- a/modules/generators/mod_status.c
+++ b/modules/generators/mod_status.c
@@ -564,7 +564,7 @@ static int status_handler(request_rec *r)
         ap_rputs("</dl>", r);
 
     if (is_async) {
-        int write_completion = 0, lingering_close = 0, keep_alive = 0,
+        int processing, write_completion = 0, lingering_close = 0, keep_alive = 0,
             connections = 0, stopping = 0, procs = 0;
         if (!short_report)
             ap_rputs("\n\n<table rules=\"all\" cellpadding=\"1%\">\n"
@@ -576,11 +576,13 @@ static int status_handler(request_rec *r)
                          "<th colspan=\"3\">Async connections</th></tr>\n"
                      "<tr><th>total</th><th>accepting</th>"
                          "<th>busy</th><th>graceful</th><th>idle</th>"
-                         "<th>writing</th><th>keep-alive</th><th>closing</th></tr>\n", r);
+                         "<th>processing</th><th>writing</th><th>keep-alive</th>"
+                         "<th>closing</th></tr>\n", r);
         for (i = 0; i < server_limit; ++i) {
             ps_record = ap_get_scoreboard_process(i);
             if (ps_record->pid) {
                 connections      += ps_record->connections;
+                processing       += ps_record->processing;
                 write_completion += ps_record->write_completion;
                 keep_alive       += ps_record->keep_alive;
                 lingering_close  += ps_record->lingering_close;
@@ -600,7 +602,7 @@ static int status_handler(request_rec *r)
                                       "<td>%s%s</td>"
                                       "<td>%u</td><td>%s</td>"
                                       "<td>%u</td><td>%u</td><td>%u</td>"
-                                      "<td>%u</td><td>%u</td><td>%u</td>"
+                                      "<td>%u</td><td>%u</td><td>%u</td><td>%u</td>"
                                       "</tr>\n",
                                i, ps_record->pid,
                                dying, old,
@@ -609,6 +611,7 @@ static int status_handler(request_rec *r)
                                thread_busy_buffer[i],
                                thread_graceful_buffer[i],
                                thread_idle_buffer[i],
+                               ps_record->processing,
                                ps_record->write_completion,
                                ps_record->keep_alive,
                                ps_record->lingering_close);
@@ -620,23 +623,26 @@ static int status_handler(request_rec *r)
                           "<td>%d</td><td>%d</td>"
                           "<td>%d</td><td>&nbsp;</td>"
                           "<td>%d</td><td>%d</td><td>%d</td>"
-                          "<td>%d</td><td>%d</td><td>%d</td>"
+                          "<td>%d</td><td>%d</td><td>%d</td><td>%d</td>"
                           "</tr>\n</table>\n",
                           procs, stopping,
                           connections,
                           busy, graceful, idle,
-                          write_completion, keep_alive, lingering_close);
+                          processing, write_completion, keep_alive,
+                          lingering_close);
         }
         else {
             ap_rprintf(r, "Processes: %d\n"
                           "Stopping: %d\n"
                           "ConnsTotal: %d\n"
+                          "ConnsAsyncProcessing: %d\n"
                           "ConnsAsyncWriting: %d\n"
                           "ConnsAsyncKeepAlive: %d\n"
                           "ConnsAsyncClosing: %d\n",
                           procs, stopping,
                           connections,
-                          write_completion, keep_alive, lingering_close);
+                          processing, write_completion, keep_alive,
+                          lingering_close);
         }
     }
 

--- a/modules/generators/mod_status.c
+++ b/modules/generators/mod_status.c
@@ -564,7 +564,7 @@ static int status_handler(request_rec *r)
         ap_rputs("</dl>", r);
 
     if (is_async) {
-        int processing = 0, write_completion = 0, lingering_close = 0, keep_alive = 0,
+        int wait_io = 0, write_completion = 0, lingering_close = 0, keep_alive = 0,
             connections = 0, stopping = 0, procs = 0;
         if (!short_report)
             ap_rputs("\n\n<table rules=\"all\" cellpadding=\"1%\">\n"
@@ -576,13 +576,13 @@ static int status_handler(request_rec *r)
                          "<th colspan=\"3\">Async connections</th></tr>\n"
                      "<tr><th>total</th><th>accepting</th>"
                          "<th>busy</th><th>graceful</th><th>idle</th>"
-                         "<th>processing</th><th>writing</th><th>keep-alive</th>"
+                         "<th>wait-io</th><th>writing</th><th>keep-alive</th>"
                          "<th>closing</th></tr>\n", r);
         for (i = 0; i < server_limit; ++i) {
             ps_record = ap_get_scoreboard_process(i);
             if (ps_record->pid) {
                 connections      += ps_record->connections;
-                processing       += ps_record->processing;
+                wait_io          += ps_record->wait_io;
                 write_completion += ps_record->write_completion;
                 keep_alive       += ps_record->keep_alive;
                 lingering_close  += ps_record->lingering_close;
@@ -611,7 +611,7 @@ static int status_handler(request_rec *r)
                                thread_busy_buffer[i],
                                thread_graceful_buffer[i],
                                thread_idle_buffer[i],
-                               ps_record->processing,
+                               ps_record->wait_io,
                                ps_record->write_completion,
                                ps_record->keep_alive,
                                ps_record->lingering_close);
@@ -628,20 +628,20 @@ static int status_handler(request_rec *r)
                           procs, stopping,
                           connections,
                           busy, graceful, idle,
-                          processing, write_completion, keep_alive,
+                          wait_io, write_completion, keep_alive,
                           lingering_close);
         }
         else {
             ap_rprintf(r, "Processes: %d\n"
                           "Stopping: %d\n"
                           "ConnsTotal: %d\n"
-                          "ConnsAsyncProcessing: %d\n"
+                          "ConnsAsyncWaitIO: %d\n"
                           "ConnsAsyncWriting: %d\n"
                           "ConnsAsyncKeepAlive: %d\n"
                           "ConnsAsyncClosing: %d\n",
                           procs, stopping,
                           connections,
-                          processing, write_completion, keep_alive,
+                          wait_io, write_completion, keep_alive,
                           lingering_close);
         }
     }

--- a/modules/generators/mod_status.c
+++ b/modules/generators/mod_status.c
@@ -572,7 +572,7 @@ static int status_handler(request_rec *r)
                          "<th rowspan=\"2\">PID</th>"
                          "<th rowspan=\"2\">Stopping</th>"
                          "<th colspan=\"2\">Connections</th>\n"
-                         "<th colspan=\"2\">Threads</th>"
+                         "<th colspan=\"3\">Threads</th>"
                          "<th colspan=\"4\">Async connections</th></tr>\n"
                      "<tr><th>total</th><th>accepting</th>"
                          "<th>busy</th><th>graceful</th><th>idle</th>"

--- a/modules/http/http_core.c
+++ b/modules/http/http_core.c
@@ -138,9 +138,9 @@ static int ap_process_http_async_connection(conn_rec *c)
     conn_state_t *cs = c->cs;
 
     AP_DEBUG_ASSERT(cs != NULL);
-    AP_DEBUG_ASSERT(cs->state == CONN_STATE_PROCESS);
+    AP_DEBUG_ASSERT(cs->state == CONN_STATE_PROCESSING);
 
-    if (cs->state == CONN_STATE_PROCESS) {
+    if (cs->state == CONN_STATE_PROCESSING) {
         ap_update_child_status_from_conn(c->sbh, SERVER_BUSY_READ, c);
         if (ap_extended_status) {
             ap_set_conn_count(c->sbh, r, c->keepalives);

--- a/modules/http/http_core.c
+++ b/modules/http/http_core.c
@@ -138,9 +138,9 @@ static int ap_process_http_async_connection(conn_rec *c)
     conn_state_t *cs = c->cs;
 
     AP_DEBUG_ASSERT(cs != NULL);
-    AP_DEBUG_ASSERT(cs->state == CONN_STATE_READ_REQUEST_LINE);
+    AP_DEBUG_ASSERT(cs->state == CONN_STATE_PROCESS);
 
-    if (cs->state == CONN_STATE_READ_REQUEST_LINE) {
+    if (cs->state == CONN_STATE_PROCESS) {
         ap_update_child_status_from_conn(c->sbh, SERVER_BUSY_READ, c);
         if (ap_extended_status) {
             ap_set_conn_count(c->sbh, r, c->keepalives);

--- a/modules/http2/h2.h
+++ b/modules/http2/h2.h
@@ -50,9 +50,9 @@ struct h2_stream;
 #endif
 
 #if AP_MODULE_MAGIC_AT_LEAST(20120211, 132)
-#define H2_USE_STATE_PROCESS       1
+#define H2_USE_STATE_PROCESSING 1
 #else
-#define H2_USE_STATE_PROCESS       0
+#define H2_USE_STATE_PROCESSING 0
 #endif
 
 /**

--- a/modules/http2/h2.h
+++ b/modules/http2/h2.h
@@ -49,6 +49,12 @@ struct h2_stream;
 #define H2_USE_WEBSOCKETS       0
 #endif
 
+#if AP_MODULE_MAGIC_AT_LEAST(20120211, 132)
+#define H2_USE_STATE_PROCESS       1
+#else
+#define H2_USE_STATE_PROCESS       0
+#endif
+
 /**
  * The magic PRIamble of RFC 7540 that is always sent when starting
  * a h2 communication.

--- a/modules/http2/h2.h
+++ b/modules/http2/h2.h
@@ -49,12 +49,6 @@ struct h2_stream;
 #define H2_USE_WEBSOCKETS       0
 #endif
 
-#if AP_MODULE_MAGIC_AT_LEAST(20120211, 132)
-#define H2_USE_STATE_PROCESSING 1
-#else
-#define H2_USE_STATE_PROCESSING 0
-#endif
-
 /**
  * The magic PRIamble of RFC 7540 that is always sent when starting
  * a h2 communication.

--- a/modules/http2/h2_c1.c
+++ b/modules/http2/h2_c1.c
@@ -161,8 +161,8 @@ apr_status_t h2_c1_run(conn_rec *c)
                      * the Timeout behaviour instead of a KeepAliveTimeout
                      * See PR 63534. 
                      */
-#if H2_USE_STATE_PROCESS
-                    c->cs->state = CONN_STATE_PROCESS;
+#if H2_USE_STATE_PROCESSING
+                    c->cs->state = CONN_STATE_PROCESSING;
 #else
                     c->cs->state = CONN_STATE_WRITE_COMPLETION;
 #endif

--- a/modules/http2/h2_c1.c
+++ b/modules/http2/h2_c1.c
@@ -161,7 +161,11 @@ apr_status_t h2_c1_run(conn_rec *c)
                      * the Timeout behaviour instead of a KeepAliveTimeout
                      * See PR 63534. 
                      */
+#if H2_USE_STATE_PROCESS
                     c->cs->state = CONN_STATE_PROCESS;
+#else
+                    c->cs->state = CONN_STATE_WRITE_COMPLETION;
+#endif
                     c->cs->sense = CONN_SENSE_WANT_READ;
                 }
                 break;

--- a/modules/http2/h2_c1.c
+++ b/modules/http2/h2_c1.c
@@ -116,7 +116,7 @@ cleanup:
 apr_status_t h2_c1_run(conn_rec *c)
 {
     apr_status_t status;
-    int mpm_state = 0;
+    int mpm_state = 0, keepalive = 0;
     h2_conn_ctx_t *conn_ctx = h2_conn_ctx_get(c);
     
     ap_assert(conn_ctx);
@@ -127,7 +127,7 @@ apr_status_t h2_c1_run(conn_rec *c)
             c->cs->state = CONN_STATE_HANDLER;
         }
     
-        status = h2_session_process(conn_ctx->session, async_mpm);
+        status = h2_session_process(conn_ctx->session, async_mpm, &keepalive);
         
         if (APR_STATUS_IS_EOF(status)) {
             ap_log_cerror(APLOG_MARK, APLOG_DEBUG, status, c, 
@@ -153,7 +153,7 @@ apr_status_t h2_c1_run(conn_rec *c)
             case H2_SESSION_ST_BUSY:
             case H2_SESSION_ST_WAIT:
                 c->cs->state = CONN_STATE_WRITE_COMPLETION;
-                if (c->cs && !conn_ctx->session->remote.emitted_count) {
+                if (!keepalive) {
                     /* let the MPM know that we are not done and want
                      * the Timeout behaviour instead of a KeepAliveTimeout
                      * See PR 63534. 

--- a/modules/http2/h2_c1.c
+++ b/modules/http2/h2_c1.c
@@ -152,20 +152,25 @@ apr_status_t h2_c1_run(conn_rec *c)
             case H2_SESSION_ST_IDLE:
             case H2_SESSION_ST_BUSY:
             case H2_SESSION_ST_WAIT:
-                c->cs->state = CONN_STATE_WRITE_COMPLETION;
-                if (!keepalive) {
+                if (keepalive) {
+                    /* flush then keep-alive */
+                    c->cs->state = CONN_STATE_WRITE_COMPLETION;
+                }
+                else {
                     /* let the MPM know that we are not done and want
                      * the Timeout behaviour instead of a KeepAliveTimeout
                      * See PR 63534. 
                      */
+                    c->cs->state = CONN_STATE_PROCESS;
                     c->cs->sense = CONN_SENSE_WANT_READ;
                 }
                 break;
+
             case H2_SESSION_ST_CLEANUP:
             case H2_SESSION_ST_DONE:
             default:
                 c->cs->state = CONN_STATE_LINGER;
-            break;
+                break;
         }
     }
 

--- a/modules/http2/h2_c1.c
+++ b/modules/http2/h2_c1.c
@@ -47,23 +47,25 @@
 
 static struct h2_workers *workers;
 
-static int async_mpm;
+static int async_mpm, mpm_can_again;
 
 APR_OPTIONAL_FN_TYPE(ap_logio_add_bytes_in) *h2_c_logio_add_bytes_in;
 APR_OPTIONAL_FN_TYPE(ap_logio_add_bytes_out) *h2_c_logio_add_bytes_out;
 
 apr_status_t h2_c1_child_init(apr_pool_t *pool, server_rec *s)
 {
-    apr_status_t status = APR_SUCCESS;
     int minw, maxw;
     apr_time_t idle_limit;
 
-    status = ap_mpm_query(AP_MPMQ_IS_ASYNC, &async_mpm);
-    if (status != APR_SUCCESS) {
+    if (ap_mpm_query(AP_MPMQ_IS_ASYNC, &async_mpm)) {
         /* some MPMs do not implemnent this */
         async_mpm = 0;
-        status = APR_SUCCESS;
     }
+#ifdef AP_MPMQ_CAN_AGAIN
+    if (!async_mpm || ap_mpm_query(AP_MPMQ_CAN_AGAIN, &mpm_can_again)) {
+        mpm_can_again = 0;
+    }
+#endif
 
     h2_config_init(pool);
 
@@ -113,23 +115,23 @@ cleanup:
     return rv;
 }
 
-apr_status_t h2_c1_run(conn_rec *c)
+int h2_c1_run(conn_rec *c)
 {
+    int rc = OK;
     apr_status_t status;
     int mpm_state = 0, keepalive = 0;
     h2_conn_ctx_t *conn_ctx = h2_conn_ctx_get(c);
     
     ap_assert(conn_ctx);
     ap_assert(conn_ctx->session);
+    c->clogging_input_filters = 0;
     do {
         if (c->cs) {
-            c->cs->sense = CONN_SENSE_DEFAULT;
             c->cs->state = CONN_STATE_HANDLER;
         }
     
         status = h2_session_process(conn_ctx->session, async_mpm, &keepalive);
-        
-        if (APR_STATUS_IS_EOF(status)) {
+        if (status != APR_SUCCESS) {
             ap_log_cerror(APLOG_MARK, APLOG_DEBUG, status, c, 
                           H2_SSSN_LOG(APLOGNO(03045), conn_ctx->session,
                           "process, closing conn"));
@@ -153,20 +155,39 @@ apr_status_t h2_c1_run(conn_rec *c)
             case H2_SESSION_ST_BUSY:
             case H2_SESSION_ST_WAIT:
                 if (keepalive) {
-                    /* flush then keep-alive */
+                    /* Flush then keep-alive */
+                    c->cs->sense = CONN_SENSE_DEFAULT;
                     c->cs->state = CONN_STATE_WRITE_COMPLETION;
                 }
                 else {
-                    /* let the MPM know that we are not done and want
-                     * the Timeout behaviour instead of a KeepAliveTimeout
+                    /* Let the MPM know that we are not done and want to wait
+                     * for read using Timeout instead of KeepAliveTimeout.
                      * See PR 63534. 
                      */
-#if H2_USE_STATE_PROCESSING
-                    c->cs->state = CONN_STATE_PROCESSING;
-#else
-                    c->cs->state = CONN_STATE_WRITE_COMPLETION;
-#endif
                     c->cs->sense = CONN_SENSE_WANT_READ;
+#ifdef AP_MPMQ_CAN_AGAIN
+                    if (mpm_can_again) {
+                        /* This tells the MPM to wait for the connection to be
+                         * readable (CONN_SENSE_WANT_READ) within the configured
+                         * Timeout and then come back to the process_connection()
+                         * hooks again when ready.
+                         */
+                        c->cs->state = CONN_STATE_PROCESSING;
+                        rc = AGAIN;
+                    }
+                    else
+#endif
+                    {
+                        /* This is a compat workaround to do the same using the
+                         * CONN_STATE_WRITE_COMPLETION state but with both
+                         * CONN_SENSE_WANT_READ to wait for readability rather
+                         * than writing and c->clogging_input_filters to force
+                         * reentering the process_connection() hooks from any
+                         * state when ready. This somehow will use Timeout too.
+                         */
+                        c->cs->state = CONN_STATE_WRITE_COMPLETION;
+                        c->clogging_input_filters = 1;
+                    }
                 }
                 break;
 
@@ -178,7 +199,7 @@ apr_status_t h2_c1_run(conn_rec *c)
         }
     }
 
-    return APR_SUCCESS;
+    return rc;
 }
 
 apr_status_t h2_c1_pre_close(struct h2_conn_ctx_t *ctx, conn_rec *c)
@@ -284,8 +305,7 @@ static int h2_c1_hook_process_connection(conn_rec* c)
             return !OK;
         }
     }
-    h2_c1_run(c);
-    return OK;
+    return h2_c1_run(c);
 
 declined:
     ap_log_cerror(APLOG_MARK, APLOG_TRACE1, 0, c, "h2_h2, declined");

--- a/modules/http2/h2_mplx.c
+++ b/modules/http2/h2_mplx.c
@@ -397,6 +397,7 @@ apr_status_t h2_mplx_c1_streams_do(h2_mplx *m, h2_mplx_stream_cb *cb, void *ctx)
 typedef struct {
     int stream_count;
     int stream_want_send;
+    int stream_send_win_exhausted;
 } stream_iter_aws_t;
 
 static int m_stream_want_send_data(void *ctx, void *stream)
@@ -417,6 +418,29 @@ int h2_mplx_c1_all_streams_want_send_data(h2_mplx *m)
     h2_ihash_iter(m->streams, m_stream_want_send_data, &x);
     H2_MPLX_LEAVE(m);
     return x.stream_count && (x.stream_count == x.stream_want_send);
+}
+
+static int m_stream_send_win_exh(void *ctx, void *s)
+{
+    h2_stream *stream = s;
+    int win;
+    stream_iter_aws_t *x = ctx;
+    ++x->stream_count;
+    win = nghttp2_session_get_stream_remote_window_size(stream->session->ngh2, stream->id);
+    if (win == 0)
+      ++x->stream_send_win_exhausted;
+    return 1;
+}
+
+int h2_mplx_c1_all_streams_send_win_exhausted(h2_mplx *m)
+{
+    stream_iter_aws_t x;
+    x.stream_count = 0;
+    x.stream_send_win_exhausted = 0;
+    H2_MPLX_ENTER(m);
+    h2_ihash_iter(m->streams, m_stream_send_win_exh, &x);
+    H2_MPLX_LEAVE(m);
+    return x.stream_count && (x.stream_count == x.stream_send_win_exhausted);
 }
 
 static int m_report_stream_iter(void *ctx, void *val) {

--- a/modules/http2/h2_mplx.h
+++ b/modules/http2/h2_mplx.h
@@ -197,6 +197,11 @@ apr_status_t h2_mplx_c1_streams_do(h2_mplx *m, h2_mplx_stream_cb *cb, void *ctx)
 int h2_mplx_c1_all_streams_want_send_data(h2_mplx *m);
 
 /**
+ * Return != 0 iff all open streams have send window exhausted
+ */
+int h2_mplx_c1_all_streams_send_win_exhausted(h2_mplx *m);
+
+/**
  * A stream has been RST_STREAM by the client. Abort
  * any processing going on and remove from processing
  * queue.

--- a/modules/http2/h2_session.c
+++ b/modules/http2/h2_session.c
@@ -323,8 +323,8 @@ static int on_header_cb(nghttp2_session *ngh2, const nghttp2_frame *frame,
         (!stream->rtmp ||
          stream->rtmp->http_status == H2_HTTP_STATUS_UNSET ||
          /* We accept a certain amount of failures in order to reply
-          * with an informative HTTP error response like 413. But if the
-          * client is too wrong, we fail the request a RESET of the stream */
+          * with an informative HTTP error response like 413. But of the
+          * client is too wrong, we RESET the stream */
          stream->request_headers_failed > 100)) {
         return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
     }
@@ -1762,12 +1762,22 @@ static void unblock_c1_out(h2_session *session) {
     }
 }
 
-apr_status_t h2_session_process(h2_session *session, int async)
+static int h2_send_flow_blocked(h2_session *session)
+{
+    /* We are completely send blocked if either the connection window
+     * is 0 or all stream flow windows are 0. */
+    return ((nghttp2_session_get_remote_window_size(session->ngh2) <= 0) ||
+             h2_mplx_c1_all_streams_send_win_exhausted(session->mplx));
+}
+
+apr_status_t h2_session_process(h2_session *session, int async,
+                                int *pkeepalive)
 {
     apr_status_t status = APR_SUCCESS;
     conn_rec *c = session->c1;
     int rv, mpm_state, trace = APLOGctrace3(c);
 
+    *pkeepalive = 0;
     if (trace) {
         ap_log_cerror( APLOG_MARK, APLOG_TRACE3, status, c,
                       H2_SSSN_MSG(session, "process start, async=%d"), async);
@@ -1922,6 +1932,14 @@ apr_status_t h2_session_process(h2_session *session, int async)
             break;
 
         case H2_SESSION_ST_WAIT:
+            /* In this state, we might have returned processing to the MPM
+             * before. On a connection socket event, we are invoked again and
+             * need to process any input before proceeding. */
+            h2_c1_read(session);
+            if (session->state != H2_SESSION_ST_WAIT) {
+                break;
+            }
+
             status = h2_c1_io_assure_flushed(&session->io);
             if (APR_SUCCESS != status) {
                 h2_session_dispatch_event(session, H2_SESSION_EV_CONN_ERROR, status, NULL);
@@ -1934,8 +1952,20 @@ apr_status_t h2_session_process(h2_session *session, int async)
                     break;
                 }
             }
-            /* No IO happening and input is exhausted. Make sure we have
-             * flushed any possibly pending output and then wait with
+#if AP_MODULE_MAGIC_AT_LEAST(20211221, 19)
+            else if (async && h2_send_flow_blocked(session)) {
+                /* On a recent HTTPD, we can return to mpm c1 monitoring,
+                 * as it does not treat all connections as having KeepAlive
+                 * timing and being purgeable on load.
+                 * By returning to the MPM, we do not block a worker
+                 * and async wait for the client send window updates. */
+                ap_log_cerror(APLOG_MARK, APLOG_DEBUG, status, c,
+                              H2_SSSN_LOG(APLOGNO(10502), session,
+                              "BLOCKED, return to mpm c1 monitoring"));
+                goto leaving;
+            }
+#endif
+            /* No IO happening and input is exhausted. Wait with
              * the c1 connection timeout for sth to happen in our c1/c2 sockets/pipes */
             ap_log_cerror(APLOG_MARK, APLOG_TRACE2, status, c,
                           H2_SSSN_MSG(session, "polling timeout=%d, open_streams=%d"),
@@ -1976,9 +2006,13 @@ apr_status_t h2_session_process(h2_session *session, int async)
     }
 
 leaving:
+    /* entering KeepAlive timing when we have no more open streams AND
+     * we have processed at least one stream. */
+    *pkeepalive = (session->open_streams == 0 && session->remote.emitted_count);
     if (trace) {
-        ap_log_cerror( APLOG_MARK, APLOG_TRACE3, status, c,
-                      H2_SSSN_MSG(session, "process returns")); 
+        ap_log_cerror(APLOG_MARK, APLOG_TRACE3, status, c,
+                      H2_SSSN_MSG(session, "process returns, keepalive=%d"),
+                      *pkeepalive);
     }
     h2_mplx_c1_going_keepalive(session->mplx);
 

--- a/modules/http2/h2_session.c
+++ b/modules/http2/h2_session.c
@@ -1762,6 +1762,7 @@ static void unblock_c1_out(h2_session *session) {
     }
 }
 
+#if AP_MODULE_MAGIC_AT_LEAST(20211221, 19)
 static int h2_send_flow_blocked(h2_session *session)
 {
     /* We are completely send blocked if either the connection window
@@ -1769,6 +1770,7 @@ static int h2_send_flow_blocked(h2_session *session)
     return ((nghttp2_session_get_remote_window_size(session->ngh2) <= 0) ||
              h2_mplx_c1_all_streams_send_win_exhausted(session->mplx));
 }
+#endif
 
 apr_status_t h2_session_process(h2_session *session, int async,
                                 int *pkeepalive)

--- a/modules/http2/h2_session.c
+++ b/modules/http2/h2_session.c
@@ -1762,7 +1762,7 @@ static void unblock_c1_out(h2_session *session) {
     }
 }
 
-#if AP_MODULE_MAGIC_AT_LEAST(20211221, 19)
+#if H2_USE_STATE_PROCESS
 static int h2_send_flow_blocked(h2_session *session)
 {
     /* We are completely send blocked if either the connection window
@@ -1954,7 +1954,7 @@ apr_status_t h2_session_process(h2_session *session, int async,
                     break;
                 }
             }
-#if AP_MODULE_MAGIC_AT_LEAST(20211221, 19)
+#if H2_USE_STATE_PROCESS
             else if (async && h2_send_flow_blocked(session)) {
                 /* On a recent HTTPD, we can return to mpm c1 monitoring,
                  * as it does not treat all connections as having KeepAlive

--- a/modules/http2/h2_session.c
+++ b/modules/http2/h2_session.c
@@ -1762,7 +1762,7 @@ static void unblock_c1_out(h2_session *session) {
     }
 }
 
-#if H2_USE_STATE_PROCESS
+#if H2_USE_STATE_PROCESSING
 static int h2_send_flow_blocked(h2_session *session)
 {
     /* We are completely send blocked if either the connection window
@@ -1954,7 +1954,7 @@ apr_status_t h2_session_process(h2_session *session, int async,
                     break;
                 }
             }
-#if H2_USE_STATE_PROCESS
+#if H2_USE_STATE_PROCESSING
             else if (async && h2_send_flow_blocked(session)) {
                 /* On a recent HTTPD, we can return to mpm c1 monitoring,
                  * as it does not treat all connections as having KeepAlive

--- a/modules/http2/h2_session.h
+++ b/modules/http2/h2_session.h
@@ -144,8 +144,11 @@ void h2_session_event(h2_session *session, h2_session_event_t ev,
  * error occurred.
  *
  * @param session the sessionm to process
+ * @param async if mpm is async
+ * @param pkeepalive on return, != 0 if connection to be put into keepalive
+ *                   behaviour and timouts
  */
-apr_status_t h2_session_process(h2_session *session, int async);
+apr_status_t h2_session_process(h2_session *session, int async, int *pkeepalive);
 
 /**
  * Last chance to do anything before the connection is closed.

--- a/modules/http2/h2_version.h
+++ b/modules/http2/h2_version.h
@@ -27,7 +27,7 @@
  * @macro
  * Version number of the http2 module as c string
  */
-#define MOD_HTTP2_VERSION "2.0.22"
+#define MOD_HTTP2_VERSION "2.0.27"
 
 /**
  * @macro
@@ -35,7 +35,7 @@
  * release. This is a 24 bit number with 8 bits for major number, 8 bits
  * for minor and 8 bits for patch. Version 1.2.3 becomes 0x010203.
  */
-#define MOD_HTTP2_VERSION_NUM 0x020016
+#define MOD_HTTP2_VERSION_NUM 0x02001b
 
 
 #endif /* mod_h2_h2_version_h */

--- a/modules/lua/lua_request.c
+++ b/modules/lua/lua_request.c
@@ -1264,8 +1264,8 @@ static int lua_ap_scoreboard_process(lua_State *L)
         lua_pushnumber(L, ps_record->suspended);
         lua_settable(L, -3);
 
-        lua_pushstring(L, "processing");
-        lua_pushnumber(L, ps_record->processing);
+        lua_pushstring(L, "wait_io");
+        lua_pushnumber(L, ps_record->wait_io);
         lua_settable(L, -3);
 
         lua_pushstring(L, "write_completion");

--- a/modules/lua/lua_request.c
+++ b/modules/lua/lua_request.c
@@ -1264,6 +1264,10 @@ static int lua_ap_scoreboard_process(lua_State *L)
         lua_pushnumber(L, ps_record->suspended);
         lua_settable(L, -3);
 
+        lua_pushstring(L, "processing");
+        lua_pushnumber(L, ps_record->processing);
+        lua_settable(L, -3);
+
         lua_pushstring(L, "write_completion");
         lua_pushnumber(L, ps_record->write_completion);
         lua_settable(L, -3);

--- a/server/mpm/event/event.c
+++ b/server/mpm/event/event.c
@@ -1144,7 +1144,7 @@ static void process_socket(apr_thread_t *thd, apr_pool_t * p, apr_socket_t * soc
         else if (c->aborted) {
             cs->pub.state = CONN_STATE_LINGER;
         }
-        if (cs->pub.state >= CONN_STATE_LINGER) {
+        if (cs->pub.state == CONN_STATE_LINGER) {
             goto lingering_close;
         }
     }

--- a/server/mpm/event/event.c
+++ b/server/mpm/event/event.c
@@ -692,6 +692,9 @@ static int event_query(int query_code, int *result, apr_status_t *rv)
     case AP_MPMQ_GENERATION:
         *result = retained->mpm->my_generation;
         break;
+    case AP_MPMQ_CAN_AGAIN:
+        *result = 1;
+        break;
     default:
         *rv = APR_ENOTIMPL;
         break;
@@ -1039,6 +1042,8 @@ static void process_socket(apr_thread_t *thd, apr_pool_t * p, apr_socket_t * soc
         if (rc != OK && rc != DONE) {
             ap_log_cerror(APLOG_MARK, APLOG_DEBUG, 0, c, APLOGNO(00469)
                           "process_socket: connection aborted");
+            close_connection(cs);
+            return;
         }
 
         /**
@@ -1056,7 +1061,6 @@ static void process_socket(apr_thread_t *thd, apr_pool_t * p, apr_socket_t * soc
          */
         cs->pub.state = CONN_STATE_PROCESSING;
         cs->pub.sense = CONN_SENSE_DEFAULT;
-        rc = OK;
     }
     else {
         c = cs->c;
@@ -1067,76 +1071,85 @@ static void process_socket(apr_thread_t *thd, apr_pool_t * p, apr_socket_t * soc
         c->id = conn_id;
     }
 
-    if (c->aborted) {
-        /* do lingering close below */
-        cs->pub.state = CONN_STATE_LINGER;
+    if (cs->pub.state >= CONN_STATE_LINGER) {
+        goto lingering_close;
     }
-    else if (cs->pub.state >= CONN_STATE_LINGER) {
-        /* fall through */
-    }
-    else {
-        if (cs->pub.state == CONN_STATE_PROCESSING
-            /* If we have an input filter which 'clogs' the input stream,
-             * like mod_ssl used to, lets just do the normal read from input
-             * filters, like the Worker MPM does. Filters that need to write
-             * where they would otherwise read, or read where they would
-             * otherwise write, should set the sense appropriately.
-             */
-             || c->clogging_input_filters) {
-process_connection:
-            clogging = c->clogging_input_filters;
-            if (clogging) {
-                apr_atomic_inc32(&clogged_count);
+
+    if (cs->pub.state == CONN_STATE_PROCESSING
+        /* If we have an input filter which 'clogs' the input stream,
+         * like mod_ssl used to, lets just do the normal read from input
+         * filters, like the Worker MPM does. Filters that need to write
+         * where they would otherwise read, or read where they would
+         * otherwise write, should set the sense appropriately.
+         */
+         || c->clogging_input_filters) {
+ process_connection:
+        cs->pub.state = CONN_STATE_PROCESSING;
+
+        clogging = c->clogging_input_filters;
+        if (clogging) {
+            apr_atomic_inc32(&clogged_count);
+        }
+        rc = ap_run_process_connection(c);
+        if (clogging) {
+            apr_atomic_dec32(&clogged_count);
+        }
+        /*
+         * The process_connection hooks should set the appropriate connection
+         * state upon return, for event MPM to either:
+         * - CONN_STATE_LINGER: do lingering close;
+         * - CONN_STATE_WRITE_COMPLETION: flush pending outputs using Timeout
+         *   and wait for next incoming data using KeepAliveTimeout, then come
+         *   back to process_connection() hooks;
+         * - CONN_STATE_SUSPENDED: suspend the connection such that it now
+         *   interacts with the MPM through suspend/resume_connection() hooks,
+         *   and/or registered poll callbacks (PT_USER), and/or registered
+         *   timed callbacks triggered by timer events;
+         * - CONN_STATE_PROCESSING: wait for read/write-ability of the underlying
+         *   socket using Timeout and come back to process_connection() hooks when
+         *   ready (the return value should be AGAIN in this case to not break old
+         *   or third-party modules which might return OK w/o touching the state and
+         *   expect lingering close, like with worker or prefork MPMs);
+         * - CONN_STATE_KEEPALIVE: now handled by CONN_STATE_WRITE_COMPLETION
+         *   to flush before waiting for next data (that might depend on it).
+         * If a process_connection hook returns an error or no hook sets the state
+         * to one of the above expected value, forcibly close the connection w/
+         * CONN_STATE_LINGER.  This covers the cases where no process_connection
+         * hook executes (DECLINED).
+         */
+        switch (rc) {
+        case DONE:
+            rc = OK; /* same as OK, fall through */
+        case OK:
+            if (cs->pub.state == CONN_STATE_PROCESSING) {
+                cs->pub.state = CONN_STATE_LINGER;
             }
-            rc = ap_run_process_connection(c);
-            if (clogging) {
-                apr_atomic_dec32(&clogged_count);
+            else if (cs->pub.state == CONN_STATE_KEEPALIVE) {
+                cs->pub.state = CONN_STATE_WRITE_COMPLETION;
             }
-            /* The sense can be set for CONN_STATE_PROCESSING (and
-             * CONN_STATE_WRITE_COMPLETION in 2.4.x) only.
-             */
-            if (cs->pub.state != CONN_STATE_PROCESSING
-                && cs->pub.state != CONN_STATE_WRITE_COMPLETION) {
-                cs->pub.sense = CONN_SENSE_DEFAULT;
-            }
-            if (rc == DONE) {
+            break;
+        case AGAIN:
+            if (cs->pub.state == CONN_STATE_PROCESSING) {
                 rc = OK;
             }
+            break;
         }
-    }
-    /*
-     * The process_connection hooks above should set the connection state
-     * appropriately upon return, for event MPM to either:
-     * - CONN_STATE_LINGER: do lingering close;
-     * - CONN_STATE_PROCESSING: wait for read/write-ability of the underlying
-     *   socket with respect to its Timeout and come back to process_connection()
-     *   hooks when ready;
-     * - CONN_STATE_WRITE_COMPLETION: flush pending outputs using Timeout and
-     *   wait for next incoming data using KeepAliveTimeout, then come back to
-     *   process_connection() hooks;
-     * - CONN_STATE_SUSPENDED: suspend the connection such that it now interacts
-     *   with the MPM through suspend/resume_connection() hooks, and/or registered
-     *   poll callbacks (PT_USER), and/or registered timed callbacks triggered by
-     *   timer events.
-     * If a process_connection hook returns an error or no hook sets the state
-     * to one of the above expected value, we forcibly close the connection w/
-     * CONN_STATE_LINGER.  This covers the cases where no process_connection
-     * hook executes (DECLINED), or one returns OK w/o touching the state (i.e.
-     * CONN_STATE_PROCESSING remains after the call) which can happen with
-     * third-party modules not updated to work specifically with event MPM
-     * while this was expected to do lingering close unconditionally with
-     * worker or prefork MPMs for instance.
-     */
-    if (rc != OK || (cs->pub.state != CONN_STATE_LINGER
-                     && cs->pub.state != CONN_STATE_PROCESSING
-                     && cs->pub.state != CONN_STATE_WRITE_COMPLETION
-                     && cs->pub.state != CONN_STATE_SUSPENDED)) {
-        ap_log_cerror(APLOG_MARK, APLOG_DEBUG, 0, c, APLOGNO(10111)
-                      "process_socket: connection processing %s: closing",
-                      rc ? apr_psprintf(c->pool, "returned error %i", rc)
-                         : apr_psprintf(c->pool, "unexpected state %i",
-                                                 (int)cs->pub.state));
-        cs->pub.state = CONN_STATE_LINGER;
+        if (rc != OK || (cs->pub.state != CONN_STATE_LINGER
+                         && cs->pub.state != CONN_STATE_PROCESSING
+                         && cs->pub.state != CONN_STATE_WRITE_COMPLETION
+                         && cs->pub.state != CONN_STATE_SUSPENDED)) {
+            ap_log_cerror(APLOG_MARK, APLOG_DEBUG, 0, c, APLOGNO(10111)
+                          "process_socket: connection processing returned %i "
+                          "(%sstate %i): closing",
+                          rc, rc ? "" : "unexpected ", (int)cs->pub.state);
+            cs->pub.state = CONN_STATE_LINGER;
+        }
+        else if (c->aborted) {
+            cs->pub.state = CONN_STATE_LINGER;
+        }
+        if (cs->pub.state >= CONN_STATE_LINGER) {
+            goto lingering_close;
+        }
     }
 
     if (cs->pub.state == CONN_STATE_PROCESSING) {
@@ -1188,9 +1201,9 @@ process_connection:
             ap_log_cerror(APLOG_MARK, APLOG_DEBUG, rv, c, APLOGNO(00470)
                           "network write failure in core output filter");
             cs->pub.state = CONN_STATE_LINGER;
+            goto lingering_close;
         }
-        else if (c->data_in_output_filters ||
-                 cs->pub.sense == CONN_SENSE_WANT_READ) {
+        if (c->data_in_output_filters || cs->pub.sense == CONN_SENSE_WANT_READ) {
             /* Still in WRITE_COMPLETION_STATE:
              * Set a read/write timeout for this connection, and let the
              * event thread poll for read/writeability.
@@ -1218,19 +1231,20 @@ process_connection:
             }
             return;
         }
-        else if (c->keepalive != AP_CONN_KEEPALIVE || c->aborted) {
+        if (c->keepalive != AP_CONN_KEEPALIVE || c->aborted) {
             cs->pub.state = CONN_STATE_LINGER;
+            goto lingering_close;
         }
-        else if (c->data_in_input_filters) {
-            cs->pub.state = CONN_STATE_PROCESSING;
+        if (c->data_in_input_filters) {
             goto process_connection;
         }
-        else if (!listener_may_exit) {
-            cs->pub.state = CONN_STATE_KEEPALIVE;
-        }
-        else {
+        if (listener_may_exit) {
             cs->pub.state = CONN_STATE_LINGER;
+            goto lingering_close;
         }
+
+        /* Fall through */
+        cs->pub.state = CONN_STATE_KEEPALIVE;
     }
 
     if (cs->pub.state == CONN_STATE_KEEPALIVE) {
@@ -1248,6 +1262,7 @@ process_connection:
         notify_suspend(cs);
 
         /* Add work to pollset. */
+        cs->pub.sense = CONN_SENSE_DEFAULT;
         update_reqevents_from_sense(cs, CONN_SENSE_WANT_READ);
         apr_thread_mutex_lock(timeout_mutex);
         TO_QUEUE_APPEND(cs->sc->ka_q, cs);
@@ -1274,6 +1289,7 @@ process_connection:
         return;
     }
 
+ lingering_close:
     /* CONN_STATE_LINGER[_*] fall through process_lingering_close() */
     process_lingering_close(cs);
 }
@@ -1538,12 +1554,11 @@ static void process_lingering_close(event_conn_state_t *cs)
             close_connection(cs);
             return;
         }
-
-        cs->queue_timestamp = apr_time_now();
-        /* Clear APR_INCOMPLETE_READ if it was ever set, we'll do the poll()
-         * at the listener only from now, if needed.
-         */
+        
+        /* All nonblocking from now, no need for APR_INCOMPLETE_READ either */
+        apr_socket_timeout_set(csd, 0);
         apr_socket_opt_set(csd, APR_INCOMPLETE_READ, 0);
+
         /*
          * If some module requested a shortened waiting period, only wait for
          * 2s (SECONDS_TO_LINGER). This is useful for mitigating certain
@@ -1557,9 +1572,17 @@ static void process_lingering_close(event_conn_state_t *cs)
         }
         cs->pub.sense = CONN_SENSE_DEFAULT;
         notify_suspend(cs);
+
+        /* One timestamp/duration for the whole lingering close time.
+         * XXX: This makes the (short_)linger_q not sorted/ordered by expiring
+         * timeouts whenever multiple schedules are necessary (EAGAIN below),
+         * but we probabaly don't care since these connections do not count
+         * for connections_above_limit() and all of them will be killed when
+         * busy or gracefully stopping anyway.
+         */
+        cs->queue_timestamp = apr_time_now();
     }
 
-    apr_socket_timeout_set(csd, 0);
     do {
         nbytes = sizeof(dummybuf);
         rv = apr_socket_recv(csd, dummybuf, &nbytes);

--- a/server/mpm/event/event.c
+++ b/server/mpm/event/event.c
@@ -262,12 +262,14 @@ struct timeout_queue {
 /*
  * Several timeout queues that use different timeouts, so that we always can
  * simply append to the end.
- *   process_q          uses vhost's TimeOut
+ *   processing_q       uses vhost's TimeOut
+ *   write_completion_q uses vhost's TimeOut
  *   keepalive_q        uses vhost's KeepAliveTimeOut
  *   linger_q           uses MAX_SECS_TO_LINGER
  *   short_linger_q     uses SECONDS_TO_LINGER
  */
-static struct timeout_queue *process_q,
+static struct timeout_queue *processing_q,
+                            *write_completion_q,
                             *keepalive_q,
                             *linger_q,
                             *short_linger_q;
@@ -414,6 +416,7 @@ static event_child_bucket *all_buckets, /* All listeners buckets */
 
 struct event_srv_cfg_s {
     struct timeout_queue *ps_q,
+                         *wc_q,
                          *ka_q;
 };
 
@@ -1051,7 +1054,7 @@ static void process_socket(apr_thread_t *thd, apr_pool_t * p, apr_socket_t * soc
          * When the accept filter is active, sockets are kept in the
          * kernel until a HTTP request is received.
          */
-        cs->pub.state = CONN_STATE_PROCESS;
+        cs->pub.state = CONN_STATE_PROCESSING;
         cs->pub.sense = CONN_SENSE_DEFAULT;
         rc = OK;
     }
@@ -1072,7 +1075,7 @@ static void process_socket(apr_thread_t *thd, apr_pool_t * p, apr_socket_t * soc
         /* fall through */
     }
     else {
-        if (cs->pub.state == CONN_STATE_PROCESS
+        if (cs->pub.state == CONN_STATE_PROCESSING
             /* If we have an input filter which 'clogs' the input stream,
              * like mod_ssl used to, lets just do the normal read from input
              * filters, like the Worker MPM does. Filters that need to write
@@ -1089,10 +1092,10 @@ process_connection:
             if (clogging) {
                 apr_atomic_dec32(&clogged_count);
             }
-            /* The sense can be set for CONN_STATE_PROCESS (and
+            /* The sense can be set for CONN_STATE_PROCESSING (and
              * CONN_STATE_WRITE_COMPLETION in 2.4.x) only.
              */
-            if (cs->pub.state != CONN_STATE_PROCESS
+            if (cs->pub.state != CONN_STATE_PROCESSING
                 && cs->pub.state != CONN_STATE_WRITE_COMPLETION) {
                 cs->pub.sense = CONN_SENSE_DEFAULT;
             }
@@ -1105,7 +1108,7 @@ process_connection:
      * The process_connection hooks above should set the connection state
      * appropriately upon return, for event MPM to either:
      * - CONN_STATE_LINGER: do lingering close;
-     * - CONN_STATE_PROCESS: wait for read/write-ability of the underlying
+     * - CONN_STATE_PROCESSING: wait for read/write-ability of the underlying
      *   socket with respect to its Timeout and come back to process_connection()
      *   hooks when ready;
      * - CONN_STATE_WRITE_COMPLETION: flush pending outputs using Timeout and
@@ -1119,13 +1122,13 @@ process_connection:
      * to one of the above expected value, we forcibly close the connection w/
      * CONN_STATE_LINGER.  This covers the cases where no process_connection
      * hook executes (DECLINED), or one returns OK w/o touching the state (i.e.
-     * CONN_STATE_PROCESS remains after the call) which can happen with
+     * CONN_STATE_PROCESSING remains after the call) which can happen with
      * third-party modules not updated to work specifically with event MPM
      * while this was expected to do lingering close unconditionally with
      * worker or prefork MPMs for instance.
      */
     if (rc != OK || (cs->pub.state != CONN_STATE_LINGER
-                     && cs->pub.state != CONN_STATE_PROCESS
+                     && cs->pub.state != CONN_STATE_PROCESSING
                      && cs->pub.state != CONN_STATE_WRITE_COMPLETION
                      && cs->pub.state != CONN_STATE_SUSPENDED)) {
         ap_log_cerror(APLOG_MARK, APLOG_DEBUG, 0, c, APLOGNO(10111)
@@ -1136,7 +1139,7 @@ process_connection:
         cs->pub.state = CONN_STATE_LINGER;
     }
 
-    if (cs->pub.state == CONN_STATE_PROCESS) {
+    if (cs->pub.state == CONN_STATE_PROCESSING) {
         /* Set a read/write timeout for this connection, and let the
          * event thread poll for read/writeability.
          */
@@ -1158,7 +1161,7 @@ process_connection:
             apr_thread_mutex_unlock(timeout_mutex);
             ap_log_error(APLOG_MARK, APLOG_ERR, rv, ap_server_conf, APLOGNO(10503)
                          "process_socket: apr_pollset_add failure in "
-                         "CONN_STATE_PROCESS");
+                         "CONN_STATE_PROCESSING");
             close_connection(cs);
             signal_threads(ST_GRACEFUL);
         }
@@ -1173,7 +1176,7 @@ process_connection:
         apr_status_t rv;
 
         /* Flush all pending outputs before going to CONN_STATE_KEEPALIVE or
-         * straight to CONN_STATE_PROCESS if inputs are pending already.
+         * straight to CONN_STATE_PROCESSING if inputs are pending already.
          */
         
         ap_update_child_status(cs->sbh, SERVER_BUSY_WRITE, NULL);
@@ -1198,11 +1201,11 @@ process_connection:
             /* Add work to pollset. */
             update_reqevents_from_sense(cs, CONN_SENSE_WANT_WRITE);
             apr_thread_mutex_lock(timeout_mutex);
-            TO_QUEUE_APPEND(cs->sc->ps_q, cs);
+            TO_QUEUE_APPEND(cs->sc->wc_q, cs);
             rv = apr_pollset_add(event_pollset, &cs->pfd);
             if (rv != APR_SUCCESS && !APR_STATUS_IS_EEXIST(rv)) {
                 AP_DEBUG_ASSERT(0);
-                TO_QUEUE_REMOVE(cs->sc->ps_q, cs);
+                TO_QUEUE_REMOVE(cs->sc->wc_q, cs);
                 apr_thread_mutex_unlock(timeout_mutex);
                 ap_log_error(APLOG_MARK, APLOG_ERR, rv, ap_server_conf, APLOGNO(03465)
                              "process_socket: apr_pollset_add failure in "
@@ -1219,7 +1222,7 @@ process_connection:
             cs->pub.state = CONN_STATE_LINGER;
         }
         else if (c->data_in_input_filters) {
-            cs->pub.state = CONN_STATE_PROCESS;
+            cs->pub.state = CONN_STATE_PROCESSING;
             goto process_connection;
         }
         else if (!listener_may_exit) {
@@ -1734,11 +1737,12 @@ static void * APR_THREAD_FUNC listener_thread(apr_thread_t * thd, void *dummy)
             /* trace log status every second */
             if (now - last_log > apr_time_from_sec(1)) {
                 ap_log_error(APLOG_MARK, APLOG_TRACE6, 0, ap_server_conf,
-                             "connections: %u (process:%d keep-alive:%d "
-                             "lingering:%d suspended:%u clogged:%u), "
+                             "connections: %u (processing:%d write-completion:%d"
+                             "keep-alive:%d lingering:%d suspended:%u clogged:%u), "
                              "workers: %u/%u shutdown",
                              apr_atomic_read32(&connection_count),
-                             apr_atomic_read32(process_q->total),
+                             apr_atomic_read32(processing_q->total),
+                             apr_atomic_read32(write_completion_q->total),
                              apr_atomic_read32(keepalive_q->total),
                              apr_atomic_read32(&lingering_count),
                              apr_atomic_read32(&suspended_count),
@@ -1848,14 +1852,18 @@ static void * APR_THREAD_FUNC listener_thread(apr_thread_t * thd, void *dummy)
                 int blocking = 0;
 
                 switch (cs->pub.state) {
-                case CONN_STATE_PROCESS:
-                case CONN_STATE_WRITE_COMPLETION:
+                case CONN_STATE_PROCESSING:
                     remove_from_q = cs->sc->ps_q;
                     blocking = 1;
                     break;
 
+                case CONN_STATE_WRITE_COMPLETION:
+                    remove_from_q = cs->sc->wc_q;
+                    blocking = 1;
+                    break;
+
                 case CONN_STATE_KEEPALIVE:
-                    cs->pub.state = CONN_STATE_PROCESS;
+                    cs->pub.state = CONN_STATE_PROCESSING;
                     remove_from_q = cs->sc->ka_q;
                     break;
 
@@ -2008,23 +2016,28 @@ do_maintenance:
             /* Steps below will recompute this. */
             queues_next_expiry = 0;
 
-            /* Step 1: keepalive timeouts */
+            /* Step 1: keepalive queue timeouts are closed */
             if (workers_were_busy || dying) {
                 process_keepalive_queue(0); /* kill'em all \m/ */
             }
             else {
                 process_keepalive_queue(now);
             }
-            /* Step 2: process timeouts */
-            process_timeout_queue(process_q, now,
-                                  defer_lingering_close);
-            /* Step 3: (normal) lingering close completion timeouts */
+
+            /* Step 2: processing queue timeouts are flushed */
+            process_timeout_queue(processing_q, now, defer_lingering_close);
+
+            /* Step 3: write completion queue timeouts are flushed */
+            process_timeout_queue(write_completion_q, now, defer_lingering_close);
+
+            /* Step 4: normal lingering close queue timeouts are closed */
             if (dying && linger_q->timeout > short_linger_q->timeout) {
                 /* Dying, force short timeout for normal lingering close */
                 linger_q->timeout = short_linger_q->timeout;
             }
             process_timeout_queue(linger_q, now, shutdown_connection);
-            /* Step 4: (short) lingering close completion timeouts */
+
+            /* Step 5: short lingering close queue timeouts are closed */
             process_timeout_queue(short_linger_q, now, shutdown_connection);
 
             apr_thread_mutex_unlock(timeout_mutex);
@@ -2033,11 +2046,12 @@ do_maintenance:
                          queues_next_expiry > now ? queues_next_expiry - now
                                                   : -1);
 
+            ps->processing = apr_atomic_read32(processing_q->total);
+            ps->write_completion = apr_atomic_read32(write_completion_q->total);
             ps->keep_alive = apr_atomic_read32(keepalive_q->total);
-            ps->write_completion = apr_atomic_read32(process_q->total);
-            ps->connections = apr_atomic_read32(&connection_count);
-            ps->suspended = apr_atomic_read32(&suspended_count);
             ps->lingering_close = apr_atomic_read32(&lingering_count);
+            ps->suspended = apr_atomic_read32(&suspended_count);
+            ps->connections = apr_atomic_read32(&connection_count);
         }
         else if ((workers_were_busy || dying)
                  && apr_atomic_read32(keepalive_q->total)) {
@@ -3433,7 +3447,7 @@ static void setup_slave_conn(conn_rec *c, void *csd)
     cs->bucket_alloc = c->bucket_alloc;
     cs->pfd = mcs->pfd;
     cs->pub = mcs->pub;
-    cs->pub.state = CONN_STATE_PROCESS;
+    cs->pub.state = CONN_STATE_PROCESSING;
     cs->pub.sense = CONN_SENSE_DEFAULT;
     
     c->cs = &(cs->pub);
@@ -3660,16 +3674,17 @@ static int event_post_config(apr_pool_t *pconf, apr_pool_t *plog,
     struct {
         struct timeout_queue *tail, *q;
         apr_hash_t *hash;
-    } ps, ka;
+    } ps, wc, ka;
 
     /* Not needed in pre_config stage */
     if (ap_state_query(AP_SQ_MAIN_STATE) == AP_SQ_MS_CREATE_PRE_CONFIG) {
         return OK;
     }
 
-    ps.tail = ka.tail = NULL;
     ps.hash = apr_hash_make(ptemp);
+    wc.hash = apr_hash_make(ptemp);
     ka.hash = apr_hash_make(ptemp);
+    ps.tail = wc.tail = ka.tail = NULL;
 
     linger_q = TO_QUEUE_MAKE(pconf, apr_time_from_sec(MAX_SECS_TO_LINGER),
                              NULL);
@@ -3684,7 +3699,11 @@ static int event_post_config(apr_pool_t *pconf, apr_pool_t *plog,
             /* The main server uses the global queues */
             ps.q = TO_QUEUE_MAKE(pconf, s->timeout, NULL);
             apr_hash_set(ps.hash, &s->timeout, sizeof s->timeout, ps.q);
-            ps.tail = process_q = ps.q;
+            ps.tail = processing_q = ps.q;
+
+            wc.q = TO_QUEUE_MAKE(pconf, s->timeout, NULL);
+            apr_hash_set(wc.hash, &s->timeout, sizeof s->timeout, wc.q);
+            wc.tail = write_completion_q = wc.q;
 
             ka.q = TO_QUEUE_MAKE(pconf, s->keep_alive_timeout, NULL);
             apr_hash_set(ka.hash, &s->keep_alive_timeout,
@@ -3701,6 +3720,13 @@ static int event_post_config(apr_pool_t *pconf, apr_pool_t *plog,
                 ps.tail = ps.tail->next = ps.q;
             }
 
+            wc.q = apr_hash_get(wc.hash, &s->timeout, sizeof s->timeout);
+            if (!wc.q) {
+                wc.q = TO_QUEUE_MAKE(pconf, s->timeout, wc.tail);
+                apr_hash_set(wc.hash, &s->timeout, sizeof s->timeout, wc.q);
+                wc.tail = wc.tail->next = wc.q;
+            }
+
             ka.q = apr_hash_get(ka.hash, &s->keep_alive_timeout,
                                 sizeof s->keep_alive_timeout);
             if (!ka.q) {
@@ -3711,6 +3737,7 @@ static int event_post_config(apr_pool_t *pconf, apr_pool_t *plog,
             }
         }
         sc->ps_q = ps.q;
+        sc->wc_q = wc.q;
         sc->ka_q = ka.q;
     }
 

--- a/server/mpm/event/event.c
+++ b/server/mpm/event/event.c
@@ -1285,10 +1285,8 @@ static void check_infinite_requests(void)
                      "Stopping process due to MaxConnectionsPerChild");
         signal_threads(ST_GRACEFUL);
     }
-    else {
-        /* keep going */
-        conns_this_child = APR_INT32_MAX;
-    }
+    /* keep going */
+    conns_this_child = APR_INT32_MAX;
 }
 
 static int close_listeners(int *closed)

--- a/server/mpm/event/event.c
+++ b/server/mpm/event/event.c
@@ -262,13 +262,13 @@ struct timeout_queue {
 /*
  * Several timeout queues that use different timeouts, so that we always can
  * simply append to the end.
- *   processing_q       uses vhost's TimeOut
+ *   waitio_q           uses vhost's TimeOut
  *   write_completion_q uses vhost's TimeOut
  *   keepalive_q        uses vhost's KeepAliveTimeOut
  *   linger_q           uses MAX_SECS_TO_LINGER
  *   short_linger_q     uses SECONDS_TO_LINGER
  */
-static struct timeout_queue *processing_q,
+static struct timeout_queue *waitio_q,
                             *write_completion_q,
                             *keepalive_q,
                             *linger_q,
@@ -415,7 +415,7 @@ static event_child_bucket *all_buckets, /* All listeners buckets */
                           *my_bucket;   /* Current child bucket */
 
 struct event_srv_cfg_s {
-    struct timeout_queue *ps_q,
+    struct timeout_queue *io_q,
                          *wc_q,
                          *ka_q;
 };
@@ -692,7 +692,7 @@ static int event_query(int query_code, int *result, apr_status_t *rv)
     case AP_MPMQ_GENERATION:
         *result = retained->mpm->my_generation;
         break;
-    case AP_MPMQ_CAN_AGAIN:
+    case AP_MPMQ_CAN_WAITIO:
         *result = 1;
         break;
     default:
@@ -1105,17 +1105,19 @@ static void process_socket(apr_thread_t *thd, apr_pool_t * p, apr_socket_t * soc
          *   interacts with the MPM through suspend/resume_connection() hooks,
          *   and/or registered poll callbacks (PT_USER), and/or registered
          *   timed callbacks triggered by timer events;
-         * - CONN_STATE_PROCESSING: wait for read/write-ability of the underlying
+         * - CONN_STATE_ASYNC_WAITIO: wait for read/write-ability of the underlying
          *   socket using Timeout and come back to process_connection() hooks when
-         *   ready (the return value should be AGAIN in this case to not break old
-         *   or third-party modules which might return OK w/o touching the state and
-         *   expect lingering close, like with worker or prefork MPMs);
+         *   ready;
          * - CONN_STATE_KEEPALIVE: now handled by CONN_STATE_WRITE_COMPLETION
          *   to flush before waiting for next data (that might depend on it).
          * If a process_connection hook returns an error or no hook sets the state
          * to one of the above expected value, forcibly close the connection w/
          * CONN_STATE_LINGER.  This covers the cases where no process_connection
-         * hook executes (DECLINED).
+         * hook executes (DECLINED), or one returns OK w/o touching the state (i.e.
+         * CONN_STATE_PROCESSING remains after the call) which can happen with
+         * third-party modules not updated to work specifically with event MPM
+         * while this was expected to do lingering close unconditionally with
+         * worker or prefork MPMs for instance.
          */
         switch (rc) {
         case DONE:
@@ -1128,14 +1130,9 @@ static void process_socket(apr_thread_t *thd, apr_pool_t * p, apr_socket_t * soc
                 cs->pub.state = CONN_STATE_WRITE_COMPLETION;
             }
             break;
-        case AGAIN:
-            if (cs->pub.state == CONN_STATE_PROCESSING) {
-                rc = OK;
-            }
-            break;
         }
         if (rc != OK || (cs->pub.state != CONN_STATE_LINGER
-                         && cs->pub.state != CONN_STATE_PROCESSING
+                         && cs->pub.state != CONN_STATE_ASYNC_WAITIO
                          && cs->pub.state != CONN_STATE_WRITE_COMPLETION
                          && cs->pub.state != CONN_STATE_SUSPENDED)) {
             ap_log_cerror(APLOG_MARK, APLOG_DEBUG, 0, c, APLOGNO(10111)
@@ -1152,7 +1149,7 @@ static void process_socket(apr_thread_t *thd, apr_pool_t * p, apr_socket_t * soc
         }
     }
 
-    if (cs->pub.state == CONN_STATE_PROCESSING) {
+    if (cs->pub.state == CONN_STATE_ASYNC_WAITIO) {
         /* Set a read/write timeout for this connection, and let the
          * event thread poll for read/writeability.
          */
@@ -1166,15 +1163,15 @@ static void process_socket(apr_thread_t *thd, apr_pool_t * p, apr_socket_t * soc
          */
         update_reqevents_from_sense(cs, CONN_SENSE_WANT_READ);
         apr_thread_mutex_lock(timeout_mutex);
-        TO_QUEUE_APPEND(cs->sc->ps_q, cs);
+        TO_QUEUE_APPEND(cs->sc->io_q, cs);
         rv = apr_pollset_add(event_pollset, &cs->pfd);
         if (rv != APR_SUCCESS && !APR_STATUS_IS_EEXIST(rv)) {
             AP_DEBUG_ASSERT(0);
-            TO_QUEUE_REMOVE(cs->sc->ps_q, cs);
+            TO_QUEUE_REMOVE(cs->sc->io_q, cs);
             apr_thread_mutex_unlock(timeout_mutex);
             ap_log_error(APLOG_MARK, APLOG_ERR, rv, ap_server_conf, APLOGNO(10503)
                          "process_socket: apr_pollset_add failure in "
-                         "CONN_STATE_PROCESSING");
+                         "CONN_STATE_ASYNC_WAITIO");
             close_connection(cs);
             signal_threads(ST_GRACEFUL);
         }
@@ -1760,11 +1757,11 @@ static void * APR_THREAD_FUNC listener_thread(apr_thread_t * thd, void *dummy)
             /* trace log status every second */
             if (now - last_log > apr_time_from_sec(1)) {
                 ap_log_error(APLOG_MARK, APLOG_TRACE6, 0, ap_server_conf,
-                             "connections: %u (processing:%d write-completion:%d"
-                             "keep-alive:%d lingering:%d suspended:%u clogged:%u), "
+                             "connections: %u (waitio:%u write-completion:%u"
+                             "keep-alive:%u lingering:%u suspended:%u clogged:%u), "
                              "workers: %u/%u shutdown",
                              apr_atomic_read32(&connection_count),
-                             apr_atomic_read32(processing_q->total),
+                             apr_atomic_read32(waitio_q->total),
                              apr_atomic_read32(write_completion_q->total),
                              apr_atomic_read32(keepalive_q->total),
                              apr_atomic_read32(&lingering_count),
@@ -1875,13 +1872,14 @@ static void * APR_THREAD_FUNC listener_thread(apr_thread_t * thd, void *dummy)
                 int blocking = 0;
 
                 switch (cs->pub.state) {
-                case CONN_STATE_PROCESSING:
-                    remove_from_q = cs->sc->ps_q;
+                case CONN_STATE_WRITE_COMPLETION:
+                    remove_from_q = cs->sc->wc_q;
                     blocking = 1;
                     break;
 
-                case CONN_STATE_WRITE_COMPLETION:
-                    remove_from_q = cs->sc->wc_q;
+                case CONN_STATE_ASYNC_WAITIO:
+                    cs->pub.state = CONN_STATE_PROCESSING;
+                    remove_from_q = cs->sc->io_q;
                     blocking = 1;
                     break;
 
@@ -2047,8 +2045,8 @@ do_maintenance:
                 process_keepalive_queue(now);
             }
 
-            /* Step 2: processing queue timeouts are flushed */
-            process_timeout_queue(processing_q, now, defer_lingering_close);
+            /* Step 2: waitio queue timeouts are flushed */
+            process_timeout_queue(waitio_q, now, defer_lingering_close);
 
             /* Step 3: write completion queue timeouts are flushed */
             process_timeout_queue(write_completion_q, now, defer_lingering_close);
@@ -2069,7 +2067,7 @@ do_maintenance:
                          queues_next_expiry > now ? queues_next_expiry - now
                                                   : -1);
 
-            ps->processing = apr_atomic_read32(processing_q->total);
+            ps->wait_io = apr_atomic_read32(waitio_q->total);
             ps->write_completion = apr_atomic_read32(write_completion_q->total);
             ps->keep_alive = apr_atomic_read32(keepalive_q->total);
             ps->lingering_close = apr_atomic_read32(&lingering_count);
@@ -3697,17 +3695,17 @@ static int event_post_config(apr_pool_t *pconf, apr_pool_t *plog,
     struct {
         struct timeout_queue *tail, *q;
         apr_hash_t *hash;
-    } ps, wc, ka;
+    } io, wc, ka;
 
     /* Not needed in pre_config stage */
     if (ap_state_query(AP_SQ_MAIN_STATE) == AP_SQ_MS_CREATE_PRE_CONFIG) {
         return OK;
     }
 
-    ps.hash = apr_hash_make(ptemp);
+    io.hash = apr_hash_make(ptemp);
     wc.hash = apr_hash_make(ptemp);
     ka.hash = apr_hash_make(ptemp);
-    ps.tail = wc.tail = ka.tail = NULL;
+    io.tail = wc.tail = ka.tail = NULL;
 
     linger_q = TO_QUEUE_MAKE(pconf, apr_time_from_sec(MAX_SECS_TO_LINGER),
                              NULL);
@@ -3718,11 +3716,11 @@ static int event_post_config(apr_pool_t *pconf, apr_pool_t *plog,
         event_srv_cfg *sc = apr_pcalloc(pconf, sizeof *sc);
 
         ap_set_module_config(s->module_config, &mpm_event_module, sc);
-        if (!ps.tail) {
+        if (!io.tail) {
             /* The main server uses the global queues */
-            ps.q = TO_QUEUE_MAKE(pconf, s->timeout, NULL);
-            apr_hash_set(ps.hash, &s->timeout, sizeof s->timeout, ps.q);
-            ps.tail = processing_q = ps.q;
+            io.q = TO_QUEUE_MAKE(pconf, s->timeout, NULL);
+            apr_hash_set(io.hash, &s->timeout, sizeof s->timeout, io.q);
+            io.tail = waitio_q = io.q;
 
             wc.q = TO_QUEUE_MAKE(pconf, s->timeout, NULL);
             apr_hash_set(wc.hash, &s->timeout, sizeof s->timeout, wc.q);
@@ -3736,11 +3734,11 @@ static int event_post_config(apr_pool_t *pconf, apr_pool_t *plog,
         else {
             /* The vhosts use any existing queue with the same timeout,
              * or their own queue(s) if there isn't */
-            ps.q = apr_hash_get(ps.hash, &s->timeout, sizeof s->timeout);
-            if (!ps.q) {
-                ps.q = TO_QUEUE_MAKE(pconf, s->timeout, ps.tail);
-                apr_hash_set(ps.hash, &s->timeout, sizeof s->timeout, ps.q);
-                ps.tail = ps.tail->next = ps.q;
+            io.q = apr_hash_get(io.hash, &s->timeout, sizeof s->timeout);
+            if (!io.q) {
+                io.q = TO_QUEUE_MAKE(pconf, s->timeout, io.tail);
+                apr_hash_set(io.hash, &s->timeout, sizeof s->timeout, io.q);
+                io.tail = io.tail->next = io.q;
             }
 
             wc.q = apr_hash_get(wc.hash, &s->timeout, sizeof s->timeout);
@@ -3759,7 +3757,7 @@ static int event_post_config(apr_pool_t *pconf, apr_pool_t *plog,
                 ka.tail = ka.tail->next = ka.q;
             }
         }
-        sc->ps_q = ps.q;
+        sc->io_q = io.q;
         sc->wc_q = wc.q;
         sc->ka_q = ka.q;
     }

--- a/server/mpm/event/event.c
+++ b/server/mpm/event/event.c
@@ -262,12 +262,12 @@ struct timeout_queue {
 /*
  * Several timeout queues that use different timeouts, so that we always can
  * simply append to the end.
- *   write_completion_q uses vhost's TimeOut
+ *   process_q          uses vhost's TimeOut
  *   keepalive_q        uses vhost's KeepAliveTimeOut
  *   linger_q           uses MAX_SECS_TO_LINGER
  *   short_linger_q     uses SECONDS_TO_LINGER
  */
-static struct timeout_queue *write_completion_q,
+static struct timeout_queue *process_q,
                             *keepalive_q,
                             *linger_q,
                             *short_linger_q;
@@ -413,7 +413,7 @@ static event_child_bucket *all_buckets, /* All listeners buckets */
                           *my_bucket;   /* Current child bucket */
 
 struct event_srv_cfg_s {
-    struct timeout_queue *wc_q,
+    struct timeout_queue *ps_q,
                          *ka_q;
 };
 
@@ -963,11 +963,18 @@ static int event_post_read_request(request_rec *r)
 /* Forward declare */
 static void process_lingering_close(event_conn_state_t *cs);
 
-static void update_reqevents_from_sense(event_conn_state_t *cs, int sense)
+static void update_reqevents_from_sense(event_conn_state_t *cs,
+                                        int default_sense)
 {
-    if (sense < 0) {
+    int sense = default_sense;
+
+    if (cs->pub.sense != CONN_SENSE_DEFAULT) {
         sense = cs->pub.sense;
+
+        /* Reset to default for the next round */
+        cs->pub.sense = CONN_SENSE_DEFAULT;
     }
+
     if (sense == CONN_SENSE_WANT_READ) {
         cs->pfd.reqevents = APR_POLLIN | APR_POLLHUP;
     }
@@ -979,9 +986,6 @@ static void update_reqevents_from_sense(event_conn_state_t *cs, int sense)
      * so it shouldn't hurt (ignored otherwise).
      */
     cs->pfd.reqevents |= APR_POLLERR;
-
-    /* Reset to default for the next round */
-    cs->pub.sense = CONN_SENSE_DEFAULT;
 }
 
 /*
@@ -1020,7 +1024,6 @@ static void process_socket(apr_thread_t *thd, apr_pool_t * p, apr_socket_t * soc
                                       &mpm_event_module);
         cs->pfd.desc_type = APR_POLL_SOCKET;
         cs->pfd.desc.s = sock;
-        update_reqevents_from_sense(cs, CONN_SENSE_WANT_READ);
         pt->type = PT_CSD;
         pt->baton = cs;
         cs->pfd.client_data = pt;
@@ -1041,15 +1044,14 @@ static void process_socket(apr_thread_t *thd, apr_pool_t * p, apr_socket_t * soc
          * and there are measurable delays before the
          * socket is readable due to the first data packet arriving,
          * it might be better to create the cs on the listener thread
-         * with the state set to CONN_STATE_CHECK_REQUEST_LINE_READABLE
+         * with the state set to CONN_STATE_KEEPALIVE
          *
          * FreeBSD users will want to enable the HTTP accept filter
          * module in their kernel for the highest performance
          * When the accept filter is active, sockets are kept in the
          * kernel until a HTTP request is received.
          */
-        cs->pub.state = CONN_STATE_READ_REQUEST_LINE;
-
+        cs->pub.state = CONN_STATE_PROCESS;
         cs->pub.sense = CONN_SENSE_DEFAULT;
         rc = OK;
     }
@@ -1070,7 +1072,7 @@ static void process_socket(apr_thread_t *thd, apr_pool_t * p, apr_socket_t * soc
         /* fall through */
     }
     else {
-        if (cs->pub.state == CONN_STATE_READ_REQUEST_LINE
+        if (cs->pub.state == CONN_STATE_PROCESS
             /* If we have an input filter which 'clogs' the input stream,
              * like mod_ssl used to, lets just do the normal read from input
              * filters, like the Worker MPM does. Filters that need to write
@@ -1078,7 +1080,7 @@ static void process_socket(apr_thread_t *thd, apr_pool_t * p, apr_socket_t * soc
              * otherwise write, should set the sense appropriately.
              */
              || c->clogging_input_filters) {
-read_request:
+process_connection:
             clogging = c->clogging_input_filters;
             if (clogging) {
                 apr_atomic_inc32(&clogged_count);
@@ -1087,8 +1089,12 @@ read_request:
             if (clogging) {
                 apr_atomic_dec32(&clogged_count);
             }
-            if (cs->pub.state > CONN_STATE_LINGER) {
-                cs->pub.state = CONN_STATE_LINGER;
+            /* The sense can be set for CONN_STATE_PROCESS (and
+             * CONN_STATE_WRITE_COMPLETION in 2.4.x) only.
+             */
+            if (cs->pub.state != CONN_STATE_PROCESS
+                && cs->pub.state != CONN_STATE_WRITE_COMPLETION) {
+                cs->pub.sense = CONN_SENSE_DEFAULT;
             }
             if (rc == DONE) {
                 rc = OK;
@@ -1098,35 +1104,29 @@ read_request:
     /*
      * The process_connection hooks above should set the connection state
      * appropriately upon return, for event MPM to either:
-     * - do lingering close (CONN_STATE_LINGER),
-     * - wait for readability of the next request with respect to the keepalive
-     *   timeout (state CONN_STATE_CHECK_REQUEST_LINE_READABLE),
-     * - wait for read/write-ability of the underlying socket with respect to
-     *   its timeout by setting c->clogging_input_filters to 1 and the sense
-     *   to CONN_SENSE_WANT_READ/WRITE (state CONN_STATE_WRITE_COMPLETION),
-     * - keep flushing the output filters stack in nonblocking mode, and then
-     *   if required wait for read/write-ability of the underlying socket with
-     *   respect to its own timeout (state CONN_STATE_WRITE_COMPLETION); since
-     *   completion at some point may require reads (e.g. SSL_ERROR_WANT_READ),
-     *   an output filter can also set the sense to CONN_SENSE_WANT_READ at any
-     *   time for event MPM to do the right thing,
-     * - suspend the connection (SUSPENDED) such that it now interacts with
-     *   the MPM through suspend/resume_connection() hooks, and/or registered
-     *   poll callbacks (PT_USER), and/or registered timed callbacks triggered
-     *   by timer events.
+     * - CONN_STATE_LINGER: do lingering close;
+     * - CONN_STATE_PROCESS: wait for read/write-ability of the underlying
+     *   socket with respect to its Timeout and come back to process_connection()
+     *   hooks when ready;
+     * - CONN_STATE_WRITE_COMPLETION: flush pending outputs using Timeout and
+     *   wait for next incoming data using KeepAliveTimeout, then come back to
+     *   process_connection() hooks;
+     * - CONN_STATE_SUSPENDED: suspend the connection such that it now interacts
+     *   with the MPM through suspend/resume_connection() hooks, and/or registered
+     *   poll callbacks (PT_USER), and/or registered timed callbacks triggered by
+     *   timer events.
      * If a process_connection hook returns an error or no hook sets the state
      * to one of the above expected value, we forcibly close the connection w/
      * CONN_STATE_LINGER.  This covers the cases where no process_connection
      * hook executes (DECLINED), or one returns OK w/o touching the state (i.e.
-     * CONN_STATE_READ_REQUEST_LINE remains after the call) which can happen
-     * with third-party modules not updated to work specifically with event MPM
+     * CONN_STATE_PROCESS remains after the call) which can happen with
+     * third-party modules not updated to work specifically with event MPM
      * while this was expected to do lingering close unconditionally with
      * worker or prefork MPMs for instance.
      */
-    if (rc != OK || (cs->pub.state >= CONN_STATE_NUM)
-                 || (cs->pub.state < CONN_STATE_LINGER
+    if (rc != OK || (cs->pub.state != CONN_STATE_LINGER
+                     && cs->pub.state != CONN_STATE_PROCESS
                      && cs->pub.state != CONN_STATE_WRITE_COMPLETION
-                     && cs->pub.state != CONN_STATE_CHECK_REQUEST_LINE_READABLE
                      && cs->pub.state != CONN_STATE_SUSPENDED)) {
         ap_log_cerror(APLOG_MARK, APLOG_DEBUG, 0, c, APLOGNO(10111)
                       "process_socket: connection processing %s: closing",
@@ -1136,9 +1136,46 @@ read_request:
         cs->pub.state = CONN_STATE_LINGER;
     }
 
+    if (cs->pub.state == CONN_STATE_PROCESS) {
+        /* Set a read/write timeout for this connection, and let the
+         * event thread poll for read/writeability.
+         */
+        cs->queue_timestamp = apr_time_now();
+        notify_suspend(cs);
+
+        ap_update_child_status(cs->sbh, SERVER_BUSY_READ, NULL);
+
+        /* Modules might set c->cs->sense to CONN_SENSE_WANT_WRITE,
+         * the default is CONN_SENSE_WANT_READ still.
+         */
+        update_reqevents_from_sense(cs, CONN_SENSE_WANT_READ);
+        apr_thread_mutex_lock(timeout_mutex);
+        TO_QUEUE_APPEND(cs->sc->ps_q, cs);
+        rv = apr_pollset_add(event_pollset, &cs->pfd);
+        if (rv != APR_SUCCESS && !APR_STATUS_IS_EEXIST(rv)) {
+            AP_DEBUG_ASSERT(0);
+            TO_QUEUE_REMOVE(cs->sc->ps_q, cs);
+            apr_thread_mutex_unlock(timeout_mutex);
+            ap_log_error(APLOG_MARK, APLOG_ERR, rv, ap_server_conf, APLOGNO(10503)
+                         "process_socket: apr_pollset_add failure in "
+                         "CONN_STATE_PROCESS");
+            close_connection(cs);
+            signal_threads(ST_GRACEFUL);
+        }
+        else {
+            apr_thread_mutex_unlock(timeout_mutex);
+        }
+        return;
+    }
+
     if (cs->pub.state == CONN_STATE_WRITE_COMPLETION) {
         ap_filter_t *output_filter = c->output_filters;
         apr_status_t rv;
+
+        /* Flush all pending outputs before going to CONN_STATE_KEEPALIVE or
+         * straight to CONN_STATE_PROCESS if inputs are pending already.
+         */
+        
         ap_update_child_status(cs->sbh, SERVER_BUSY_WRITE, NULL);
         while (output_filter->next != NULL) {
             output_filter = output_filter->next;
@@ -1158,17 +1195,18 @@ read_request:
             cs->queue_timestamp = apr_time_now();
             notify_suspend(cs);
 
-            update_reqevents_from_sense(cs, -1);
+            /* Add work to pollset. */
+            update_reqevents_from_sense(cs, CONN_SENSE_WANT_WRITE);
             apr_thread_mutex_lock(timeout_mutex);
-            TO_QUEUE_APPEND(cs->sc->wc_q, cs);
+            TO_QUEUE_APPEND(cs->sc->ps_q, cs);
             rv = apr_pollset_add(event_pollset, &cs->pfd);
             if (rv != APR_SUCCESS && !APR_STATUS_IS_EEXIST(rv)) {
                 AP_DEBUG_ASSERT(0);
-                TO_QUEUE_REMOVE(cs->sc->wc_q, cs);
+                TO_QUEUE_REMOVE(cs->sc->ps_q, cs);
                 apr_thread_mutex_unlock(timeout_mutex);
                 ap_log_error(APLOG_MARK, APLOG_ERR, rv, ap_server_conf, APLOGNO(03465)
-                             "process_socket: apr_pollset_add failure for "
-                             "write completion");
+                             "process_socket: apr_pollset_add failure in "
+                             "CONN_STATE_WRITE_COMPLETION");
                 close_connection(cs);
                 signal_threads(ST_GRACEFUL);
             }
@@ -1181,18 +1219,18 @@ read_request:
             cs->pub.state = CONN_STATE_LINGER;
         }
         else if (c->data_in_input_filters) {
-            cs->pub.state = CONN_STATE_READ_REQUEST_LINE;
-            goto read_request;
+            cs->pub.state = CONN_STATE_PROCESS;
+            goto process_connection;
         }
         else if (!listener_may_exit) {
-            cs->pub.state = CONN_STATE_CHECK_REQUEST_LINE_READABLE;
+            cs->pub.state = CONN_STATE_KEEPALIVE;
         }
         else {
             cs->pub.state = CONN_STATE_LINGER;
         }
     }
 
-    if (cs->pub.state == CONN_STATE_CHECK_REQUEST_LINE_READABLE) {
+    if (cs->pub.state == CONN_STATE_KEEPALIVE) {
         ap_update_child_status(cs->sbh, SERVER_BUSY_KEEPALIVE, NULL);
 
         /* It greatly simplifies the logic to use a single timeout value per q
@@ -1234,10 +1272,7 @@ read_request:
     }
 
     /* CONN_STATE_LINGER[_*] fall through process_lingering_close() */
-    if (cs->pub.state >= CONN_STATE_LINGER) {
-        process_lingering_close(cs);
-        return;
-    }
+    process_lingering_close(cs);
 }
 
 /* conns_this_child has gone to zero or below.  See if the admin coded
@@ -1519,6 +1554,7 @@ static void process_lingering_close(event_conn_state_t *cs)
         else {
             cs->pub.state = CONN_STATE_LINGER_NORMAL;
         }
+        cs->pub.sense = CONN_SENSE_DEFAULT;
         notify_suspend(cs);
     }
 
@@ -1699,24 +1735,19 @@ static void * APR_THREAD_FUNC listener_thread(apr_thread_t * thd, void *dummy)
         if (APLOGtrace6(ap_server_conf)) {
             /* trace log status every second */
             if (now - last_log > apr_time_from_sec(1)) {
-                last_log = now;
-                apr_thread_mutex_lock(timeout_mutex);
                 ap_log_error(APLOG_MARK, APLOG_TRACE6, 0, ap_server_conf,
-                             "connections: %u (clogged: %u write-completion: %d "
-                             "keep-alive: %d lingering: %d suspended: %u)",
+                             "connections: %u (process:%d keep-alive:%d "
+                             "lingering:%d suspended:%u clogged:%u), "
+                             "workers: %u/%u shutdown",
                              apr_atomic_read32(&connection_count),
-                             apr_atomic_read32(&clogged_count),
-                             apr_atomic_read32(write_completion_q->total),
+                             apr_atomic_read32(process_q->total),
                              apr_atomic_read32(keepalive_q->total),
                              apr_atomic_read32(&lingering_count),
-                             apr_atomic_read32(&suspended_count));
-                if (dying) {
-                    ap_log_error(APLOG_MARK, APLOG_TRACE6, 0, ap_server_conf,
-                                 "%u/%u workers shutdown",
-                                 apr_atomic_read32(&threads_shutdown),
-                                 threads_per_child);
-                }
-                apr_thread_mutex_unlock(timeout_mutex);
+                             apr_atomic_read32(&suspended_count),
+                             apr_atomic_read32(&clogged_count),
+                             apr_atomic_read32(&threads_shutdown),
+                             threads_per_child);
+                last_log = now;
             }
         }
 
@@ -1819,13 +1850,14 @@ static void * APR_THREAD_FUNC listener_thread(apr_thread_t * thd, void *dummy)
                 int blocking = 0;
 
                 switch (cs->pub.state) {
+                case CONN_STATE_PROCESS:
                 case CONN_STATE_WRITE_COMPLETION:
-                    remove_from_q = cs->sc->wc_q;
+                    remove_from_q = cs->sc->ps_q;
                     blocking = 1;
                     break;
 
-                case CONN_STATE_CHECK_REQUEST_LINE_READABLE:
-                    cs->pub.state = CONN_STATE_READ_REQUEST_LINE;
+                case CONN_STATE_KEEPALIVE:
+                    cs->pub.state = CONN_STATE_PROCESS;
                     remove_from_q = cs->sc->ka_q;
                     break;
 
@@ -1985,8 +2017,8 @@ do_maintenance:
             else {
                 process_keepalive_queue(now);
             }
-            /* Step 2: write completion timeouts */
-            process_timeout_queue(write_completion_q, now,
+            /* Step 2: process timeouts */
+            process_timeout_queue(process_q, now,
                                   defer_lingering_close);
             /* Step 3: (normal) lingering close completion timeouts */
             if (dying && linger_q->timeout > short_linger_q->timeout) {
@@ -2004,7 +2036,7 @@ do_maintenance:
                                                   : -1);
 
             ps->keep_alive = apr_atomic_read32(keepalive_q->total);
-            ps->write_completion = apr_atomic_read32(write_completion_q->total);
+            ps->write_completion = apr_atomic_read32(process_q->total);
             ps->connections = apr_atomic_read32(&connection_count);
             ps->suspended = apr_atomic_read32(&suspended_count);
             ps->lingering_close = apr_atomic_read32(&lingering_count);
@@ -3403,7 +3435,7 @@ static void setup_slave_conn(conn_rec *c, void *csd)
     cs->bucket_alloc = c->bucket_alloc;
     cs->pfd = mcs->pfd;
     cs->pub = mcs->pub;
-    cs->pub.state = CONN_STATE_READ_REQUEST_LINE;
+    cs->pub.state = CONN_STATE_PROCESS;
     cs->pub.sense = CONN_SENSE_DEFAULT;
     
     c->cs = &(cs->pub);
@@ -3630,15 +3662,15 @@ static int event_post_config(apr_pool_t *pconf, apr_pool_t *plog,
     struct {
         struct timeout_queue *tail, *q;
         apr_hash_t *hash;
-    } wc, ka;
+    } ps, ka;
 
     /* Not needed in pre_config stage */
     if (ap_state_query(AP_SQ_MAIN_STATE) == AP_SQ_MS_CREATE_PRE_CONFIG) {
         return OK;
     }
 
-    wc.tail = ka.tail = NULL;
-    wc.hash = apr_hash_make(ptemp);
+    ps.tail = ka.tail = NULL;
+    ps.hash = apr_hash_make(ptemp);
     ka.hash = apr_hash_make(ptemp);
 
     linger_q = TO_QUEUE_MAKE(pconf, apr_time_from_sec(MAX_SECS_TO_LINGER),
@@ -3650,11 +3682,11 @@ static int event_post_config(apr_pool_t *pconf, apr_pool_t *plog,
         event_srv_cfg *sc = apr_pcalloc(pconf, sizeof *sc);
 
         ap_set_module_config(s->module_config, &mpm_event_module, sc);
-        if (!wc.tail) {
+        if (!ps.tail) {
             /* The main server uses the global queues */
-            wc.q = TO_QUEUE_MAKE(pconf, s->timeout, NULL);
-            apr_hash_set(wc.hash, &s->timeout, sizeof s->timeout, wc.q);
-            wc.tail = write_completion_q = wc.q;
+            ps.q = TO_QUEUE_MAKE(pconf, s->timeout, NULL);
+            apr_hash_set(ps.hash, &s->timeout, sizeof s->timeout, ps.q);
+            ps.tail = process_q = ps.q;
 
             ka.q = TO_QUEUE_MAKE(pconf, s->keep_alive_timeout, NULL);
             apr_hash_set(ka.hash, &s->keep_alive_timeout,
@@ -3664,11 +3696,11 @@ static int event_post_config(apr_pool_t *pconf, apr_pool_t *plog,
         else {
             /* The vhosts use any existing queue with the same timeout,
              * or their own queue(s) if there isn't */
-            wc.q = apr_hash_get(wc.hash, &s->timeout, sizeof s->timeout);
-            if (!wc.q) {
-                wc.q = TO_QUEUE_MAKE(pconf, s->timeout, wc.tail);
-                apr_hash_set(wc.hash, &s->timeout, sizeof s->timeout, wc.q);
-                wc.tail = wc.tail->next = wc.q;
+            ps.q = apr_hash_get(ps.hash, &s->timeout, sizeof s->timeout);
+            if (!ps.q) {
+                ps.q = TO_QUEUE_MAKE(pconf, s->timeout, ps.tail);
+                apr_hash_set(ps.hash, &s->timeout, sizeof s->timeout, ps.q);
+                ps.tail = ps.tail->next = ps.q;
             }
 
             ka.q = apr_hash_get(ka.hash, &s->keep_alive_timeout,
@@ -3680,7 +3712,7 @@ static int event_post_config(apr_pool_t *pconf, apr_pool_t *plog,
                 ka.tail = ka.tail->next = ka.q;
             }
         }
-        sc->wc_q = wc.q;
+        sc->ps_q = ps.q;
         sc->ka_q = ka.q;
     }
 


### PR DESCRIPTION
  *) mod_http2: sync with github module. Add async handling
     on newer httpd for blocked connections, fix yield handling.
     Trunk version of patch:
        https://svn.apache.org/r1918003
        https://svn.apache.org/r1918022
        https://svn.apache.org/r1918035
        https://svn.apache.org/r1918078
        https://svn.apache.org/r1918098
        https://svn.apache.org/r1918099
        https://svn.apache.org/r1918257
        https://svn.apache.org/r1918482
        https://svn.apache.org/r1918483
        https://svn.apache.org/r1918491