### PR TITLE
2.4: Add API exposing the DavBasePath setting for use by DAV repository

### DIFF
--- a/changes-entries/dav-get-base-path.txt
+++ b/changes-entries/dav-get-base-path.txt
@@ -1,0 +1,2 @@
+  *) mod_dav: Add API to expose DavBasePath setting.  [Joe Orton]
+

--- a/include/ap_mmn.h
+++ b/include/ap_mmn.h
@@ -608,6 +608,7 @@
  * 20120211.136 (2.4.63-dev) Add wait_io field to struct process_score
  * 20120211.137 (2.4.63-dev) Add AP_MPMQ_CAN_WAITIO
  * 20120211.138 (2.4.63-dev) Add is_host_matchable to proxy_worker_shared
+ * 20120211.139 (2.4.63-dev) Add dav_get_base_path() to mod_dav
  */
 
 #define MODULE_MAGIC_COOKIE 0x41503234UL /* "AP24" */
@@ -615,7 +616,7 @@
 #ifndef MODULE_MAGIC_NUMBER_MAJOR
 #define MODULE_MAGIC_NUMBER_MAJOR 20120211
 #endif
-#define MODULE_MAGIC_NUMBER_MINOR 138                 /* 0...n */
+#define MODULE_MAGIC_NUMBER_MINOR 139                 /* 0...n */
 
 /**
  * Determine if the server's current MODULE_MAGIC_NUMBER is at least a

--- a/modules/dav/main/mod_dav.c
+++ b/modules/dav/main/mod_dav.c
@@ -250,6 +250,13 @@ DAV_DECLARE(const dav_hooks_search *) dav_get_search_hooks(request_rec *r)
     return dav_get_provider(r)->search;
 }
 
+DAV_DECLARE(const char *) dav_get_base_path(request_rec *r)
+{
+    dav_dir_conf *conf = ap_get_module_config(r->per_dir_config, &dav_module);
+
+    return conf && conf->base ? conf->base : NULL;
+}
+
 /*
  * Command handler for the DAV directive, which is TAKE1.
  */

--- a/modules/dav/main/mod_dav.h
+++ b/modules/dav/main/mod_dav.h
@@ -430,6 +430,11 @@ typedef struct dav_locktoken dav_locktoken;
 DAV_DECLARE(dav_error *) dav_get_resource(request_rec *r, int label_allowed,
                                           int use_checked_in, dav_resource **res_p);
 
+/*
+** If DavBasePath is configured for the request location, return the
+** configured path, otherwise NULL.
+*/
+DAV_DECLARE(const char *) dav_get_base_path(request_rec *r);
 
 /* --------------------------------------------------------------------
 **


### PR DESCRIPTION
```
Add API exposing the DavBasePath setting for use by DAV repository
backend modules (mod_dav_svn needs this for POST method handling).

* modules/dav/main/mod_dav.c (dav_get_base_path): New function.

* include/ap_mmn.h: Bump MMN minor.
```