### PR TITLE
###  Macro to Simplify Array Length Calculation (Revived from PR #401)

### DIFF
--- a/include/ap_config.h
+++ b/include/ap_config.h
@@ -261,5 +261,18 @@
 #define AP_FN_ATTR_NONNULL(x)
 #endif
 
-
+#ifndef AP_ARRAY_LEN
+/**
+ * @def AP_ARRAY_LEN(a)
+ * @brief Computes the number of elements in a static array.
+ *
+ * This macro replaces `sizeof(a)/sizeof(a[0])` to improve readability.
+ * It should only be used with fixed-size arrays, not pointers or dynamically
+ * allocated memory.
+ *
+ * @param a The static array.
+ * @return The number of elements in the array.
+ */
+#define AP_ARRAY_LEN(a) (sizeof(a) / sizeof((a)[0]))
+#endif
 #endif /* AP_CONFIG_H */

--- a/modules/filters/sed1.c
+++ b/modules/filters/sed1.c
@@ -24,6 +24,7 @@
 #include "sed.h"
 #include "apr_strings.h"
 #include "regexp.h"
+#include "ap_config.h"
 
 static const char *const trans[040]  = {
     "\\01",
@@ -330,7 +331,7 @@ apr_status_t sed_reset_eval(sed_eval_t *eval, sed_commands_t *commands, sed_err_
     eval->hspend = eval->holdbuf;
     eval->lcomend = &eval->genbuf[71];
 
-    for (i = 0; i < sizeof(eval->abuf) / sizeof(eval->abuf[0]); i++)
+    for (i = 0; i < AP_ARRAY_LEN(eval->abuf); i++)
         eval->abuf[i] = NULL;
     eval->aptr = eval->abuf;
     eval->pending = NULL;

--- a/modules/http2/h2.h
+++ b/modules/http2/h2.h
@@ -95,8 +95,6 @@ extern const char *H2_MAGIC_TOKEN;
 
 #define H2_STREAM_CLIENT_INITIATED(id)      (id&0x01)
 
-#define H2_ALEN(a)          (sizeof(a)/sizeof((a)[0]))
-
 #define H2MAX(x,y) ((x) > (y) ? (x) : (y))
 #define H2MIN(x,y) ((x) < (y) ? (x) : (y))
 

--- a/modules/http2/h2_bucket_beam.c
+++ b/modules/http2/h2_bucket_beam.c
@@ -74,7 +74,7 @@ static int h2_blist_count(h2_blist *blist)
     do { \
         if (APLOG_C_IS_LEVEL((c),(level))) { \
             char buffer[4 * 1024]; \
-            apr_size_t len, bmax = sizeof(buffer)/sizeof(buffer[0]); \
+            apr_size_t len, bmax = AP_ARRAY_LEN(buffer); \
             len = bb? h2_util_bb_print(buffer, bmax, "", "", bb) : 0; \
             ap_log_cerror(APLOG_MARK, (level), rv, (c), \
                           "BEAM[%s,%s%sdata=%ld,buckets(send/consumed)=%d/%d]: %s %s", \

--- a/modules/http2/h2_c1_io.c
+++ b/modules/http2/h2_c1_io.c
@@ -63,7 +63,7 @@ static void h2_c1_io_bb_log(conn_rec *c, int stream_id, int level,
 {
     char buffer[16 * 1024];
     const char *line = "(null)";
-    int bmax = sizeof(buffer)/sizeof(buffer[0]);
+    int bmax = AP_ARRAY_LEN(buffer);
     int off = 0;
     apr_bucket *b;
     

--- a/modules/http2/h2_c2_filter.c
+++ b/modules/http2/h2_c2_filter.c
@@ -154,7 +154,7 @@ apr_status_t h2_c2_filter_request_in(ap_filter_t *f,
     do { \
         if (APLOG_C_IS_LEVEL((c),(level))) { \
             char buffer[4 * 1024]; \
-            apr_size_t len, bmax = sizeof(buffer)/sizeof(buffer[0]); \
+            apr_size_t len, bmax = AP_ARRAY_LEN(buffer); \
             len = h2_util_bb_print(buffer, bmax, "", "", (bb)); \
             ap_log_cerror(APLOG_MARK, (level), rv, (c), \
                           "FILTER[%s]: %s %s", \
@@ -800,7 +800,7 @@ static void make_chunk(conn_rec *c, h2_chunk_filter_t *fctx, apr_bucket_brigade 
     apr_bucket *b;
     apr_size_t len;
 
-    len = (apr_size_t)apr_snprintf(buffer, H2_ALEN(buffer),
+    len = (apr_size_t)apr_snprintf(buffer, AP_ARRAY_LEN(buffer),
                                    "%"APR_UINT64_T_HEX_FMT"\r\n", (apr_uint64_t)chunk_len);
     b = apr_bucket_heap_create(buffer, len, NULL, bb->bucket_alloc);
     APR_BUCKET_INSERT_BEFORE(first, b);

--- a/modules/http2/h2_protocol.c
+++ b/modules/http2/h2_protocol.c
@@ -77,7 +77,7 @@ static const char *h2_err_descr[] = {
 
 const char *h2_protocol_err_description(unsigned int h2_error)
 {
-    if (h2_error < (sizeof(h2_err_descr)/sizeof(h2_err_descr[0]))) {
+    if (h2_error < (AP_ARRAY_LEN(h2_err_descr))) {
         return h2_err_descr[h2_error];
     }
     return "unknown http/2 error code";
@@ -395,7 +395,7 @@ static const char *RFC7540_names[] = {
     "SSL3_CK_SCSV",                     /* TLS_EMPTY_RENEGOTIATION_INFO_SCSV */
     "SSL3_CK_FALLBACK_SCSV"
 };
-static size_t RFC7540_names_LEN = sizeof(RFC7540_names)/sizeof(RFC7540_names[0]);
+static size_t RFC7540_names_LEN = AP_ARRAY_LEN(RFC7540_names);
 
 
 static apr_hash_t *BLCNames;

--- a/modules/http2/h2_proxy_session.c
+++ b/modules/http2/h2_proxy_session.c
@@ -265,7 +265,7 @@ static int on_frame_recv(nghttp2_session *ngh2, const nghttp2_frame *frame,
     if (APLOGcdebug(session->c)) {
         char buffer[256];
         
-        h2_proxy_util_frame_print(frame, buffer, sizeof(buffer)/sizeof(buffer[0]));
+        h2_proxy_util_frame_print(frame, buffer, AP_ARRAY_LEN(buffer));
         ap_log_cerror(APLOG_MARK, APLOG_DEBUG, 0, session->c, APLOGNO(03341)
                       "h2_proxy_session(%s): recv FRAME[%s]",
                       session->id, buffer);
@@ -343,7 +343,7 @@ static int before_frame_send(nghttp2_session *ngh2,
     if (APLOGcdebug(session->c)) {
         char buffer[256];
 
-        h2_proxy_util_frame_print(frame, buffer, sizeof(buffer)/sizeof(buffer[0]));
+        h2_proxy_util_frame_print(frame, buffer, AP_ARRAY_LEN(buffer));
         ap_log_cerror(APLOG_MARK, APLOG_DEBUG, 0, session->c, APLOGNO(03343)
                       "h2_proxy_session(%s): sent FRAME[%s]",
                       session->id, buffer);
@@ -801,7 +801,7 @@ static apr_status_t session_start(h2_proxy_session *session)
     settings[1].value = (1 << session->window_bits_stream) - 1;
     
     rv = nghttp2_submit_settings(session->ngh2, NGHTTP2_FLAG_NONE, settings, 
-                                 H2_ALEN(settings));
+                                 AP_ARRAY_LEN(settings));
     
     /* If the connection window is larger than our default, trigger a WINDOW_UPDATE */
     add_conn_window = ((1 << session->window_bits_connection) - 1 -

--- a/modules/http2/h2_proxy_session.h
+++ b/modules/http2/h2_proxy_session.h
@@ -17,8 +17,6 @@
 #ifndef h2_proxy_session_h
 #define h2_proxy_session_h
 
-#define H2_ALEN(a)          (sizeof(a)/sizeof((a)[0]))
-
 #include <nghttp2/nghttp2.h>
 
 struct h2_proxy_iqueue;

--- a/modules/http2/h2_proxy_util.c
+++ b/modules/http2/h2_proxy_util.c
@@ -478,7 +478,7 @@ typedef struct {
 } literal;
 
 #define H2_DEF_LITERAL(n)   { (n), (sizeof(n)-1) }
-#define H2_LIT_ARGS(a)      (a),H2_ALEN(a)
+#define H2_LIT_ARGS(a)      (a),AP_ARRAY_LEN(a)
 
 static literal IgnoredRequestHeaders[] = {
     H2_DEF_LITERAL("upgrade"),

--- a/modules/http2/h2_session.c
+++ b/modules/http2/h2_session.c
@@ -219,7 +219,7 @@ static int on_invalid_frame_recv_cb(nghttp2_session *ngh2,
     if (APLOGcdebug(session->c1)) {
         char buffer[256];
         
-        h2_util_frame_print(frame, buffer, sizeof(buffer)/sizeof(buffer[0]));
+        h2_util_frame_print(frame, buffer, AP_ARRAY_LEN(buffer));
         ap_log_cerror(APLOG_MARK, APLOG_DEBUG, 0, session->c1,
                       H2_SSSN_LOG(APLOGNO(03063), session, 
                       "recv invalid FRAME[%s], frames=%ld/%ld (r/s)"),
@@ -352,7 +352,7 @@ static int on_frame_recv_cb(nghttp2_session *ng2s,
     if (APLOGcdebug(session->c1)) {
         char buffer[256];
 
-        h2_util_frame_print(frame, buffer, sizeof(buffer)/sizeof(buffer[0]));
+        h2_util_frame_print(frame, buffer, AP_ARRAY_LEN(buffer));
         if (stream) {
             ap_log_cerror(APLOG_MARK, APLOG_DEBUG, 0, session->c1,
                           H2_STRM_LOG(APLOGNO(10302), stream,
@@ -450,7 +450,7 @@ static int on_frame_recv_cb(nghttp2_session *ng2s,
                 char buffer[256];
                 
                 h2_util_frame_print(frame, buffer,
-                                    sizeof(buffer)/sizeof(buffer[0]));
+                                    AP_ARRAY_LEN(buffer));
                 ap_log_cerror(APLOG_MARK, APLOG_TRACE2, 0, session->c1,
                               H2_SSSN_MSG(session, "on_frame_rcv %s"), buffer);
             }
@@ -600,7 +600,7 @@ static int on_frame_send_cb(nghttp2_session *ngh2,
     if (APLOGcdebug(session->c1)) {
         char buffer[256];
         
-        h2_util_frame_print(frame, buffer, sizeof(buffer)/sizeof(buffer[0]));
+        h2_util_frame_print(frame, buffer, AP_ARRAY_LEN(buffer));
         if (stream) {
             ap_log_cerror(APLOG_MARK, APLOG_DEBUG, 0, session->c1,
                           H2_STRM_LOG(APLOGNO(10303), stream,
@@ -635,7 +635,7 @@ static int on_frame_not_send_cb(nghttp2_session *ngh2,
     char buffer[256];
 
     stream = get_stream(session, stream_id);
-    h2_util_frame_print(frame, buffer, sizeof(buffer)/sizeof(buffer[0]));
+    h2_util_frame_print(frame, buffer, AP_ARRAY_LEN(buffer));
     ap_log_cerror(APLOG_MARK, APLOG_ERR, 0, session->c1,
                   H2_SSSN_LOG(APLOGNO(), session,
                   "not sent FRAME[%s], error %d: %s"),

--- a/modules/http2/h2_stream.c
+++ b/modules/http2/h2_stream.c
@@ -156,12 +156,12 @@ static int on_frame(h2_stream_state_t state, int frame_type,
 
 static int on_frame_send(h2_stream_state_t state, int frame_type)
 {
-    return on_frame(state, frame_type, trans_on_send, H2_ALEN(trans_on_send));
+    return on_frame(state, frame_type, trans_on_send, AP_ARRAY_LEN(trans_on_send));
 }
 
 static int on_frame_recv(h2_stream_state_t state, int frame_type)
 {
-    return on_frame(state, frame_type, trans_on_recv, H2_ALEN(trans_on_recv));
+    return on_frame(state, frame_type, trans_on_recv, AP_ARRAY_LEN(trans_on_recv));
 }
 
 static int on_event(h2_stream* stream, h2_stream_event_t ev)
@@ -170,7 +170,7 @@ static int on_event(h2_stream* stream, h2_stream_event_t ev)
     if (stream->monitor && stream->monitor->on_event) {
         stream->monitor->on_event(stream->monitor->ctx, stream, ev);
     }
-    if (ev < H2_ALEN(trans_on_event)) {
+    if (ev < AP_ARRAY_LEN(trans_on_event)) {
         return on_map(stream->state, trans_on_event[ev]);
     }
     return stream->state;
@@ -189,7 +189,7 @@ static void H2_STREAM_OUT_LOG(int lvl, h2_stream *s, const char *tag)
     if (APLOG_C_IS_LEVEL(s->session->c1, lvl)) {
         conn_rec *c = s->session->c1;
         char buffer[4 * 1024];
-        apr_size_t len, bmax = sizeof(buffer)/sizeof(buffer[0]);
+        apr_size_t len, bmax = AP_ARRAY_LEN(buffer);
         
         len = h2_util_bb_print(buffer, bmax, tag, "", s->out_buffer);
         ap_log_cerror(APLOG_MARK, lvl, 0, c, 

--- a/modules/http2/h2_util.c
+++ b/modules/http2/h2_util.c
@@ -1530,7 +1530,7 @@ apr_status_t h2_res_create_ngheader(h2_ngheader **ph, apr_pool_t *p,
         apr_psprintf(p, "%d", response->status)
     };
     return ngheader_create(ph, p, is_unsafe(response),
-                           H2_ALEN(keys), keys, values, response->headers);
+                           AP_ARRAY_LEN(keys), keys, values, response->headers);
 }
 
 #else /* AP_HAS_RESPONSE_BUCKETS */
@@ -1558,7 +1558,7 @@ apr_status_t h2_res_create_ngheader(h2_ngheader **ph, apr_pool_t *p,
         apr_psprintf(p, "%d", headers->status)
     };
     return ngheader_create(ph, p, is_unsafe(headers),
-                           H2_ALEN(keys), keys, values, headers->headers);
+                           AP_ARRAY_LEN(keys), keys, values, headers->headers);
 }
 
 #endif /* else AP_HAS_RESPONSE_BUCKETS */
@@ -1585,7 +1585,7 @@ apr_status_t h2_req_create_ngheader(h2_ngheader **ph, apr_pool_t *p,
     ap_assert(req->path);
     ap_assert(req->method);
 
-    return ngheader_create(ph, p, 0, H2_ALEN(keys), keys, values, req->headers);
+    return ngheader_create(ph, p, 0, AP_ARRAY_LEN(keys), keys, values, req->headers);
 }
 
 /*******************************************************************************
@@ -1599,7 +1599,7 @@ typedef struct {
 } literal;
 
 #define H2_DEF_LITERAL(n)   { (n), (sizeof(n)-1) }
-#define H2_LIT_ARGS(a)      (a),H2_ALEN(a)
+#define H2_LIT_ARGS(a)      (a),AP_ARRAY_LEN(a)
 
 static literal IgnoredRequestHeaders[] = {
     H2_DEF_LITERAL("upgrade"),

--- a/modules/http2/h2_util.h
+++ b/modules/http2/h2_util.h
@@ -458,7 +458,7 @@ if (APLOG_C_IS_LEVEL(c, level)) { \
     do { \
         char buffer[4 * 1024]; \
         const char *line = "(null)"; \
-        apr_size_t len, bmax = sizeof(buffer)/sizeof(buffer[0]); \
+        apr_size_t len, bmax = AP_ARRAY_LEN(buffer); \
         len = h2_util_bb_print(buffer, bmax, (tag), "", (bb)); \
         ap_log_cerror(APLOG_MARK, level, 0, (c), "bb_dump(%ld): %s", \
             ((c)->master? (c)->master->id : (c)->id), (len? buffer : line)); \

--- a/modules/http2/mod_http2.c
+++ b/modules/http2/mod_http2.c
@@ -306,11 +306,6 @@ static h2_var_def H2_VARS[] = {
     { "H2_STREAM_TAG",       val_H2_STREAM_TAG, 1 },
 };
 
-#ifndef H2_ALEN
-#define H2_ALEN(a)          (sizeof(a)/sizeof((a)[0]))
-#endif
-
-
 static int http2_is_h2(conn_rec *c)
 {
     return h2_conn_ctx_get(c->master? c->master : c) != NULL;
@@ -321,7 +316,7 @@ static char *http2_var_lookup(apr_pool_t *p, server_rec *s,
 {
     unsigned int i;
     /* If the # of vars grow, we need to put definitions in a hash */
-    for (i = 0; i < H2_ALEN(H2_VARS); ++i) {
+    for (i = 0; i < AP_ARRAY_LEN(H2_VARS); ++i) {
         h2_var_def *vdef = &H2_VARS[i];
         if (!strcmp(vdef->name, name)) {
             h2_conn_ctx_t *ctx = (r? h2_conn_ctx_get(c) :
@@ -338,7 +333,7 @@ static int h2_h2_fixups(request_rec *r)
         h2_conn_ctx_t *ctx = h2_conn_ctx_get(r->connection);
         unsigned int i;
 
-        for (i = 0; ctx && i < H2_ALEN(H2_VARS); ++i) {
+        for (i = 0; ctx && i < AP_ARRAY_LEN(H2_VARS); ++i) {
             h2_var_def *vdef = &H2_VARS[i];
             if (vdef->subprocess) {
                 apr_table_setn(r->subprocess_env, vdef->name, 

--- a/modules/md/md_acme_authz.c
+++ b/modules/md/md_acme_authz.c
@@ -38,6 +38,7 @@
 
 #include "md_acme.h"
 #include "md_acme_authz.h"
+#include "ap_config.h"
 
 md_acme_authz_t *md_acme_authz_create(apr_pool_t *p)
 {
@@ -568,7 +569,7 @@ static const cha_type CHA_TYPES[] = {
     { MD_AUTHZ_TYPE_TLSALPN01,  cha_tls_alpn_01_setup,  cha_teardown_dir },
     { MD_AUTHZ_TYPE_DNS01,      cha_dns_01_setup,       cha_dns_01_teardown },
 };
-static const apr_size_t CHA_TYPES_LEN = (sizeof(CHA_TYPES)/sizeof(CHA_TYPES[0]));
+static const apr_size_t CHA_TYPES_LEN = (AP_ARRAY_LEN(CHA_TYPES));
 
 typedef struct {
     apr_pool_t *p;

--- a/modules/md/md_store.c
+++ b/modules/md/md_store.c
@@ -32,6 +32,7 @@
 #include "md_json.h"
 #include "md_store.h"
 #include "md_util.h"
+#include "ap_config.h"
 
 /**************************************************************************************************/
 /* generic callback handling */
@@ -61,7 +62,7 @@ static const char *GROUP_NAME[] = {
 
 const char *md_store_group_name(unsigned int group)
 {
-    if (group < sizeof(GROUP_NAME)/sizeof(GROUP_NAME[0])) {
+    if (group < AP_ARRAY_LEN(GROUP_NAME)) {
         return GROUP_NAME[group];
     }
     return "UNKNOWN";

--- a/modules/md/md_store_fs.c
+++ b/modules/md/md_store_fs.c
@@ -34,6 +34,7 @@
 #include "md_store_fs.h"
 #include "md_util.h"
 #include "md_version.h"
+#include "ap_config.h"
 
 /**************************************************************************************************/
 /* file system based implementation of md_store_t */
@@ -376,7 +377,7 @@ apr_status_t md_store_fs_group_perms_set(md_store_t *store, md_store_group_t gro
 {
     md_store_fs_t *s_fs = FS_STORE(store);
     
-    if (group >= (sizeof(s_fs->group_perms)/sizeof(s_fs->group_perms[0]))) {
+    if (group >= (AP_ARRAY_LEN(s_fs->group_perms))) {
         return APR_ENOTIMPL;
     }
     s_fs->group_perms[group].file = file_perms;
@@ -395,7 +396,7 @@ apr_status_t md_store_fs_set_event_cb(struct md_store_t *store, md_store_fs_cb *
 
 static const perms_t *gperms(md_store_fs_t *s_fs, md_store_group_t group)
 {
-    if (group >= (sizeof(s_fs->group_perms)/sizeof(s_fs->group_perms[0]))
+    if (group >= (AP_ARRAY_LEN(s_fs->group_perms))
         || !s_fs->group_perms[group].dir) {
         return &s_fs->def_perms;
     }

--- a/modules/md/md_util.c
+++ b/modules/md/md_util.c
@@ -32,6 +32,7 @@
 #include "md.h"
 #include "md_log.h"
 #include "md_util.h"
+#include "ap_config.h"
 
 /**************************************************************************************************/
 /* pool utils */
@@ -477,7 +478,7 @@ apr_status_t md_text_fread8k(const char **ptext, apr_pool_t *p, const char *fpat
 
     *ptext = NULL;
     if (APR_SUCCESS == (rv = apr_file_open(&f, fpath, APR_FOPEN_READ, 0, p))) {
-        apr_size_t blen = sizeof(buffer)/sizeof(buffer[0]) - 1;
+        apr_size_t blen = AP_ARRAY_LEN(buffer) - 1;
         rv = apr_file_read_full(f, buffer, blen, &blen);
         if (APR_SUCCESS == rv || APR_STATUS_IS_EOF(rv)) {
             *ptext = apr_pstrndup(p, buffer, blen);

--- a/modules/md/mod_md.c
+++ b/modules/md/mod_md.c
@@ -162,7 +162,7 @@ static apr_status_t notify(md_job_t *job, const char *reason,
     int i;
 
     log_msg_reason = apr_psprintf(p, "message-%s", reason);
-    for (i = 0; i < (int)(sizeof(notify_rates)/sizeof(notify_rates[0])); ++i) {
+    for (i = 0; i < (int)(AP_ARRAY_LEN(notify_rates)); ++i) {
         if (!strcmp(reason, notify_rates[i].reason)) {
             min_interim = notify_rates[i].min_interim;
         }

--- a/modules/md/mod_md_status.c
+++ b/modules/md/mod_md_status.c
@@ -720,14 +720,14 @@ static int add_md_row(void *baton, apr_size_t index, md_json_t *mdj)
 
     if (HTML_STATUS(ctx)) {
         apr_brigade_printf(ctx->bb, NULL, NULL, "<tr class=\"%s\">", (index % 2)? "odd" : "even");
-        for (i = 0; i < (int)(sizeof(status_infos)/sizeof(status_infos[0])); ++i) {
+        for (i = 0; i < (AP_ARRAY_LEN(status_infos)); ++i) {
             apr_brigade_puts(ctx->bb, NULL, NULL, "<td>");
             add_status_cell(ctx, mdj, &status_infos[i]);
             apr_brigade_puts(ctx->bb, NULL, NULL, "</td>");
         }
         apr_brigade_puts(ctx->bb, NULL, NULL, "</tr>");
     } else {
-        for (i = 0; i < (int)(sizeof(status_infos)/sizeof(status_infos[0])); ++i) {
+        for (i = 0; i < (AP_ARRAY_LEN(status_infos)); ++i) {
             ctx->prefix = apr_pstrcat(ctx->p, prefix, apr_psprintf(ctx->p, "[%" APR_SIZE_T_FMT "]", index), NULL);
             add_status_cell(ctx, mdj, &status_infos[i]);
             ctx->prefix = prefix;
@@ -791,7 +791,7 @@ int md_domains_status_hook(request_rec *r, int flags)
             ap_log_rerror(APLOG_MARK, APLOG_TRACE1, 0, r, "html managed domain status table");
             apr_brigade_puts(ctx.bb, NULL, NULL,
                              "<hr>\n<h3>Managed Certificates</h3>\n<table class='md_status'><thead><tr>\n");
-            for (i = 0; i < (int)(sizeof(status_infos)/sizeof(status_infos[0])); ++i) {
+            for (i = 0; i < (AP_ARRAY_LEN(status_infos)); ++i) {
                 si_add_header(&ctx, &status_infos[i]);
             }
             apr_brigade_puts(ctx.bb, NULL, NULL, "</tr>\n</thead><tbody>");

--- a/modules/metadata/mod_mime_magic.c
+++ b/modules/metadata/mod_mime_magic.c
@@ -2076,22 +2076,20 @@ static const struct {
     },
 };
 
-#define ncompr (sizeof(compr) / sizeof(compr[0]))
-
 static int zmagic(request_rec *r, unsigned char *buf, apr_size_t nbytes)
 {
     unsigned char *newbuf;
     int newsize;
     int i;
 
-    for (i = 0; i < ncompr; i++) {
+    for (i = 0; i < AP_ARRAY_LEN(compr); i++) {
         if (nbytes < compr[i].maglen)
             continue;
         if (memcmp(buf, compr[i].magic, compr[i].maglen) == 0)
             break;
     }
 
-    if (i == ncompr)
+    if (i == AP_ARRAY_LEN(compr))
         return 0;
 
     if ((newsize = uncompress(r, i, &newbuf, HOWMANY)) > 0) {

--- a/modules/ssl/ssl_engine_init.c
+++ b/modules/ssl/ssl_engine_init.c
@@ -136,7 +136,7 @@ static void init_dh_params(void)
 {
     unsigned n;
 
-    for (n = 0; n < sizeof(dhparams)/sizeof(dhparams[0]); n++)
+    for (n = 0; n < AP_ARRAY_LEN(dhparams); n++)
         dhparams[n].dh = make_dh_params(dhparams[n].prime);
 }
 
@@ -147,7 +147,7 @@ static void free_dh_params(void)
     /* DH_free() is a noop for a NULL parameter, so these are harmless
      * in the (unexpected) case where these variables are already
      * NULL. */
-    for (n = 0; n < sizeof(dhparams)/sizeof(dhparams[0]); n++) {
+    for (n = 0; n < AP_ARRAY_LEN(dhparams); n++) {
         DH_free(dhparams[n].dh);
         dhparams[n].dh = NULL;
     }
@@ -164,7 +164,7 @@ DH *modssl_get_dh_params(unsigned keylen)
 {
     unsigned n;
 
-    for (n = 0; n < sizeof(dhparams)/sizeof(dhparams[0]); n++)
+    for (n = 0; n < AP_ARRAY_LEN(dhparams); n++)
         if (keylen >= dhparams[n].min)
             return dhparams[n].dh;
         

--- a/server/mpm/event/event.c
+++ b/server/mpm/event/event.c
@@ -2701,7 +2701,7 @@ static void setup_threads_runtime(void)
      */
     pollset_flags = APR_POLLSET_THREADSAFE | APR_POLLSET_NOCOPY |
                     APR_POLLSET_WAKEABLE | APR_POLLSET_NODEFAULT;
-    for (i = 0; i < sizeof(good_methods) / sizeof(good_methods[0]); i++) {
+    for (i = 0; i < AP_ARRAY_LEN(good_methods); i++) {
         rv = apr_pollset_create_ex(&event_pollset, pollset_size + 1, pruntime,
                                    pollset_flags, good_methods[i]);
         if (rv == APR_SUCCESS) {

--- a/server/mpm/motorz/motorz.c
+++ b/server/mpm/motorz/motorz.c
@@ -529,7 +529,7 @@ static int motorz_setup_pollset(motorz_core_t *mz)
     apr_status_t rv;
     int good_methods[] = {APR_POLLSET_KQUEUE, APR_POLLSET_PORT, APR_POLLSET_EPOLL};
 
-    for (i = 0; i < sizeof(good_methods) / sizeof(good_methods[0]); i++) {
+    for (i = 0; i < AP_ARRAY_LEN(good_methods); i++) {
         rv = apr_pollset_create_ex(&mz->pollset,
                                   512,
                                   mz->pool,

--- a/server/mpm/simple/simple_run.c
+++ b/server/mpm/simple/simple_run.c
@@ -260,7 +260,7 @@ static int simple_setup_pollcb(simple_core_t * sc)
     apr_status_t rv;
     int good_methods[] = {APR_POLLSET_KQUEUE, APR_POLLSET_PORT, APR_POLLSET_EPOLL};
 
-    for (i = 0; i < sizeof(good_methods) / sizeof(good_methods[0]); i++) {
+    for (i = 0; i < AP_ARRAY_LEN(good_methods); i++) {
         /* pqXXXXX: make size of pollcb configrable or dynamic */
         rv = apr_pollcb_create_ex(&sc->pollcb, 512,
                                   sc->pool, APR_POLLSET_NODEFAULT, good_methods[i]);


### PR DESCRIPTION
This PR is based on [PR #401](https://github.com/apache/httpd/pull/401), which proposed 
adding the `ARRAY_LEN` macro to improve code readability and maintainability. The original 
PR was abandoned and had conflicts, so I have rebased it, resolved issues, and integrated 
the changes.