### PR TITLE
mod_ssl: ClientHello variable collection

### DIFF
--- a/docs/manual/mod/mod_ssl.xml
+++ b/docs/manual/mod/mod_ssl.xml
@@ -113,11 +113,11 @@ compatibility variables.</p>
 <tr><td><code>SSL_CLIENTHELLO_VERSION</code></td>       <td>string</td>    <td>Version field (legacy) from ClientHello as four hex encoded characters</td></tr>
 <tr><td><code>SSL_CLIENTHELLO_CIPHERS</code></td>       <td>string</td>    <td>Cipher Suites from ClientHello as four hex encoded characters per item</td></tr>
 <tr><td><code>SSL_CLIENTHELLO_EXTENSIONS</code></td>    <td>string</td>    <td>Extension IDs from ClientHello as four hex encoded characters per item</td></tr>
-<tr><td><code>SSL_CLIENTHELLO_GROUPS</code></td>        <td>string</td>    <td>Value of Supported Groups Extension (10) from ClientHello as four hex encoded characters per item</td></tr>
-<tr><td><code>SSL_CLIENTHELLO_EC_FORMATS</code></td>    <td>string</td>    <td>Value of EC Point Formats Extension (11) from ClientHello as two hex encoded characters per item</td></tr>
-
- 
- 
+<tr><td><code>SSL_CLIENTHELLO_GROUPS</code></td>        <td>string</td>    <td>Value of Supported Groups extension (10) from ClientHello as four hex encoded characters per item</td></tr>
+<tr><td><code>SSL_CLIENTHELLO_EC_FORMATS</code></td>    <td>string</td>    <td>Value of EC Point Formats extension (11) from ClientHello as two hex encoded characters per item</td></tr>
+<tr><td><code>SSL_CLIENTHELLO_SIG_ALGOS</code></td>     <td>string</td>    <td>Value of Signature Algorithms extension (13) from ClientHello as four hex encoded characters per item</td></tr>
+<tr><td><code>SSL_CLIENTHELLO_ALPN</code></td>          <td>string</td>    <td>Value of ALPN extension (16) from ClientHello as hex encoded string including leading string lengths</td></tr>
+<tr><td><code>SSL_CLIENTHELLO_VERSIONS</code></td>      <td>string</td>    <td>Value of Supported Versions extension (43) from ClientHello as four hex encoded characters per item</td></tr>
 </table>
 
 <p><em>x509</em> specifies a component of an X.509 DN; one of

--- a/docs/manual/mod/mod_ssl.xml
+++ b/docs/manual/mod/mod_ssl.xml
@@ -2867,6 +2867,20 @@ be protected with file permissions similar to those used for
 </directivesynopsis>
 
 <directivesynopsis>
+<name>SSLClientHelloVars</name>
+<description>Enable collection of ClientHello variables</description>
+<syntax>SSLClientHelloVars on|off</syntax>
+<default>SSLClientHelloVars off</default>
+<contextlist><context>server config</context>
+<context>virtual host</context></contextlist>
+<compatibility>Available in httpd 2.5.x and later, if using OpenSSL 1.1.1 or later</compatibility>
+
+<usage>
+<p>This directive enables collection of ClientHello data during the handshake that is retained for the length of the connection so it can be exposed as <code>SSL_CLIENTHELLLO_*</code> environment variables for requests depending upon the <code>StdEnvVars</code> setting.</p>
+</usage> 
+</directivesynopsis>
+ 
+<directivesynopsis>
 <name>SSLCompression</name>
 <description>Enable compression on the SSL level</description>
 <syntax>SSLCompression on|off</syntax>

--- a/docs/manual/mod/mod_ssl.xml
+++ b/docs/manual/mod/mod_ssl.xml
@@ -110,6 +110,8 @@ compatibility variables.</p>
 <tr><td><code>SSL_SRP_USERINFO</code></td>              <td>string</td>    <td>SRP user info</td></tr>
 <tr><td><code>SSL_TLS_SNI</code></td>                   <td>string</td>    <td>Contents of the SNI TLS extension (if supplied with ClientHello)</td></tr>
 <tr><td><code>SSL_HANDSHAKE_RTT</code></td>             <td>number</td>    <td>Round-trip time of TLS handshake in microseconds including endpoint processing (set to empty string if OpenSSL version prior to 3.2 or if round-trip time can not be determined)</td></tr>
+<tr><td><code>SSL_CLIENTHELLO_VERSION</code></td>       <td>string</td>    <td>Version field (legacy) from ClientHello as four hex encoded characters</td></tr>
+<tr><td><code>SSL_CLIENTHELLO_CIPHERS</code></td>       <td>string</td>    <td>Cipher Suites from ClientHello as four hex encoded characters per item</td></tr>
 </table>
 
 <p><em>x509</em> specifies a component of an X.509 DN; one of

--- a/docs/manual/mod/mod_ssl.xml
+++ b/docs/manual/mod/mod_ssl.xml
@@ -150,6 +150,10 @@ suffix (if any). For example, <code>SSL_SERVER_S_DN_OU_RAW</code> or
 <p><code>SSL_CLIENT_V_REMAIN</code> is only available in version 2.1
 and later.</p>
 
+<p>The <code>SSL_CLIENTHELLO_*</code> variables require the directive 
+<directive module="mod_ssl">SSLClientHelloVars</directive> to be 
+enabled or they will not be populated.</p>
+ 
 <p>A number of additional environment variables can also be used
 in <directive>SSLRequire</directive> expressions, or in custom log
 formats:</p>
