### PR TITLE
Fix example in expr.xml

### DIFF
--- a/docs/manual/expr.xml
+++ b/docs/manual/expr.xml
@@ -762,7 +762,7 @@ Header set foo-checksum "expr=%{md5:foo}"
 
 # This delays the evaluation of the condition clause compared to &lt;If&gt;
 SetEnvIf REQUEST_URI ^/special_path\.php$ special
-Header set CustomHeader my-value env=special
+Header always set CustomHeader my-value env=special
 
 # Add a header to forward client's certificate SAN to some backend
 RequestHeader set X-Client-SAN "expr=%{:join PeerExtList('subjectAltName'):}"

--- a/docs/manual/expr.xml
+++ b/docs/manual/expr.xml
@@ -761,7 +761,8 @@ Require expr replace(%{REQUEST_METHOD},  'E', 'O') == 'GET'"
 Header set foo-checksum "expr=%{md5:foo}"
 
 # This delays the evaluation of the condition clause compared to &lt;If&gt;
-Header always set CustomHeader my-value "expr=%{REQUEST_URI} =~ m#^/special_path\.php$#"
+SetEnvIf REQUEST_URI ^/special_path\.php$ special
+Header set CustomHeader my-value env=special
 
 # Add a header to forward client's certificate SAN to some backend
 RequestHeader set X-Client-SAN "expr=%{:join PeerExtList('subjectAltName'):}"


### PR DESCRIPTION
The original example doesn’t actually work. This PR replaces it with a functional snippet along the lines of ex. 4 from mod_headers.