### PR TITLE
🌙 Native light/dark mode support for Apache error pages

### DIFF
--- a/modules/http/http_protocol.c
+++ b/modules/http/http_protocol.c
@@ -1357,8 +1357,11 @@ AP_DECLARE(void) ap_send_error_response(request_rec *r, int recursive_error)
 
         ap_rvputs_proto_in_ascii(r,
                   DOCTYPE_HTML_4_01
-                  "<html><head>\n<title>", title,
-                  "</title>\n</head><body>\n<h1>", h1, "</h1>\n",
+                  "<html>\n<head>\n"
+                  "<meta name=\"color-scheme\" content=\"light dark\">\n"
+                  "<title>", title, "</title>\n"
+                  "</head>\n<body>\n"
+                  "<h1>", h1, "</h1>\n",
                   NULL);
 
         ap_rvputs_proto_in_ascii(r,


### PR DESCRIPTION
This adds native support for light and dark mode on Apache’s default error pages. 

`<meta name="color-scheme" content="light dark"> `

The tag is now included in the head, so modern browsers can automatically switch based on the user’s system preference.

No extra styling is needed—just letting browsers/OS do their thing.

 P.S. As example how it's working on nginx 404 Demo page here - https://nginx-light-dark-404.vercel.app/404.html Just switch OS between light/dark mode
 
 Original PR https://github.com/nginx/nginx/pull/567