@@ -2873,10 +2877,16 @@ be protected with file permissions similar to those used for
 <default>SSLClientHelloVars off</default>
 <contextlist><context>server config</context>
 <context>virtual host</context></contextlist>
-<compatibility>Available in httpd 2.5.x and later, if using OpenSSL 1.1.1 or later</compatibility>
+<compatibility>Available in httpd 2.5.2 and later, requires OpenSSL 1.1.1 or later</compatibility>
 
 <usage>
-<p>This directive enables collection of ClientHello data during the handshake that is retained for the length of the connection so it can be exposed as <code>SSL_CLIENTHELLLO_*</code> environment variables for requests depending upon the <code>StdEnvVars</code> setting.</p>
+<p>This directive enables collection of ClientHello data during the handshake that is retained for 
+the length of the connection so it can be exposed as <code>SSL_CLIENTHELLLO_*</code> environment 
+variables for requests depending upon the <code>StdEnvVars</code> setting. The variables are 
+formatted as the hex-encoded raw buffers seen in the raw network protocol and as provided 
+by OpenSSL. GREASE (RFC 8701) values are filtered by OpenSSL when enumerating extension IDs, but 
+otherwise, are passed through unchanged for other variables. If this directive is not enabled or 
+if OpenSSL prior to version 1.1.1 is used, these variables will not have a value set.</p>
 </usage> 
 </directivesynopsis>
  

--- a/docs/manual/mod/mod_ssl.xml
+++ b/docs/manual/mod/mod_ssl.xml
@@ -112,6 +112,12 @@ compatibility variables.</p>
 <tr><td><code>SSL_HANDSHAKE_RTT</code></td>             <td>number</td>    <td>Round-trip time of TLS handshake in microseconds including endpoint processing (set to empty string if OpenSSL version prior to 3.2 or if round-trip time can not be determined)</td></tr>
 <tr><td><code>SSL_CLIENTHELLO_VERSION</code></td>       <td>string</td>    <td>Version field (legacy) from ClientHello as four hex encoded characters</td></tr>
 <tr><td><code>SSL_CLIENTHELLO_CIPHERS</code></td>       <td>string</td>    <td>Cipher Suites from ClientHello as four hex encoded characters per item</td></tr>
+<tr><td><code>SSL_CLIENTHELLO_EXTENSIONS</code></td>    <td>string</td>    <td>Extension IDs from ClientHello as four hex encoded characters per item</td></tr>
+<tr><td><code>SSL_CLIENTHELLO_GROUPS</code></td>        <td>string</td>    <td>Value of Supported Groups Extension (10) from ClientHello as four hex encoded characters per item</td></tr>
+<tr><td><code>SSL_CLIENTHELLO_EC_FORMATS</code></td>    <td>string</td>    <td>Value of EC Point Formats Extension (11) from ClientHello as two hex encoded characters per item</td></tr>
+
+ 
+ 
 </table>
 
 <p><em>x509</em> specifies a component of an X.509 DN; one of

--- a/modules/ssl/mod_ssl.c
+++ b/modules/ssl/mod_ssl.c
@@ -166,6 +166,9 @@ static const command_rec ssl_config_cmds[] = {
                 "('[+-][" SSL_PROTOCOLS "] ...' - see manual)")
     SSL_CMD_SRV(HonorCipherOrder, FLAG,
                 "Use the server's cipher ordering preference")
+    SSL_CMD_SRV(ClientHelloVars, FLAG,
+                "Enable SSL ClientHello variable collection "
+                "(`on', `off')")
     SSL_CMD_SRV(Compression, FLAG,
                 "Enable SSL level compression "
                 "(`on', `off')")

--- a/modules/ssl/ssl_engine_config.c
+++ b/modules/ssl/ssl_engine_config.c
@@ -220,6 +220,7 @@ static SSLSrvConfigRec *ssl_config_server_new(apr_pool_t *p)
 #ifndef OPENSSL_NO_COMP
     sc->compression            = UNSET;
 #endif
+    sc->clienthello_vars       = UNSET;
     sc->session_tickets        = UNSET;
 
     modssl_ctx_init_server(sc, p);
@@ -347,6 +348,7 @@ void *ssl_config_server_merge(apr_pool_t *p, void *basev, void *addv)
     cfgMerge(enabled, SSL_ENABLED_UNSET);
     cfgMergeInt(session_cache_timeout);
     cfgMergeBool(cipher_server_pref);
+    cfgMergeBool(clienthello_vars);
 #ifdef HAVE_TLSEXT
     cfgMerge(strict_sni_vhost_check, SSL_ENABLED_UNSET);
 #endif
@@ -954,6 +956,13 @@ const char *ssl_cmd_SSLCompression(cmd_parms *cmd, void *dcfg, int flag)
         return "Setting Compression mode unsupported; not implemented by the SSL library";
     }
 #endif
+    return NULL;
+}
+
+const char *ssl_cmd_SSLClientHelloVars(cmd_parms *cmd, void *dcfg, int flag)
+{
+    SSLSrvConfigRec *sc = mySrvConfig(cmd->server);
+    sc->clienthello_vars = flag ? TRUE : FALSE;
     return NULL;
 }
 

--- a/modules/ssl/ssl_engine_kernel.c
+++ b/modules/ssl/ssl_engine_kernel.c
@@ -1547,6 +1547,14 @@ static const char *const ssl_hook_Fixup_vars[] = {
     "SSL_SRP_USERINFO",
 #endif
     "SSL_HANDSHAKE_RTT",
+    "SSL_CLIENTHELLO_VERSION",
+    "SSL_CLIENTHELLO_CIPHERS",
+    "SSL_CLIENTHELLO_EXTENSIONS",
+    "SSL_CLIENTHELLO_GROUPS",
+    "SSL_CLIENTHELLO_EC_FORMATS",
+    "SSL_CLIENTHELLO_SIG_ALGOS",
+    "SSL_CLIENTHELLO_ALPN",
+    "SSL_CLIENTHELLO_VERSIONS",
     NULL
 };
 
