### PR TITLE
mod_ssl: directly abort connection when receiving HTTP requests

### DIFF
--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -609,8 +609,6 @@ typedef struct {
     int disabled;
     enum {
         NON_SSL_OK = 0,        /* is SSL request, or error handling completed */
-        NON_SSL_SEND_REQLINE,  /* Need to send the fake request line */
-        NON_SSL_SEND_HDR_SEP,  /* Need to send the header separator */
         NON_SSL_SET_ERROR_MSG  /* Need to set the error message */
     } non_ssl_request;
 


### PR DESCRIPTION
Shutdown the ssl filter and abort the connection instead of disabling is and pass a fake request to the core handler. The current implementation allows to exhaust workers by sendin HTTP request to HTTPS port. Additionally the Openssl lib doesn't detect the http methods PATCH, DELETE, OPTIONS and TRACE. So the current implementation only works partially. See openssl PR: https://github.com/openssl/openssl/pull/26968