### PR TITLE
log getpwuid error

### DIFF
--- a/modules/arch/unix/mod_unixd.c
+++ b/modules/arch/unix/mod_unixd.c
@@ -97,12 +97,13 @@ static int set_group_privs(void)
         if (ap_unixd_config.user_name[0] == '#') {
             struct passwd *ent;
             uid_t uid = atol(&ap_unixd_config.user_name[1]);
-
+            errno = 0;
             if ((ent = getpwuid(uid)) == NULL) {
                 ap_log_error(APLOG_MARK, APLOG_ALERT, errno, NULL, APLOGNO(02155)
-                         "getpwuid: couldn't determine user name from uid %ld, "
+                         "getpwuid: couldn't determine user name from uid %ld (errno %d: %s), "
                          "you probably need to modify the User directive",
-                         (long)uid);
+                         (long)uid, errno, strerror(errno));
+
                 return -1;
             }
 


### PR DESCRIPTION
was in a situation where getpwuid() failed, and I would've liked to see the errno/strerror at the time of the error.

quoting https://pubs.opengroup.org/onlinepubs/009604499/functions/getpwuid.html
> Applications wishing to check for error situations should set errno to 0 before calling getpwuid(). If getpwuid() returns a null pointer and errno is set to non-zero, an error occurred.