@@ -2466,10 +2474,48 @@ int ssl_callback_ServerNameIndication(SSL *ssl, int *al, modssl_ctx_t *mctx)
 
 #if OPENSSL_VERSION_NUMBER >= 0x10101000L && !defined(LIBRESSL_VERSION_NUMBER)
 /*
+ * Copy data from clienthello for env vars use later
+ */
+static void copy_clienthello_vars(conn_rec *c, SSL *ssl)
+{
+    SSLConnRec *sslcon;
+    modssl_clienthello_vars *clienthello_vars;
+    const unsigned char *data;
+    int *ids;
+
+    sslcon = myConnConfig(c);
+
+    sslcon->clienthello_vars = apr_palloc(c->pool, sizeof(*clienthello_vars));
+    clienthello_vars = sslcon->clienthello_vars;
+
+    if (clienthello_vars) {
+        clienthello_vars->version = SSL_client_hello_get0_legacy_version(ssl);
+        clienthello_vars->ciphers_len = SSL_client_hello_get0_ciphers(ssl, &data);
+        clienthello_vars->ciphers_data = apr_pmemdup(c->pool, data, clienthello_vars->ciphers_len);
+        if (SSL_client_hello_get1_extensions_present(ssl, &ids, &clienthello_vars->extids_len) == 1) {
+            clienthello_vars->extids_data = apr_pmemdup(c->pool, ids, clienthello_vars->extids_len * sizeof(int));
+            OPENSSL_free(ids);
+        }
+        SSL_client_hello_get0_ext(ssl, 0x0a, &data, &clienthello_vars->ecgroups_len);
+        clienthello_vars->ecgroups_data = apr_pmemdup(c->pool, data, clienthello_vars->ecgroups_len);
+        SSL_client_hello_get0_ext(ssl, 0x0b, &data, &clienthello_vars->ecformats_len);
+        clienthello_vars->ecformats_data = apr_pmemdup(c->pool, data, clienthello_vars->ecformats_len);
+        SSL_client_hello_get0_ext(ssl, 0x0d, &data, &clienthello_vars->sigalgos_len);
+        clienthello_vars->sigalgos_data = apr_pmemdup(c->pool, data, clienthello_vars->sigalgos_len);
+        SSL_client_hello_get0_ext(ssl, 0x10, &data, &clienthello_vars->alpn_len);
+        clienthello_vars->alpn_data = apr_pmemdup(c->pool, data, clienthello_vars->alpn_len);
+        SSL_client_hello_get0_ext(ssl, 0x2b, &data, &clienthello_vars->versions_len);
+        clienthello_vars->versions_data = apr_pmemdup(c->pool, data, clienthello_vars->versions_len);
+    }
+}
+
+/*
  * This callback function is called when the ClientHello is received.
  */
 int ssl_callback_ClientHello(SSL *ssl, int *al, void *arg)
 {
+    server_rec *s;
+    SSLSrvConfigRec *sc;
     char *servername = NULL;
     conn_rec *c = (conn_rec *)SSL_get_app_data(ssl);
     const unsigned char *pos;
@@ -2520,6 +2566,12 @@ int ssl_callback_ClientHello(SSL *ssl, int *al, void *arg)
 
 give_up:
     init_vhost(c, ssl, servername);
+    
+    s = mySrvFromConn(c);
+    sc = mySrvConfig(s);
+    if (sc->clienthello_vars == TRUE)
+        copy_clienthello_vars(c, ssl);
+
     return SSL_CLIENT_HELLO_SUCCESS;
 }
 #endif /* OPENSSL_VERSION_NUMBER < 0x10101000L */

--- a/modules/ssl/ssl_engine_kernel.c
+++ b/modules/ssl/ssl_engine_kernel.c
@@ -2489,75 +2489,35 @@ static void copy_clienthello_vars(conn_rec *c, SSL *ssl)
     clienthello_vars = sslcon->clienthello_vars;
 
     clienthello_vars->version = SSL_client_hello_get0_legacy_version(ssl);
-
     clienthello_vars->ciphers_len = SSL_client_hello_get0_ciphers(ssl, &data);
     if (clienthello_vars->ciphers_len > 0) {
         clienthello_vars->ciphers_data = apr_pmemdup(c->pool, data, clienthello_vars->ciphers_len);
     }
-    else {
-        clienthello_vars->ciphers_data = NULL;
-    }
-
     if (SSL_client_hello_get1_extensions_present(ssl, &ids, &clienthello_vars->extids_len) == 1) {
         if (clienthello_vars->extids_len > 0)
             clienthello_vars->extids_data = apr_pmemdup(c->pool, ids, clienthello_vars->extids_len * sizeof(int));
         OPENSSL_free(ids);
     }
-    else {
-        clienthello_vars->extids_len = 0;
-    }
-    if (clienthello_vars->extids_len == 0)
-        clienthello_vars->extids_data = NULL;
-
     if (SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_supported_groups, &data, &clienthello_vars->ecgroups_len) == 1) {
         if (clienthello_vars->ecgroups_len > 0)
             clienthello_vars->ecgroups_data = apr_pmemdup(c->pool, data, clienthello_vars->ecgroups_len);
     }
