### PR TITLE
mod_ssl: Add SSL_HANDSHAKE_RTT variable

### DIFF
--- a/docs/manual/mod/mod_ssl.xml
+++ b/docs/manual/mod/mod_ssl.xml
@@ -109,6 +109,7 @@ compatibility variables.</p>
 <tr><td><code>SSL_SRP_USER</code></td>                  <td>string</td>    <td>SRP username</td></tr>
 <tr><td><code>SSL_SRP_USERINFO</code></td>              <td>string</td>    <td>SRP user info</td></tr>
 <tr><td><code>SSL_TLS_SNI</code></td>                   <td>string</td>    <td>Contents of the SNI TLS extension (if supplied with ClientHello)</td></tr>
+<tr><td><code>SSL_HANDSHAKE_RTT</code></td>             <td>number</td>    <td>Round-trip time of TLS handshake in microseconds including endpoint processing (set to 0 if OpenSSL version prior to 3.2 or if round-trip time can not be determined)</td></tr>
 </table>
 
 <p><em>x509</em> specifies a component of an X.509 DN; one of

--- a/docs/manual/mod/mod_ssl.xml
+++ b/docs/manual/mod/mod_ssl.xml
@@ -109,7 +109,7 @@ compatibility variables.</p>
 <tr><td><code>SSL_SRP_USER</code></td>                  <td>string</td>    <td>SRP username</td></tr>
 <tr><td><code>SSL_SRP_USERINFO</code></td>              <td>string</td>    <td>SRP user info</td></tr>
 <tr><td><code>SSL_TLS_SNI</code></td>                   <td>string</td>    <td>Contents of the SNI TLS extension (if supplied with ClientHello)</td></tr>
-<tr><td><code>SSL_HANDSHAKE_RTT</code></td>             <td>number</td>    <td>Round-trip time of TLS handshake in microseconds including endpoint processing (set to 0 if OpenSSL version prior to 3.2 or if round-trip time can not be determined)</td></tr>
+<tr><td><code>SSL_HANDSHAKE_RTT</code></td>             <td>number</td>    <td>Round-trip time of TLS handshake in microseconds including endpoint processing (set to empty string if OpenSSL version prior to 3.2 or if round-trip time can not be determined)</td></tr>
 </table>
 
 <p><em>x509</em> specifies a component of an X.509 DN; one of

--- a/modules/ssl/ssl_engine_kernel.c
+++ b/modules/ssl/ssl_engine_kernel.c
@@ -1546,6 +1546,7 @@ static const char *const ssl_hook_Fixup_vars[] = {
     "SSL_SRP_USER",
     "SSL_SRP_USERINFO",
 #endif
+    "SSL_HANDSHAKE_RTT",
     NULL
 };
 

--- a/modules/ssl/ssl_engine_vars.c
+++ b/modules/ssl/ssl_engine_vars.c
@@ -51,7 +51,7 @@ static const char *ssl_var_lookup_ssl_cert_rfc4523_cea(apr_pool_t *p, SSL *ssl);
 static const char *ssl_var_lookup_ssl_cert_verify(apr_pool_t *p, const SSLConnRec *sslconn);
 static const char *ssl_var_lookup_ssl_cipher(apr_pool_t *p, const SSLConnRec *sslconn, const char *var);
 static void  ssl_var_lookup_ssl_cipher_bits(SSL *ssl, int *usekeysize, int *algkeysize);
-static char *ssl_var_lookup_ssl_handshake_rtt(apr_pool_t *p, SSL *ssl);
+static const char *ssl_var_lookup_ssl_handshake_rtt(apr_pool_t *p, SSL *ssl);
 static const char *ssl_var_lookup_ssl_version(const char *var);
 static const char *ssl_var_lookup_ssl_compress_meth(SSL *ssl);
 
@@ -965,24 +965,14 @@ static void ssl_var_lookup_ssl_cipher_bits(SSL *ssl, int *usekeysize, int *algke
     return;
 }
 
-static char *ssl_var_lookup_ssl_handshake_rtt(apr_pool_t *p, SSL *ssl)
+static const char *ssl_var_lookup_ssl_handshake_rtt(apr_pool_t *p, SSL *ssl)
 {
-    char *result;
-    long handshakertt;
-    uint64_t rtt;
-    int ret;
-
-    result = NULL;
-    handshakertt = 0;
-
 #if OPENSSL_VERSION_NUMBER >= 0x30200000L
-    ret = SSL_get_handshake_rtt(ssl, &rtt);
-    if (ret > 0)
-        handshakertt = (long) rtt;
+    apr_uint64_t rtt;
+    if (SSL_get_handshake_rtt(ssl, &rtt) > 0)
+        return apr_psprintf(p, "%" APR_UINT64_T_FMT, rtt);
 #endif
-
-    result = apr_ltoa(p, handshakertt);
-    return result;
+    return NULL;
 }
 
 static const char *ssl_var_lookup_ssl_version(const char *var)

--- a/modules/ssl/ssl_engine_vars.c
+++ b/modules/ssl/ssl_engine_vars.c
@@ -975,7 +975,7 @@ static char *ssl_var_lookup_ssl_handshake_rtt(apr_pool_t *p, SSL *ssl)
     result = NULL;
     handshakertt = 0;
 
-#if OPENSSL_VERSION_NUMBER > 0x30200000L
+#if OPENSSL_VERSION_NUMBER >= 0x30200000L
     ret = SSL_get_handshake_rtt(ssl, &rtt);
     if (ret > 0)
         handshakertt = (long) rtt;


### PR DESCRIPTION
OpenSSL 3.2 added the SSL_get_handshake_rtt function. This addition to mod_ssl exposes this data as a new variable, SSL_HANDSHAKE_RTT.

Notes about implementation:

SSL_HANDSHAKE_RTT is always set. It is set to 0 if handshake_rtt can not be retreived, either because a version of OpenSSL prior to 3.2 is used or because OpenSSL could not retrieve the handshake RTT (as in case of 0-RTT handshake). Given how the upstream function is called (after handshake is completed), there no meaningful feedback provided by upstream function so a second variable indicating errors does not seem warranted.

The handshake_rtt value is cast from uint64_t to long which should be adequate considering that it still supports handshakes up to 2147s in length on systems where long is 32-bit. I think proposed approach is best. If supporting handshakes that take over 2147s to complete is necessary, options include:
- divide value by 1000 and report value in units of ms (most people expect latency measurements in ms and precision below ms resolution is not necessary for most applications)
- use equivalent of apr_ltoa() that supports 64-bit int (please point me to example of this)
- value could be split into two variables (SSL_HANDSHAKE_RTT_S, SSL_HANDSHAKE_RTT_US). 

I've provided documentation addition in English only. I think it's preferable for others to provide French and Spanish translation (but I'll try if necessary).

I've tested this patch on Ubuntu 24 Apache/2.4.62,OpenSSL/3.3.1 and Ubuntu 22 Apache/2.4.52,OpenSSL/3.0.2 and both operated as expected. 