### PR TITLE
mod_dav_fs: return a 404 rather than a 400 where path_info is found

### DIFF
--- a/modules/dav/fs/repos.c
+++ b/modules/dav/fs/repos.c
@@ -777,10 +777,10 @@ static dav_error * dav_fs_get_resource(
             {
                 /*
                 ** The base of the path refers to a file -- nothing should
-                ** be in path_info. The resource is simply an error: it
+                ** be in path_info. The resource cannot exist: it
                 ** can't be a null or a locknull resource.
                 */
-                return dav_new_error(r->pool, HTTP_BAD_REQUEST, 0, 0,
+                return dav_new_error(r->pool, HTTP_NOT_FOUND, 0, 0,
                                      "The URL contains extraneous path "
                                      "components. The resource could not "
                                      "be identified.");


### PR DESCRIPTION
```
* modules/dav/fs/repos.c (dav_fs_get_resource): Return a 404 rather
  than a 400 where r->path_info is not empty for a file; a valid but
  unsatisfiable request to a path which cannot exist,
  e.g. /dav/foo.txt/blah where /dav/foo.txt is not a directory.
```