-    else {
-        clienthello_vars->ecgroups_len = 0;
-    }
-    if (clienthello_vars->ecgroups_len == 0)
-        clienthello_vars->ecgroups_data = NULL;
-
     if (SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_ec_point_formats, &data, &clienthello_vars->ecformats_len) == 1) {
         if (clienthello_vars->ecformats_len > 0)
             clienthello_vars->ecformats_data = apr_pmemdup(c->pool, data, clienthello_vars->ecformats_len);
     }
-    else {
-        clienthello_vars->ecformats_len = 0;
-    }
-    if (clienthello_vars->ecformats_len == 0)
-        clienthello_vars->ecformats_data = NULL;
-
     if (SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_signature_algorithms, &data, &clienthello_vars->sigalgos_len) == 1) {
         if (clienthello_vars->sigalgos_len > 0)
             clienthello_vars->sigalgos_data = apr_pmemdup(c->pool, data, clienthello_vars->sigalgos_len);
     }
-    else {
-        clienthello_vars->sigalgos_len = 0;
-    }
-    if (clienthello_vars->sigalgos_len == 0)
-        clienthello_vars->sigalgos_data = NULL;
-
     if (SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_application_layer_protocol_negotiation, &data, &clienthello_vars->alpn_len) == 1) {
         if (clienthello_vars->alpn_len > 0)
             clienthello_vars->alpn_data = apr_pmemdup(c->pool, data, clienthello_vars->alpn_len);
     }
-    else {
-        clienthello_vars->alpn_len = 0;
-    }
-    if (clienthello_vars->alpn_len == 0)
-        clienthello_vars->alpn_data = NULL;
-
     if (SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_supported_versions, &data, &clienthello_vars->versions_len) == 1) {
         if (clienthello_vars->versions_len > 0)
             clienthello_vars->versions_data = apr_pmemdup(c->pool, data, clienthello_vars->versions_len);
     }
