### PR TITLE
CI: For LDAP tests, switch to using OpenLDAP slapd running on

### DIFF
--- a/test/travis_Dockerfile_slapd.centos
+++ b/test/travis_Dockerfile_slapd.centos
@@ -1,0 +1,5 @@
+FROM quay.io/centos/centos:stream9
+RUN dnf install -y epel-release && \
+    dnf install -y openldap openldap-clients openldap-servers openldap-devel && \
+    dnf -y clean all --enablerepo='*'
+CMD /usr/sbin/slapd -u ldap -d1 '-h ldap:// ldapi:///'

--- a/test/travis_Dockerfile_slapd.centos7
+++ b/test/travis_Dockerfile_slapd.centos7
@@ -1,5 +1,0 @@
-FROM quay.io/centos/centos:7
-RUN yum install -y yum-utils && \
-    yum install -y openldap openldap-clients openldap-servers openldap-devel && \
-    yum -y clean all --enablerepo='*'
-CMD /usr/sbin/slapd -u ldap -d1 '-h ldap:// ldapi:///'

--- a/test/travis_before_linux.sh
+++ b/test/travis_before_linux.sh
@@ -97,7 +97,7 @@ fi
 # For LDAP testing, run slapd listening on port 8389 and populate the
 # directory as described in t/modules/ldap.t in the test framework:
 if test -v TEST_LDAP -a -x test/perl-framework/scripts/ldap-init.sh; then
-    docker build -t httpd_ldap -f test/travis_Dockerfile_slapd.centos7 test/
+    docker build -t httpd_ldap -f test/travis_Dockerfile_slapd.centos test/
     pushd test/perl-framework
        ./scripts/ldap-init.sh
     popd


### PR DESCRIPTION
CentOS Stream 9.