### PR TITLE
Fix undefined behavior in dsortf comparison function

### DIFF
--- a/modules/generators/mod_autoindex.c
+++ b/modules/generators/mod_autoindex.c
@@ -1925,6 +1925,9 @@ static int dsortf(struct ent **e1, struct ent **e2)
      * First, see if either of the entries is for the parent directory.
      * If so, that *always* sorts lower than anything else.
      */
+    if ((*e1)->name[0] == '/' && (*e2)->name[0] == '/') {
+        return 0;
+    }
     if ((*e1)->name[0] == '/') {
         return -1;
     }


### PR DESCRIPTION
In the dsortf function, when both (*e1)->name[0] == '/' and (*e2)->name[0] == '/', a situation occurs where a < b but b < a, violating the transitivity requirement for comparison functions used by qsort as specified by the C standard. This leads to undefined behavior, which can cause incorrect sorting and memory corruption in glibc's qsort implementation, creating a potential security issue [1].

Fix the issue by returning 0 when both entries begin with '/', preventing the undefined behavior.

[1] https://www.qualys.com/2024/01/30/qsort.txt