### PR TITLE
mod_ssl: Check the SSLProtocol directive when loading the configuration

### DIFF
--- a/modules/ssl/ssl_engine_config.c
+++ b/modules/ssl/ssl_engine_config.c
@@ -1483,6 +1483,10 @@ const char *ssl_cmd_SSLOptions(cmd_parms *cmd,
         }
     }
 
+    if (*options == SSL_PROTOCOL_NONE) {
+        return "SSLProtocol: No SSL protocols available";
+    }
+
     return NULL;
 }
 


### PR DESCRIPTION
Previously, the SSLProtocol directive was checked at runtime. Apache quit if the directive contained an invalid combination of protocols, and logged the message "AH02231: No SSL protocols available [hint: SSLProtocol]".

With this change, most invalid SSLProtocol directives are detected when checking the configuration, e.g. with "httpd -t -f httpd.conf".

Examples of invalid protocol combinations that are catched:
* SSLProtocol "-TLSv1"
* SSLProtocol "-all"
* SSLProtocol "TLSv1.2 -TLSv1.2"