### PR TITLE
mod_md: change types of fields of ocsp_summary_ctx_t

### DIFF
--- a/modules/md/md_ocsp.c
+++ b/modules/md/md_ocsp.c
@@ -929,9 +929,9 @@ apr_status_t md_ocsp_remove_responses_older_than(md_ocsp_reg_t *reg, apr_pool_t 
 typedef struct {
     apr_pool_t *p;
     md_ocsp_reg_t *reg;
-    int good;
-    int revoked;
-    int unknown;
+    unsigned good;
+    unsigned revoked;
+    unsigned unknown;
 } ocsp_summary_ctx_t;
 
 static int add_to_summary(void *baton, const void *key, apr_ssize_t klen, const void *val)


### PR DESCRIPTION
The number of members in ostat_by_id may be up to UINT_MAX and there are no guarantees that all types of members (good, revoked or unknown) are present. An integer overflow may also occur in md_ocsp_get_summary() when they are summed as ints.

Change types of good, revoked and unknown to unsigned.

Found by Linux Verification Center (linuxtesting.org) with SVACE.