### PR TITLE
mod_asis: Fix the log level of the message AH01236

### DIFF
--- a/modules/generators/mod_asis.c
+++ b/modules/generators/mod_asis.c
@@ -99,7 +99,7 @@ static int asis_handler(request_rec *r)
         APR_BRIGADE_INSERT_TAIL(bb, b);
         rv = ap_pass_brigade(r->output_filters, bb);
         if (rv != APR_SUCCESS) {
-            ap_log_rerror(APLOG_MARK, APLOG_ERR, rv, r, APLOGNO(01236)
+            ap_log_rerror(APLOG_MARK, APLOG_DEBUG, rv, r, APLOGNO(01236)
                           "mod_asis: ap_pass_brigade failed for file %s", r->filename);
             return AP_FILTER_ERROR;
         }


### PR DESCRIPTION
Change the log level from ERROR to DEBUG.

The message "mod_asis: ap_pass_brigade failed for file ..." was logged with the level ERROR. This log level is inappropriate here, because a client can trigger this log message by aborting the request.

Most other modules don't log at all or use the log level DEBUG when ap_pass_brigade() fails.