### PR TITLE
mod_proxy: Allow override Host header and SSL SNI in ProxyPass

### DIFF
--- a/modules/proxy/mod_proxy.c
+++ b/modules/proxy/mod_proxy.c
@@ -368,6 +368,20 @@ static const char *set_worker_param(apr_pool_t *p,
         return "multipathtcp is not supported on your platform";
 #endif
     }
+    else if (!strcasecmp(key, "override_http_host")) {
+        if (strlen(val) >= sizeof(worker->s->override_http_host))
+            return apr_psprintf(p, "Override HTTP Host header length must be < %d characters",
+                                (int)sizeof(worker->s->override_http_host));
+        PROXY_STRNCPY(worker->s->override_http_host, val);
+        worker->s->override_http_host_set = 1;
+    }
+    else if (!strcasecmp(key, "override_ssl_sni")) {
+        if (strlen(val) >= sizeof(worker->s->override_ssl_sni))
+            return apr_psprintf(p, "Override SSL SNI length must be < %d characters",
+                                (int)sizeof(worker->s->override_ssl_sni));
+        PROXY_STRNCPY(worker->s->override_ssl_sni, val);
+        worker->s->override_ssl_sni_set = 1;
+    }
     else {
         if (set_worker_hc_param_f) {
             return set_worker_hc_param_f(p, s, worker, key, val, NULL);

--- a/modules/proxy/mod_proxy.h
+++ b/modules/proxy/mod_proxy.h
@@ -498,6 +498,10 @@ typedef struct {
     apr_int32_t      address_ttl;    /* backend address' TTL (seconds) */
     apr_uint32_t     address_expiry; /* backend address' next expiry time */
     int              sock_proto;     /* The protocol to use to create the socket */
+    unsigned int override_http_host_set:1;
+    unsigned int override_ssl_sni_set:1;
+    char override_http_host[PROXY_RFC1035_HOSTNAME_SIZE];
+    char override_ssl_sni[PROXY_RFC1035_HOSTNAME_SIZE];
 } proxy_worker_shared;
 
 #define ALIGNED_PROXY_WORKER_SHARED_SIZE (APR_ALIGN_DEFAULT(sizeof(proxy_worker_shared)))


### PR DESCRIPTION
This patch adds 2 optional parameters, `override_http_host` and `override_ssl_sni` for `ProxyPass` directive.

`override_http_host` allows setting custom HTTP `Host:` header. This may be done by utilizing `ProxyPreserveHost On` and `RequestHeader set Host`.

`override_ssl_sni` allows setting custom SSL server name (SNI). This seems could not be done without this patch.

This patch could be helpful in the scenario described below:

- A HTTPS server on `203.0.113.2:443` hosting a site `domain.tld`, **with strict HTTP Host header check and TLS SNI check**.
- Apache HTTPd, running on `203.0.113.1`, is being used to reverse proxy `https://domain.tld` hosted on `203.0.113.2:443`
- There is no (type A) DNS record pointed to `203.0.113.2`, which forced us to use IP address in `ProxyPass`
- Administrator adds `ProxyPass / https://203.0.113.2` to Apache's configuration
- Reverse proxy fails, because SNI and HTTP host was `203.0.113.2` instead of `domain.tld`
- Administrator adds `ProxyPreserveHost On` and `RequestHeader set Host domain.tld` to Apache's configuration
- Reverse proxy still fail, because only HTTP host header was set correctly, SNI is still incorrect.

With this patch ...

- Administrator adds a single line `ProxyPass / https://203.0.113.2 override_http_host=domain.tld override_ssl_sni=domain.tld`
- It works

Besides, this patch introduce no breaking change. (i.e. incompatibility against current configurations)