### PR TITLE
Remove restriction preventing expressions in Redirects outside of <Location>

### DIFF
--- a/modules/mappers/mod_alias.c
+++ b/modules/mappers/mod_alias.c
@@ -301,11 +301,7 @@ static const char *add_redirect_internal(cmd_parms *cmd,
      * if we understand the first arg but have no second arg, we are dealing
      * with a status like "GONE" or a non-redirect status (e.g. 404, 503).
      */
-    if (!cmd->path) {
-        /* <Location> context only for now */
-        ;
-    }
-    else if ((grokarg1 > 0 && arg2 && !arg3) || (!grokarg1 && !arg2)) {
+    if ((grokarg1 > 0 && arg2 && !arg3) || (!grokarg1 && !arg2)) {
         const char *expr_err = NULL;
 
         url = grokarg1 ? arg2 : arg1;


### PR DESCRIPTION
Currently, it's not possible to use expression syntax like this in (say) .htaccess files:

 ```
<If "%{HTTPS} != 'on'">
 Redirect 301 https://%{HTTP_HOST}%{REQUEST_URI}
 </If>
```
You have to instead use a much uglier RewriteCond/RewriteRule.

The reason it doesn't work is not because the code doesn't exist, but because mod_alias.c restricts expressions in redirects to `<Location> context only for now`.

It's not clear why that restriction was/is needed. I asked if anyone knew the reason for it on the httpd dev mailing list in 2022, but nobody replied: https://lists.apache.org/thread/m72z147c3rffpk7goy7n0z66l7jw16lc

My company has been running this patch on many production servers for three years with no trouble. It allows the above example to work as expected from a .htaccess file, which seems generally useful and in accordance with the "ongoing effort to only use a single variant, called ap_expr, for all configuration directives".