-    else {
-        clienthello_vars->versions_len = 0;
-    }
-    if (clienthello_vars->versions_len == 0)
-        clienthello_vars->versions_data = NULL;
 }
 
 /*

--- a/modules/ssl/ssl_engine_kernel.c
+++ b/modules/ssl/ssl_engine_kernel.c
@@ -2485,26 +2485,72 @@ static void copy_clienthello_vars(conn_rec *c, SSL *ssl)
 
     sslcon = myConnConfig(c);
 
-    sslcon->clienthello_vars = apr_palloc(c->pool, sizeof(*clienthello_vars));
+    sslcon->clienthello_vars = apr_pcalloc(c->pool, sizeof(*clienthello_vars));
     clienthello_vars = sslcon->clienthello_vars;
 
     clienthello_vars->version = SSL_client_hello_get0_legacy_version(ssl);
+
     clienthello_vars->ciphers_len = SSL_client_hello_get0_ciphers(ssl, &data);
-    clienthello_vars->ciphers_data = apr_pmemdup(c->pool, data, clienthello_vars->ciphers_len);
-    if (SSL_client_hello_get1_extensions_present(ssl, &ids, &clienthello_vars->extids_len) == 1) {
-        clienthello_vars->extids_data = apr_pmemdup(c->pool, ids, clienthello_vars->extids_len * sizeof(int));
-        OPENSSL_free(ids);
+    if (clienthello_vars->ciphers_len > 0) {
+        clienthello_vars->ciphers_data = apr_pmemdup(c->pool, data, clienthello_vars->ciphers_len);
+    } else {
+        clienthello_vars->ciphers_data = NULL;
     }
-    SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_supported_groups, &data, &clienthello_vars->ecgroups_len);
-    clienthello_vars->ecgroups_data = apr_pmemdup(c->pool, data, clienthello_vars->ecgroups_len);
-    SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_ec_point_formats, &data, &clienthello_vars->ecformats_len);
-    clienthello_vars->ecformats_data = apr_pmemdup(c->pool, data, clienthello_vars->ecformats_len);
-    SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_signature_algorithms, &data, &clienthello_vars->sigalgos_len);
-    clienthello_vars->sigalgos_data = apr_pmemdup(c->pool, data, clienthello_vars->sigalgos_len);
-    SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_application_layer_protocol_negotiation, &data, &clienthello_vars->alpn_len);
-    clienthello_vars->alpn_data = apr_pmemdup(c->pool, data, clienthello_vars->alpn_len);
-    SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_supported_versions, &data, &clienthello_vars->versions_len);
-    clienthello_vars->versions_data = apr_pmemdup(c->pool, data, clienthello_vars->versions_len);
+
+    if (SSL_client_hello_get1_extensions_present(ssl, &ids, &clienthello_vars->extids_len) == 1) {
+        if (clienthello_vars->extids_len > 0)
+            clienthello_vars->extids_data = apr_pmemdup(c->pool, ids, clienthello_vars->extids_len * sizeof(int));
+        OPENSSL_free(ids);
+    } else {
+        clienthello_vars->extids_len = 0;
+    }
+    if (clienthello_vars->extids_len == 0)
+        clienthello_vars->extids_data = NULL;
+
+    if (SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_supported_groups, &data, &clienthello_vars->ecgroups_len) == 1) {
+        if (clienthello_vars->ecgroups_len > 0)
+            clienthello_vars->ecgroups_data = apr_pmemdup(c->pool, data, clienthello_vars->ecgroups_len);
+    } else {
+        clienthello_vars->ecgroups_len = 0;
+    }
+    if (clienthello_vars->ecgroups_len == 0)
+        clienthello_vars->ecgroups_data = NULL;
+
+    if (SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_ec_point_formats, &data, &clienthello_vars->ecformats_len) == 1) {
+        if (clienthello_vars->ecformats_len > 0)
+            clienthello_vars->ecformats_data = apr_pmemdup(c->pool, data, clienthello_vars->ecformats_len);
+    } else {
+        clienthello_vars->ecformats_len = 0;
+    }
+    if (clienthello_vars->ecformats_len == 0)
+        clienthello_vars->ecformats_data = NULL;
+
+    if (SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_signature_algorithms, &data, &clienthello_vars->sigalgos_len) == 1) {
+        if (clienthello_vars->sigalgos_len > 0)
+            clienthello_vars->sigalgos_data = apr_pmemdup(c->pool, data, clienthello_vars->sigalgos_len);
+    } else {
+        clienthello_vars->sigalgos_len = 0;
+    }
+    if (clienthello_vars->sigalgos_len == 0)
+        clienthello_vars->sigalgos_data = NULL;
+
+    if (SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_application_layer_protocol_negotiation, &data, &clienthello_vars->alpn_len) == 1) {
+        if (clienthello_vars->alpn_len > 0)
+            clienthello_vars->alpn_data = apr_pmemdup(c->pool, data, clienthello_vars->alpn_len);
+    } else {
+        clienthello_vars->alpn_len = 0;
+    }
+    if (clienthello_vars->alpn_len == 0)
+        clienthello_vars->alpn_data = NULL;
+
+    if (SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_supported_versions, &data, &clienthello_vars->versions_len) == 1) {
+        if (clienthello_vars->versions_len > 0)
+            clienthello_vars->versions_data = apr_pmemdup(c->pool, data, clienthello_vars->versions_len);
+    } else {
+        clienthello_vars->versions_len = 0;
+    }
+    if (clienthello_vars->versions_len == 0)
+        clienthello_vars->versions_data = NULL;
 }
 
 /*

--- a/modules/ssl/ssl_engine_kernel.c
+++ b/modules/ssl/ssl_engine_kernel.c
@@ -2493,7 +2493,8 @@ static void copy_clienthello_vars(conn_rec *c, SSL *ssl)
     clienthello_vars->ciphers_len = SSL_client_hello_get0_ciphers(ssl, &data);
     if (clienthello_vars->ciphers_len > 0) {
         clienthello_vars->ciphers_data = apr_pmemdup(c->pool, data, clienthello_vars->ciphers_len);
-    } else {
+    }
+    else {
         clienthello_vars->ciphers_data = NULL;
     }
 
@@ -2501,7 +2502,8 @@ static void copy_clienthello_vars(conn_rec *c, SSL *ssl)
         if (clienthello_vars->extids_len > 0)
             clienthello_vars->extids_data = apr_pmemdup(c->pool, ids, clienthello_vars->extids_len * sizeof(int));
         OPENSSL_free(ids);
-    } else {
+    }
+    else {
         clienthello_vars->extids_len = 0;
     }
     if (clienthello_vars->extids_len == 0)
@@ -2510,7 +2512,8 @@ static void copy_clienthello_vars(conn_rec *c, SSL *ssl)
     if (SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_supported_groups, &data, &clienthello_vars->ecgroups_len) == 1) {
         if (clienthello_vars->ecgroups_len > 0)
             clienthello_vars->ecgroups_data = apr_pmemdup(c->pool, data, clienthello_vars->ecgroups_len);
-    } else {
+    }
+    else {
         clienthello_vars->ecgroups_len = 0;
     }
     if (clienthello_vars->ecgroups_len == 0)
@@ -2519,7 +2522,8 @@ static void copy_clienthello_vars(conn_rec *c, SSL *ssl)
     if (SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_ec_point_formats, &data, &clienthello_vars->ecformats_len) == 1) {
         if (clienthello_vars->ecformats_len > 0)
             clienthello_vars->ecformats_data = apr_pmemdup(c->pool, data, clienthello_vars->ecformats_len);
-    } else {
+    }
+    else {
         clienthello_vars->ecformats_len = 0;
     }
     if (clienthello_vars->ecformats_len == 0)
@@ -2528,7 +2532,8 @@ static void copy_clienthello_vars(conn_rec *c, SSL *ssl)
     if (SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_signature_algorithms, &data, &clienthello_vars->sigalgos_len) == 1) {
         if (clienthello_vars->sigalgos_len > 0)
             clienthello_vars->sigalgos_data = apr_pmemdup(c->pool, data, clienthello_vars->sigalgos_len);
-    } else {
+    }
+    else {
         clienthello_vars->sigalgos_len = 0;
     }
     if (clienthello_vars->sigalgos_len == 0)
@@ -2537,7 +2542,8 @@ static void copy_clienthello_vars(conn_rec *c, SSL *ssl)
     if (SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_application_layer_protocol_negotiation, &data, &clienthello_vars->alpn_len) == 1) {
         if (clienthello_vars->alpn_len > 0)
             clienthello_vars->alpn_data = apr_pmemdup(c->pool, data, clienthello_vars->alpn_len);
-    } else {
+    }
+    else {
         clienthello_vars->alpn_len = 0;
     }
     if (clienthello_vars->alpn_len == 0)
@@ -2546,7 +2552,8 @@ static void copy_clienthello_vars(conn_rec *c, SSL *ssl)
     if (SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_supported_versions, &data, &clienthello_vars->versions_len) == 1) {
         if (clienthello_vars->versions_len > 0)
             clienthello_vars->versions_data = apr_pmemdup(c->pool, data, clienthello_vars->versions_len);
-    } else {
+    }
+    else {
         clienthello_vars->versions_len = 0;
     }
     if (clienthello_vars->versions_len == 0)

--- a/modules/ssl/ssl_engine_vars.c
+++ b/modules/ssl/ssl_engine_vars.c
@@ -1002,7 +1002,7 @@ static const char *ssl_var_lookup_ssl_clienthello(apr_pool_t *p, const SSLConnRe
     else if (strEQ(var, "EXTENSIONS") && (clienthello_vars->extids_len > 0)) {
         value = apr_palloc(p, clienthello_vars->extids_len * 4 + 1);
         for (i = 0; i < clienthello_vars->extids_len; i++) {
-            snprintf(value + i * 4, 5, "%04x", (uint16_t) clienthello_vars->extids_data[i]);
+            apr_snprintf(value + i * 4, 5, "%04x", (uint16_t) clienthello_vars->extids_data[i]);
         }
         return value;
     }

--- a/modules/ssl/ssl_engine_vars.c
+++ b/modules/ssl/ssl_engine_vars.c
@@ -52,6 +52,7 @@ static const char *ssl_var_lookup_ssl_cert_verify(apr_pool_t *p, const SSLConnRe
 static const char *ssl_var_lookup_ssl_cipher(apr_pool_t *p, const SSLConnRec *sslconn, const char *var);
 static void  ssl_var_lookup_ssl_cipher_bits(SSL *ssl, int *usekeysize, int *algkeysize);
 static const char *ssl_var_lookup_ssl_handshake_rtt(apr_pool_t *p, SSL *ssl);
+static const char *ssl_var_lookup_ssl_clienthello(apr_pool_t *p, SSLConnRec *sslconn, char *var);
 static const char *ssl_var_lookup_ssl_version(const char *var);
 static const char *ssl_var_lookup_ssl_compress_meth(SSL *ssl);
 
@@ -475,6 +476,9 @@ static const char *ssl_var_lookup_ssl(apr_pool_t *p, const SSLConnRec *sslconn,
     }
     else if (ssl != NULL && strcEQ(var, "HANDSHAKE_RTT")) {
         result = ssl_var_lookup_ssl_handshake_rtt(p, ssl);
+    }
+    else if (ssl != NULL && strlen(var) >= 12 && strcEQn(var, "CLIENTHELLO_", 12)) {
+        result = ssl_var_lookup_ssl_clienthello(p, sslconn, var+12);
     }
     else if (ssl != NULL && strlen(var) > 18 && strcEQn(var, "CLIENT_CERT_CHAIN_", 18)) {
         sk = SSL_get_peer_cert_chain(ssl);
@@ -971,6 +975,56 @@ static const char *ssl_var_lookup_ssl_handshake_rtt(apr_pool_t *p, SSL *ssl)
     apr_uint64_t rtt;
     if (SSL_get_handshake_rtt(ssl, &rtt) > 0)
         return apr_psprintf(p, "%" APR_UINT64_T_FMT, rtt);
+#endif
+    return NULL;
+}
+
+static const char *ssl_var_lookup_ssl_clienthello(apr_pool_t *p, SSLConnRec *sslconn, char *var)
+{
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+    char *value;
+    modssl_clienthello_vars *clienthello_vars;
+    int i;
+
+    clienthello_vars = sslconn->clienthello_vars;
+
+    if (!clienthello_vars)
+        return NULL; 
+
+    if (strEQ(var, "VERSION")) {
+        return apr_psprintf(p, "%04x", (uint16_t) clienthello_vars->version);
+    } else if (strEQ(var, "CIPHERS") && (clienthello_vars->ciphers_len > 0)) {
+        value = apr_palloc(p, clienthello_vars->ciphers_len * 2 + 1);
+        ap_bin2hex(clienthello_vars->ciphers_data, clienthello_vars->ciphers_len, value);
+        return value;
+    } else if (strEQ(var, "EXTENSIONS") && (clienthello_vars->extids_len > 0)) {
+        value = apr_palloc(p, clienthello_vars->extids_len * 4 + 1);
+        for (i = 0; i < clienthello_vars->extids_len; i++)
+        {
+            snprintf(value + i * 4, 5, "%04x", (uint16_t) clienthello_vars->extids_data[i]);
+        }
+        return value;
+    } else if (strEQ(var, "GROUPS") && (clienthello_vars->ecgroups_len > 2)) {
+        value = apr_palloc(p, clienthello_vars->ecgroups_len * 2 + 1 - 2);
+        ap_bin2hex(clienthello_vars->ecgroups_data + 2, clienthello_vars->ecgroups_len - 2, value);
+        return value;
+    } else if (strEQ(var, "EC_FORMATS") && (clienthello_vars->ecformats_len > 1)) {
+        value = apr_palloc(p, clienthello_vars->ecformats_len * 2 + 1 - 1);
+        ap_bin2hex(clienthello_vars->ecformats_data + 1, clienthello_vars->ecformats_len - 1, value);
+        return value;
+    } else if (strEQ(var, "SIG_ALGOS") && (clienthello_vars->sigalgos_len > 2)) {
+        value = apr_palloc(p, clienthello_vars->sigalgos_len * 2 + 1 - 2);
+        ap_bin2hex(clienthello_vars->sigalgos_data + 2, clienthello_vars->sigalgos_len - 2, value);
+        return value;
+    } else if (strEQ(var, "ALPN") && (clienthello_vars->alpn_len > 2)) {
+        value = apr_palloc(p, clienthello_vars->alpn_len * 2 + 1 - 2);
+        ap_bin2hex(clienthello_vars->alpn_data + 2, clienthello_vars->alpn_len - 2, value);
+        return value;
+    } else if (strEQ(var, "VERSIONS") && (clienthello_vars->versions_len > 1)) {
+        value = apr_palloc(p, clienthello_vars->versions_len * 2 + 1 - 1);
+        ap_bin2hex(clienthello_vars->versions_data + 1, clienthello_vars->versions_len - 1, value);
+        return value;
+    }
 #endif
     return NULL;
 }

--- a/modules/ssl/ssl_engine_vars.c
+++ b/modules/ssl/ssl_engine_vars.c
@@ -981,10 +981,10 @@ static const char *ssl_var_lookup_ssl_handshake_rtt(apr_pool_t *p, SSL *ssl)
 
 static const char *ssl_var_lookup_ssl_clienthello(apr_pool_t *p, const SSLConnRec *sslconn, const char *var)
 {
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L && !defined(LIBRESSL_VERSION_NUMBER)
     char *value;
     modssl_clienthello_vars *clienthello_vars;
-    int i;
+    apr_size_t i;
 
     clienthello_vars = sslconn->clienthello_vars;
 

--- a/modules/ssl/ssl_engine_vars.c
+++ b/modules/ssl/ssl_engine_vars.c
@@ -52,7 +52,7 @@ static const char *ssl_var_lookup_ssl_cert_verify(apr_pool_t *p, const SSLConnRe
 static const char *ssl_var_lookup_ssl_cipher(apr_pool_t *p, const SSLConnRec *sslconn, const char *var);
 static void  ssl_var_lookup_ssl_cipher_bits(SSL *ssl, int *usekeysize, int *algkeysize);
 static const char *ssl_var_lookup_ssl_handshake_rtt(apr_pool_t *p, SSL *ssl);
-static const char *ssl_var_lookup_ssl_clienthello(apr_pool_t *p, SSLConnRec *sslconn, char *var);
+static const char *ssl_var_lookup_ssl_clienthello(apr_pool_t *p, const SSLConnRec *sslconn, const char *var);
 static const char *ssl_var_lookup_ssl_version(const char *var);
 static const char *ssl_var_lookup_ssl_compress_meth(SSL *ssl);
 
@@ -979,7 +979,7 @@ static const char *ssl_var_lookup_ssl_handshake_rtt(apr_pool_t *p, SSL *ssl)
     return NULL;
 }
 
-static const char *ssl_var_lookup_ssl_clienthello(apr_pool_t *p, SSLConnRec *sslconn, char *var)
+static const char *ssl_var_lookup_ssl_clienthello(apr_pool_t *p, const SSLConnRec *sslconn, const char *var)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x10101000L
     char *value;
@@ -989,38 +989,44 @@ static const char *ssl_var_lookup_ssl_clienthello(apr_pool_t *p, SSLConnRec *ssl
     clienthello_vars = sslconn->clienthello_vars;
 
     if (!clienthello_vars)
-        return NULL; 
+        return NULL;
 
     if (strEQ(var, "VERSION")) {
         return apr_psprintf(p, "%04x", (uint16_t) clienthello_vars->version);
-    } else if (strEQ(var, "CIPHERS") && (clienthello_vars->ciphers_len > 0)) {
+    }
+    else if (strEQ(var, "CIPHERS") && (clienthello_vars->ciphers_len > 0)) {
         value = apr_palloc(p, clienthello_vars->ciphers_len * 2 + 1);
         ap_bin2hex(clienthello_vars->ciphers_data, clienthello_vars->ciphers_len, value);
         return value;
-    } else if (strEQ(var, "EXTENSIONS") && (clienthello_vars->extids_len > 0)) {
+    }
+    else if (strEQ(var, "EXTENSIONS") && (clienthello_vars->extids_len > 0)) {
         value = apr_palloc(p, clienthello_vars->extids_len * 4 + 1);
-        for (i = 0; i < clienthello_vars->extids_len; i++)
-        {
+        for (i = 0; i < clienthello_vars->extids_len; i++) {
             snprintf(value + i * 4, 5, "%04x", (uint16_t) clienthello_vars->extids_data[i]);
         }
         return value;
-    } else if (strEQ(var, "GROUPS") && (clienthello_vars->ecgroups_len > 2)) {
+    }
+    else if (strEQ(var, "GROUPS") && (clienthello_vars->ecgroups_len > 2)) {
         value = apr_palloc(p, clienthello_vars->ecgroups_len * 2 + 1 - 2);
         ap_bin2hex(clienthello_vars->ecgroups_data + 2, clienthello_vars->ecgroups_len - 2, value);
         return value;
-    } else if (strEQ(var, "EC_FORMATS") && (clienthello_vars->ecformats_len > 1)) {
+    }
+    else if (strEQ(var, "EC_FORMATS") && (clienthello_vars->ecformats_len > 1)) {
         value = apr_palloc(p, clienthello_vars->ecformats_len * 2 + 1 - 1);
         ap_bin2hex(clienthello_vars->ecformats_data + 1, clienthello_vars->ecformats_len - 1, value);
         return value;
-    } else if (strEQ(var, "SIG_ALGOS") && (clienthello_vars->sigalgos_len > 2)) {
+    }
+    else if (strEQ(var, "SIG_ALGOS") && (clienthello_vars->sigalgos_len > 2)) {
         value = apr_palloc(p, clienthello_vars->sigalgos_len * 2 + 1 - 2);
         ap_bin2hex(clienthello_vars->sigalgos_data + 2, clienthello_vars->sigalgos_len - 2, value);
         return value;
-    } else if (strEQ(var, "ALPN") && (clienthello_vars->alpn_len > 2)) {
+    }
+    else if (strEQ(var, "ALPN") && (clienthello_vars->alpn_len > 2)) {
         value = apr_palloc(p, clienthello_vars->alpn_len * 2 + 1 - 2);
         ap_bin2hex(clienthello_vars->alpn_data + 2, clienthello_vars->alpn_len - 2, value);
         return value;
-    } else if (strEQ(var, "VERSIONS") && (clienthello_vars->versions_len > 1)) {
+    }
+    else if (strEQ(var, "VERSIONS") && (clienthello_vars->versions_len > 1)) {
         value = apr_palloc(p, clienthello_vars->versions_len * 2 + 1 - 1);
         ap_bin2hex(clienthello_vars->versions_data + 1, clienthello_vars->versions_len - 1, value);
         return value;

--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -578,7 +578,7 @@ typedef enum {
  * Define the structure to hold clienthello variables
  * (later exposed as environment vars)
  */
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L && !defined(LIBRESSL_VERSION_NUMBER)
 typedef struct {
     unsigned int version;
     apr_size_t ciphers_len;
@@ -629,7 +629,7 @@ typedef struct {
     int service_unavailable;  /* thouugh we negotiate SSL, no requests will be served */
     int vhost_found;          /* whether we found vhost from SNI already */
 
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L && !defined(LIBRESSL_VERSION_NUMBER)
     modssl_clienthello_vars *clienthello_vars;  /* info from clienthello callback */
 #endif
 } SSLConnRec;

--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -574,6 +574,30 @@ typedef enum {
     SSL_SHUTDOWN_TYPE_ACCURATE
 } ssl_shutdown_type_e;
 
+/**
+ * Define the structure to hold clienthello variables
+ * (later exposed as environment vars)
+ */
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+typedef struct {
+    unsigned int version;
+    apr_size_t ciphers_len;
+    const unsigned char *ciphers_data;
+    apr_size_t extids_len;
+    int *extids_data;
+    apr_size_t ecgroups_len;
+    const unsigned char *ecgroups_data;
+    apr_size_t ecformats_len;
+    const unsigned char *ecformats_data;
+    apr_size_t sigalgos_len;
+    const unsigned char *sigalgos_data;
+    apr_size_t alpn_len;
+    const unsigned char *alpn_data;
+    apr_size_t versions_len;
+    const unsigned char *versions_data;
+} modssl_clienthello_vars;
+#endif
+
 typedef struct {
     SSL *ssl;
     const char *client_dn;
@@ -604,6 +628,10 @@ typedef struct {
     const char *cipher_suite; /* cipher suite used in last reneg */
     int service_unavailable;  /* thouugh we negotiate SSL, no requests will be served */
     int vhost_found;          /* whether we found vhost from SNI already */
+
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+    modssl_clienthello_vars *clienthello_vars;  /* info from clienthello callback */
+#endif
 } SSLConnRec;
 
 /* Private keys are retained across reloads, since decryption
@@ -833,7 +861,7 @@ struct SSLSrvConfigRec {
     BOOL             compression;
 #endif
     BOOL             session_tickets;
-    
+    BOOL             clienthello_vars;
 };
 
 /**
@@ -893,6 +921,7 @@ const char  *ssl_cmd_SSLCARevocationPath(cmd_parms *, void *, const char *);
 const char  *ssl_cmd_SSLCARevocationFile(cmd_parms *, void *, const char *);
 const char  *ssl_cmd_SSLCARevocationCheck(cmd_parms *, void *, const char *);
 const char  *ssl_cmd_SSLHonorCipherOrder(cmd_parms *cmd, void *dcfg, int flag);
+const char  *ssl_cmd_SSLClientHelloVars(cmd_parms *, void *, int flag);
 const char  *ssl_cmd_SSLCompression(cmd_parms *, void *, int flag);
 const char  *ssl_cmd_SSLSessionTickets(cmd_parms *, void *, int flag);
 const char  *ssl_cmd_SSLVerifyClient(cmd_parms *, void *, const char *);

--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -584,7 +584,7 @@ typedef struct {
     apr_size_t ciphers_len;
     const unsigned char *ciphers_data;
     apr_size_t extids_len;
-    int *extids_data;
+    const int *extids_data;
     apr_size_t ecgroups_len;
     const unsigned char *ecgroups_data;
     apr_size_t ecformats_len;


### PR DESCRIPTION
This patch implements collection of variables from the ClientHello which are later made available in the same manner as the other environment variables of mod_ssl. A new directive, SSLClientHelloVars, enables collection of the raw variables during the clienthello callback which are then formated and provided as environment variables for all the requests in that connection, subject to the standard StdEnvVars functionality. If SSLClientHelloVars is not enabled or if openssl prior to 1.1.1 is used, this option should have little impact--no clienthello information is collected. The environment variables are populated with null if openssl < 1.1.1 is used or SSLClientHelloVars is not set to on.

The ClientHello variables are provided as hex encoded data the same as the raw network protocol/what is returned from openssl.

This patch has been tested on ubuntu 24.10 apache 2.4.62/openssl 3.3.1 verifying correct operation of the config directive when not set (default to off), set to off, and set to on. The variables have been tested in the context of both environment variables for cgi scripts and CustomLog entries. The variables have been used to succesfully generate the correct ja3 and ja4 fingerprints for a small number of common clients (as validated by comparison to zeek implementations of ja3/ja4).

This patch complements my prior pull request, #477.