### PR TITLE
Fix missing initialization, follow up to r1918098

### DIFF
--- a/modules/generators/mod_status.c
+++ b/modules/generators/mod_status.c
@@ -564,7 +564,7 @@ static int status_handler(request_rec *r)
         ap_rputs("</dl>", r);
 
     if (is_async) {
-        int processing, write_completion = 0, lingering_close = 0, keep_alive = 0,
+        int processing = 0, write_completion = 0, lingering_close = 0, keep_alive = 0,
             connections = 0, stopping = 0, procs = 0;
         if (!short_report)
             ap_rputs("\n\n<table rules=\"all\" cellpadding=\"1%\">\n"


### PR DESCRIPTION
One of the latest changes in https://github.com/apache/httpd/commit/d821182d76394cb38d5c80d447a66c1be23dc46c triggers a warning that causes compilation failure with `-Werror`. (It broke our CI and the CI here as well.)