### PR TITLE
ap_log_error: Include ap_config_auto.h to define _GNU_SOURCE

### DIFF
--- a/server/log.c
+++ b/server/log.c
@@ -21,6 +21,10 @@
  *
  */
 
+#if !defined(WIN32) && !defined(NETWARE)
+#include "ap_config_auto.h"
+#endif
+
 #include "apr.h"
 #include "apr_general.h"        /* for signal stuff */
 #include "apr_strings.h"


### PR DESCRIPTION
gettid() needs _GNU_SOURCE defined which is provided by ap_config_auto.h

Fixes buildroot error:
http://autobuild.buildroot.net/results/2f6/2f6b7bbb4c97e4c91b3abd6bb205e237e57045fa//build-end.log

log.c: In function 'log_tid':
log.c:637:21: error: implicit declaration of function 'gettid'; did you mean 'getgid'? [-Wimplicit-function-declaration]
  637 |         pid_t tid = gettid();