### PR TITLE
Document `htcacheclean`’s timestamp output

### DIFF
--- a/docs/manual/caching.xml
+++ b/docs/manual/caching.xml
@@ -458,7 +458,7 @@ Vary: negotiate,accept-language,accept-charset
       <p>Typically the module will be configured as so;</p>
 
       <highlight language="config">
-CacheRoot   "/var/cache/apache/"
+CacheRoot   "/var/cache/apache"
 CacheEnable disk /
 CacheDirLevels 2
 CacheDirLength 1

--- a/docs/manual/programs/htcacheclean.xml
+++ b/docs/manual/programs/htcacheclean.xml
@@ -189,10 +189,13 @@
         <dt>status</dt><dd>Status of the cached response.</dd>
         <dt>entity version</dt><dd>The number of times this entry has been
         revalidated without being deleted.</dd>
-        <dt>date</dt><dd>Date of the response.</dd>
-        <dt>expiry</dt><dd>Expiry date of the response.</dd>
-        <dt>request time</dt><dd>Time of the start of the request.</dd>
-        <dt>response time</dt><dd>Time of the end of the request.</dd>
+        <dt>date</dt><dd>Timestamp of the response in microseconds.</dd>
+        <dt>expiry</dt><dd>Expiry timestamp of the response in
+        microseconds.</dd>
+        <dt>request time</dt><dd>Timestamp of the start of the request in
+        microseconds.</dd>
+        <dt>response time</dt><dd>Timestamp of the end of the request in
+        microseconds.</dd>
         <dt>body present</dt><dd>If 0, no body is stored with this request,
         1 otherwise.</dd>
         <dt>head request</dt><dd>If 1, the entry contains a cached HEAD


### PR DESCRIPTION
This PR makes it clear that the datetime output of `htcacheclean -A` is a Unix timestamp in microseconds. This helps those trying to convert it to human-readable format using `date -d` or `gawk`’s `strftime()`, which take seconds.