### PR TITLE
mod_dav: Add API exposing the DavBasePath setting

### DIFF
--- a/changes-entries/dav-get-base-path.txt
+++ b/changes-entries/dav-get-base-path.txt
@@ -1,0 +1,2 @@
+  *) mod_dav: Add API to expose DavBasePath setting.  [Joe Orton]
+

--- a/include/ap_mmn.h
+++ b/include/ap_mmn.h
@@ -733,6 +733,7 @@
  * 20211221.25 (2.5.1-dev) AP_SLASHES and AP_IS_SLASH
  * 20211221.26 (2.5.1-dev) Add is_host_matchable to proxy_worker_shared
  * 20211221.27 (2.5.1-dev) Add sock_proto to proxy_worker_shared, and AP_LISTEN_MPTCP
+ * 20211221.28 (2.5.1-dev) Add dav_get_base_path() to mod_dav
  */
 
 #define MODULE_MAGIC_COOKIE 0x41503235UL /* "AP25" */
@@ -740,7 +741,7 @@
 #ifndef MODULE_MAGIC_NUMBER_MAJOR
 #define MODULE_MAGIC_NUMBER_MAJOR 20211221
 #endif
-#define MODULE_MAGIC_NUMBER_MINOR 27             /* 0...n */
+#define MODULE_MAGIC_NUMBER_MINOR 28             /* 0...n */
 
 /**
  * Determine if the server's current MODULE_MAGIC_NUMBER is at least a

--- a/modules/dav/main/mod_dav.c
+++ b/modules/dav/main/mod_dav.c
@@ -263,6 +263,13 @@ DAV_DECLARE(const dav_hooks_search *) dav_get_search_hooks(request_rec *r)
     return dav_get_provider(r)->search;
 }
 
+DAV_DECLARE(const char *) dav_get_base_path(request_rec *r)
+{
+    dav_dir_conf *conf = ap_get_module_config(r->per_dir_config, &dav_module);
+
+    return conf && conf->base ? conf->base : NULL;
+}
+
 /*
  * Command handler for the DAV directive, which is TAKE1.
  */

--- a/modules/dav/main/mod_dav.h
+++ b/modules/dav/main/mod_dav.h
@@ -436,6 +436,11 @@ typedef struct dav_locktoken dav_locktoken;
 DAV_DECLARE(dav_error *) dav_get_resource(request_rec *r, int label_allowed,
                                           int use_checked_in, dav_resource **res_p);
 
+/*
+** If DavBasePath is configured for the request location, return the
+** configured path, otherwise NULL.
+*/
+DAV_DECLARE(const char *) dav_get_base_path(request_rec *r);
 
 /* --------------------------------------------------------------------
 **


### PR DESCRIPTION
```
Add API exposing the DavBasePath setting for use by DAV repository
backend modules (mod_dav_svn needs this for POST method handling).

* modules/dav/main/mod_dav.c (dav_get_base_path): New function.

* include/ap_mmn.h: Bump MMN minor.
```