### PR TITLE
mod_ssl: Don't reject expired client certs with optional_no_ca.

### DIFF
--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -459,7 +459,8 @@ typedef enum {
     || (errnum == X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN) \
     || (errnum == X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY) \
     || (errnum == X509_V_ERR_CERT_UNTRUSTED) \
-    || (errnum == X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE))
+    || (errnum == X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE) \
+    || (errnum == X509_V_ERR_CERT_HAS_EXPIRED))
 
 /**
   * CRL checking mask (mode | flags)


### PR DESCRIPTION
The SSLVerifyClient optional_no_ca setting has been broken since it was introduced in that expired certificates result in the request being rejected, which is contrary to the documentation and how the setting is supposed to behave. To fix this, add X509_V_ERR_CRL_HAS_EXPIRED to the list of error exceptions that allow ssl_callback_SSLVerify in ssl_engine_kernel.c and ssl_io_filter_handshake in ssl_engine_io.c to accept the client certificate anyways.

PR: 60028
PR: 60186