### PR TITLE
mod_ssl: Accept expired client certs with optional_no_ca mode.

### DIFF
--- a/changes-entries/pr60028.txt
+++ b/changes-entries/pr60028.txt
@@ -1,0 +1,3 @@
+  *) mod_ssl: For "SSLVerifyClient optional_no_ca" mode, accept
+     expired client certificates.  PR 60028
+     [Naveen Albert <apache2 phreaknet.org>]

--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -468,7 +468,8 @@ typedef enum {
     || (errnum == X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN) \
     || (errnum == X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY) \
     || (errnum == X509_V_ERR_CERT_UNTRUSTED) \
-    || (errnum == X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE))
+    || (errnum == X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE) \
+    || (errnum == X509_V_ERR_CERT_HAS_EXPIRED))
 
 /**
   * CRL checking mask (mode | flags)


### PR DESCRIPTION
```
* modules/ssl/ssl_private.h (ssl_verify_error_is_optional): Add X509_V_ERR_CERT_HAS_EXPIRED to the list of error exceptions permitted for "optional_no_ca" mode.

Submitted by: Naveen Albert <apache2 phreaknet.org>
PR: 60028
Github: closes #509


git-svn-id: https://svn.apache.org/repos/asf/httpd/httpd/trunk@1926714 13f79535-47bb-0310-9956-ffa450edef68
```