### PR TITLE
Fix variable declaration after statement warning in scoreboard.c

### DIFF
--- a/server/scoreboard.c
+++ b/server/scoreboard.c
@@ -657,11 +657,11 @@ AP_DECLARE(void) ap_time_process_request(ap_sb_handle_t *sbh, int status)
 AP_DECLARE(void) ap_set_time_process_request(ap_sb_handle_t* const sbh,
 		const apr_time_t timebeg,const apr_time_t timeend)
 {
+    worker_score *ws;
     if (!sbh || sbh->child_num < 0)
         return;
 
-    worker_score* const ws =
-	&ap_scoreboard_image->servers[sbh->child_num][sbh->thread_num];
+    ws = &ap_scoreboard_image->servers[sbh->child_num][sbh->thread_num];
     
     ws->start_time = timebeg;
     ws->stop_time = ws->last_used = timeend;


### PR DESCRIPTION
The latest commit broke compilation with maintainer mode (the warning is treated as an error) incl. some jobs in CI.

https://github.com/apache/httpd/actions/runs/13282453047/job/37083598064

This PR fixes it.

https://github.com/jajik/httpd/actions/runs/13311390743