### PR TITLE
Update pt-br manual to UTF-8 (trunk)

### DIFF
--- a/docs/manual/howto/htaccess.xml.pt-br
+++ b/docs/manual/howto/htaccess.xml.pt-br
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <!DOCTYPE manualpage SYSTEM "../style/manualpage.dtd">
 <?xml-stylesheet type="text/xsl" href="../style/manual.pt-br.xsl"?>
-<!-- English Revision: 151408:1741842 (outdated) -->
-
+<!-- Brazilian Portuguese translation : leonardolara -->
+<!-- English Revision: 1741842 -->
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
@@ -21,13 +21,13 @@
 -->
 
 <manualpage metafile="htaccess.xml.meta">
-<parentdocument href="./">How-To / Tutoriais</parentdocument>
+<parentdocument href="./">Como Fazer / Tutoriais</parentdocument>
 
-<title>Tutorial do Apache: arquivos .htaccess</title>
+<title>Tutorial do Servidor HTTP Apache: arquivos .htaccess</title>
 
 <summary>
-<p>Arquivos <code>.htaccess</code> oferecem um meio de fazer mudan&#231;as
- nas configura&#231;&#245;es por-diret&#243;rio.</p>
+<p>Arquivos <code>.htaccess</code> oferecem um meio de fazer alterações
+nas configurações para cada diretório.</p>
 </summary>
 
 <section id="related"><title>Arquivos .htaccess </title>
@@ -55,59 +55,60 @@
         </directivelist>
 
     </related>
+
+    <note>Deve-se evitar totalmente o uso de arquivos <code>.htaccess</code> se a configuração puder ser feita
+    diretamente no arquivo de configuração principal do servidor httpd. O uso de arquivos <code>.htaccess</code> reduz o desempenho do servidor HTTP Apache.
+    Qualquer diretiva que possa ser incluída em um arquivo <code>.htaccess</code> fica melhor em um bloco <directive module="core">Directory</directive>, já que terá o mesmo efeito com um desempenho melhor.</note>
 </section>
 
 <section id="what">
-<title>O que eles s&#227;o/Como us&#225;-los</title>
+<title>O que eles são/Como utilizá-los</title>
 
-    <p>Os arquivos <code>.htaccess</code> (ou "arquivos de
-    configura&#231;&#227;o distribu&#237;da") oferecem um meio de fazer mudan&#231;as nas
-    configura&#231;&#245;es por-diret&#243;rio. Um arquivo, contendo uma ou mais
-    diretrizes de configura&#231;&#245;es, &#233; colocado em um diret&#243;rio 
-    em particular, e as diretrizes se aplicam para aquele diret&#243;rio e todos 
-    os seu subdiret&#243;rios subseq&#252;entes.</p>
+    <p>Os arquivos <code>.htaccess</code> (ou "arquivos de configuração distribuídos")
+    oferecem um meio de fazer alterações nas configurações de cada diretório. Um
+    arquivo, contendo uma ou mais diretivas de configuração, é inserido em um
+    diretório de documentos em particular, e as diretivas se aplicam para esse
+    diretório e para todos os seus subdiretórios.</p>
 
-    <note><title>Nota:</title>
-      <p>Se voc&#234; quiser renomear o seu arquivo <code>.htaccess</code>
-      para outro nome, voc&#234; deve usar a diretriz <directive
-      module="core">AccessFileName</directive>. Por exemplo, se voc&#234;
-      prefere que o arquivo se chame <code>.config</code>, ent&#227;o voc&#234; 
-      pode adicionar a seguinte linha ao seu arquivo de configura&#231;&#227;o
-      do servidor:</p>
+    <note><title>Observação:</title>
+      <p>Se você quiser dar outro nome ao seu arquivo <code>.htaccess</code>,
+      pode alterar o nome do arquivo usando a diretiva <directive
+      module="core">AccessFileName</directive>. Por exemplo,
+      se preferir chamar o arquivo <code>.config</code>,
+      pode inserir o seguinte no arquivo de configuração do seu servidor:</p>
 
-      <example>
-        AccessFileName .config
-      </example>
+      <highlight language="config">
+AccessFileName ".config"
+      </highlight>
     </note>
 
-    <p>No geral, arquivos <code>.htaccess</code> usam a mesma sintaxe
+    <p>Em geral, arquivos <code>.htaccess</code> usam a mesma sintaxe
     que os <a href="../configuring.html#syntax">arquivos de
-    configura&#231;&#227;o principal</a>. O que voc&#234; pode colocar nesses
-    arquivos &#233; determinado pele diretriz <directive
-    module="core">AllowOverride</directive>. Essa diretriz especifica,
-    em categorias, quais diretrizes ser&#227;o aceitas caso sejam
-    encontradas em um arquivo <code>.htaccess</code>.  Se uma diretriz
-    for permitida em um arquivo <code>.htaccess</code>, a documenta&#231;&#227;o
-    para essa diretriz ir&#225; conter uma se&#231;&#227;o <em>Override</em>,
+    configuração principal</a>. O que pode ser colocado nesses arquivos é determinado pela
+    diretiva <directive module="core">AllowOverride</directive>. Esta
+    diretiva especifica, em categorias, quais diretivas serão
+    respeitadas caso sejam encontradas em um arquivo <code>.htaccess</code>.  Se uma
+    diretiva for permitida em um arquivo <code>.htaccess</code>, a
+    documentação para esta diretiva conterá uma seção Override,
     especificando que valor precisa estar em <directive
-    module="core">AllowOverride</directive> para que esta diretriz
-    seja permitida.</p>
+    module="core">AllowOverride</directive> para que esta
+    diretiva seja permitida.</p>
 
-    <p>Por exemplo, se voc&#234; procurar na documenta&#231;&#227;o pela diretriz
-    <directive module="core">AddDefaultCharset</directive>, voc&#234;
-    achar&#225; que ela &#233; permitida nos arquivos <code>.htaccess</code>.
-    (Veja a linha Contexto no sum&#225;rio das diretivas.) A
-    linha <a href="../mod/directive-dict.html#Context">Override</a> l&#234;
-    <code>FileInfo</code>. Ent&#227;o, voc&#234; deve ao menos ter
-    <code>AllowOverride FileInfo</code> para que essa diretriz seja
-    aceita nos arquivos <code>.htaccess</code>.</p>
+    <p>Por exemplo, se a documentação da diretiva <directive
+    module="core">AddDefaultCharset</directive> for consultada,
+    pode ser visto que ela é permitida em arquivos <code>.htaccess</code>
+    (consulte a linha Context no sumário da diretiva.) A linha <a
+    href="../mod/directive-dict.html#Context">Override</a> contém
+    <code>FileInfo</code>. Portanto, deve-se ter pelo menos
+    <code>AllowOverride FileInfo</code> para que esta diretiva seja
+    respeitada em arquivos <code>.htaccess</code>.</p>
 
     <example><title>Exemplo:</title>
       <table>
         <tr>
           <td><a
           href="../mod/directive-dict.html#Context">Contexto:</a></td>
-          <td>configura&#231;&#227;o do servidor, hospedeiros virtuais, diret&#243;rio, .htaccess</td>
+          <td>configuração do servidor, host virtual, diretório, .htaccess</td>
         </tr>
 
         <tr>
@@ -118,61 +119,59 @@
       </table>
     </example>
 
-    <p>Se voc&#234; estiver incerto se uma diretriz em particular &#233;
-    aceita em um arquivo <code>.htaccess</code>, procure na
-    documenta&#231;&#227;o por essa diretriz, e verifique a linha de
-    Contexto por ".htaccess".</p> </section>
+    <p>Se não houver certeza se uma diretiva em particular é permitida em um
+    arquivo <code>.htaccess</code>, consulte a documentação para esta
+    diretiva e verifique se a linha de Contexto contém ".htaccess".</p>
+</section>
 
-    <section id="when"><title>Quando (n&#227;o) usar arquivos .htaccess</title>
+<section id="when"><title>Quando (não) usar arquivos .htaccess</title>
 
-    <p>No geral, voc&#234; nunca deve usar arquivos <code>.htaccess</code>
-    a n&#227;o ser que voc&#234; n&#227;o tenha acesso ao arquivo de configura&#231;&#227;o
-    principal do servidor. Existe, por exemplo, um erro de concep&#231;&#227;o
-    que dita que a autentica&#231;&#227;o de usu&#225;rios sempre deve
-    ser feita usando os arquivos <code>.htaccess</code>. Esse
-    simplesmente n&#227;o &#233; o caso. Voc&#234; pode usar as configura&#231;&#245;es de
-    autentica&#231;&#227;o de usu&#225;rio no arquivo de configura&#231;&#227;o principal do
-    servidor, e isso &#233;, de fato, a maneira mais adequada de se fazer
-    as coisas.</p>
+    <p>Em geral, arquivos <code>.htaccess</code> só devem ser usados quando
+    não for possível o acesso ao arquivo de configuração principal do servidor. Há,
+    por exemplo, um equívoco comum de que a autenticação do usuário deve
+    sempre ser feita em arquivos <code>.htaccess</code> e, mais recentemente,
+    outro equívoco de que as diretivas <module>mod_rewrite</module>
+    devem ser inseridas em arquivos <code>.htaccess</code>. Este simplesmente não é
+    o caso. As configurações de autenticação do usuário podem ser colocadas na configuração principal do servidor
+    e esta é, de fato, a maneira preferida de fazer
+    as coisas. Da mesma forma, as diretivas <code>mod_rewrite</code> funcionam melhor,
+    em muitos aspectos, na configuração principal do servidor.</p>
 
-    <p>Arquivos <code>.htaccess</code> devem ser usados em casos onde
-    os provedores de conte&#250;do do site precisem fazer mudan&#231;as na
-    configura&#231;&#227;o do servidor por-diret&#243;rio, mas n&#227;o tem
-    acesso <em>root</em> ao sistema do servidor. Caso o administrador do 
-    servidor n&#227;o esteja disposto a fazer mudan&#231;as freq&#252;entes nas
-    configura&#231;&#245;es do servidor, &#233; desej&#225;vel permitir que os 
-    usu&#225;rios possam fazer essas mudan&#231;as atrav&#233;s de arquivos
-    <code>.htaccess</code> eles mesmos. Isso &#233; particularmente
-    verdade, por exemplo, em casos onde provedores est&#227;o fornecendo
-    m&#250;ltiplos sites para usu&#225;rios em apenas uma m&#225;quina, e querem que
-    seus usu&#225;rios possam alterar suas configura&#231;&#245;es.</p>
+    <p>Arquivos <code>.htaccess</code> devem ser usados ​​em casos em que os
+    provedores de conteúdo precisam fazer alterações de configuração no servidor
+    por diretório, mas não têm acesso de administrador no sistema do servidor.
+    Caso o administrador do servidor não queira fazer
+    alterações frequentes de configuração, pode ser desejável permitir
+    que usuários individuais façam essas alterações nos arquivos <code>.htaccess</code>
+    por si próprios. Isso é particularmente verdadeiro, por exemplo, em casos em que
+    ISPs hospedam sites de vários usuários em uma única máquina e desejam
+    que seus usuários possam alterar suas configurações.</p>
 
-    <p>No entanto, de modo geral, o uso de arquivos <code>.htaccess</code>
-    deve ser evitado quando poss&#237;vel. Quaisquer configura&#231;&#245;es 
-    que voc&#234; considerar acrescentar em um arquivo <code>.htaccess</code>, podem
-    ser efetivamente colocadas em uma se&#231;&#227;o <directive module="core"
-    type="section">Directory</directive> no arquivo principal de
-    configura&#231;&#227;o de seu servidor.</p>
+    <p>No entanto, em geral, o uso de arquivos <code>.htaccess</code> deve ser
+    evitado sempre que possível. Qualquer configuração que possa
+    ser colocada em um arquivo <code>.htaccess</code> pode ser feita com a mesma eficácia
+    em uma seção <directive module="core"
+    type="section">Directory</directive> no arquivo de configuração
+    do servidor principal.</p>
 
-    <p>Existem duas raz&#245;es principais para evitar o uso de arquivos
+    <p>Existem dois motivos principais para evitar o uso de arquivos
     <code>.htaccess</code>.</p>
 
-    <p>A primeira delas &#233; a performance. Quando <directive
-    module="core">AllowOverride</directive> &#233; configurado para
-    permitir o uso de arquivos <code>.htaccess</code>, o Apache procura
-    em todos diret&#243;rios por arquivos <code>.htaccess</code>.  
-    Logo, permitir arquivos <code>.htaccess</code> causa um impacto na 
-    performance, mesmo sem voc&#234; us&#225;-los de fato! Al&#233;m disso, 
-    o arquivo <code>.htaccess</code> &#233; carregado toda vez que um documento 
-    &#233; requerido.</p>
+    <p>O primeiro deles é o desempenho. Quando <directive
+    module="core">AllowOverride</directive> é configurado para
+    permitir o uso de arquivos <code>.htaccess</code>, o httpd pesquisará
+    em todos os diretórios por arquivos <code>.htaccess</code>. Logo,
+    permitir arquivos <code>.htaccess</code> causa um impacto no
+    desempenho, mesmo que eles nunca sejam realmente usados! Além disso, o
+    arquivo <code>.htaccess</code> é carregado toda vez que um documento
+    solicitado.</p>
 
-    <p>Al&#233;m disso, note que o Apache precisa procurar pelos arquivos
-    <code>.htaccess</code> em todos os diret&#243;rios superiores, para ter
-    o complemento total de todas as diretivas que devem ser
-    aplicadas. (Veja a se&#231;&#227;o <a href="#how">como as diretrizes s&#227;o
-    aplicadas</a>.) Ent&#227;o, se um arquivo de um diret&#243;rio
-    <code>/www/htdocs/example</code> &#233; requerido, o Apache precisa
-    procurar pelos seguintes arquivos:</p>
+    <p>Observe ainda que o httpd deve procurar por arquivos <code>.htaccess</code>
+    em todos os diretórios de nível superior, para ter um conjunto completo de
+    diretivas que ele deve aplicar (consulte a seção sobre <a href="#how">como
+    as diretivas são aplicadas</a>). Portanto, se um arquivo for solicitado de um
+    diretório <code>/www/htdocs/example</code>, o httpd deve procurar pelos
+    seguintes arquivos:</p>
 
     <example>
       /.htaccess<br />
@@ -181,216 +180,298 @@
       /www/htdocs/example/.htaccess
     </example>
 
-    <p>Assim, para cada acesso de arquivo fora desse diret&#243;rio,
-    existem 4 acessos ao sistema de arquivos adicionais, mesmo
-    que nenhum desses arquivos estejam presentes. (Note que esse
-    s&#243; ser&#225; o caso se os arquivos <code>.htaccess</code>
-    estiverem habilitados para <code>/</code>, o que
-    normalmente n&#227;o &#233; o verdade.)</p>
+    <p>E assim, para cada acesso a um arquivo fora desse diretório, há 4
+    acessos adicionais ao sistema de arquivos, mesmo que nenhum desses arquivos esteja
+    presente (observe que isso só seria o caso se os
+    arquivos <code>.htaccess</code> estivessem habilitados para <code>/</code>, o que
+    normalmente não é o caso).</p>
 
-    <p>A segunda considera&#231;&#227;o &#233; relativa &#224; seguran&#231;a. 
-    Voc&#234; est&#225; permitindo que os usu&#225;rios modifiquem as 
-    configura&#231;&#245;es do servidor, o que pode resultar em mudan&#231;as 
-    que podem fugir ao seu controle. Considere com cuidado se voc&#234; quer 
-    ou n&#227;o dar aos seus usu&#225;rios esses privil&#233;gios. Note tamb&#233;m 
-    que dar aos usu&#225;rios menos privil&#233;gios que eles precisam, acarreta em 
-    pedidos de suporte t&#233;cnico adicionais. Tenha certeza que voc&#234; comunicou
-    aos usu&#225;rios que n&#237;vel de privil&#233;gios voc&#234; os deu. 
-    Especificar exatamente o que voc&#234; configurou na diretriz <directive
-    module="core">AllowOverride</directive>, e direcion&#225;-los para a
-    documenta&#231;&#227;o relevante, ir&#225; poup&#225;-lo de muita confus&#227;o 
-    depois.</p>
+    <p>No caso das diretivas <directive
+    module="mod_rewrite">RewriteRule</directive>, no contexto
+    <code>.htaccess</code>, essas expressões regulares precisam ser
+    recompiladas a cada solicitação ao diretório, enquanto no contexto
+    de configuração do servidor principal, elas são compiladas uma vez e armazenadas em cache.
+    Além disso, as regras em si são mais complicadas, pois é preciso
+    contornar as restrições que vêm com o contexto por diretório
+    e <code>mod_rewrite</code>. Consulte o <a
+    href="../rewrite/intro.html#htaccess">Guia de Reescrita</a> para mais
+    detalhes sobre este assunto.</p>
 
-    <p>Perceba que &#233; exatamente equivalente colocar o arquivo
-    <code>.htaccess</code> em um diret&#243;rio
-    <code>/www/htdocs/example</code> contendo uma diretriz, e
-    adicionar a mesma diretriz em uma se&#231;&#227;o <em>Directory</em>
-    <code>&lt;Directory /www/htdocs/example&gt;</code> na configura&#231;&#227;o
-    principal do seu servidor:</p>
+    <p>A segunda consideração é de segurança. Está sendo permitindo
+    que os usuários modifiquem a configuração do servidor, o que pode resultar em alterações
+    sobre as quais não se tem controle. Considere cuidadosamente se deseja conceder
+    esse privilégio aos seus usuários. Observe também que conceder aos usuários menos
+    privilégios do que eles precisam resultará em solicitações adicionais de suporte
+    técnico. Certifique-se de informar claramente aos seus usuários qual o nível de
+    privilégios que você concedeu a eles. Especificar exatamente o que você definiu
+    em <directive module="core">AllowOverride</directive> e direcioná-los
+    para a documentação relevante evitará muita confusão
+    mais tarde.</p>
+
+    <p>Observe que é totalmente equivalente colocar um arquivo <code>.htaccess</code>
+    em um diretório <code>/www/htdocs/example</code> contendo uma diretiva
+    e colocar essa mesma diretiva em uma seção Directory
+    <code>&lt;Directory "/www/htdocs/example"&gt;</code> na configuração principal
+    do seu servidor:</p>
 
     <p>Arquivo <code>.htaccess</code> em <code>/www/htdocs/example</code>:</p>
 
-    <example><title>Conte&#250;do de um arquivo .htaccess em
+    <example><title>Conteúdo do arquivo .htaccess em
     <code>/www/htdocs/example</code></title>
-        AddType text/example .exm
+    <highlight language="config">
+AddType text/example ".exm"
+    </highlight>
     </example>
 
-    <example><title>Se&#231;&#227;o do seu arquivo <code>httpd.conf</code></title>
-      &lt;Directory /www/htdocs/example&gt;<br />
-      <indent>
-        AddType text/example .exm<br />
-      </indent>
-      &lt;/Directory&gt;
+    <example><title>Seção do seu arquivo
+    <code>httpd.conf</code></title>
+    <highlight language="config">
+&lt;Directory "/www/htdocs/example"&gt;
+    AddType text/example ".exm"
+&lt;/Directory&gt;
+    </highlight>
     </example>
 
-    <p>No entanto, adicionando isso ao seu arquivo de configura&#231;&#227;o do
-    servidor resultar&#225; em uma menor perda de performance, na medida que
-    a configura&#231;&#227;o &#233; carregada no momento da inicializa&#231;&#227;o do
-    servidor, ao inv&#233;s de toda que que um arquivo &#233; requerido.</p>
+    <p>No entanto, colocar essa configuração no arquivo de configuração do seu
+    servidor resultará em menos impacto no desempenho, pois a configuração é
+    carregada uma vez quando o httpd é iniciado, em vez de toda vez que um arquivo é
+    solicitado.</p>
 
-    <p>O uso de arquivos <code>.htaccess</code> pode ser totalmente
-    desabilitado, ajustando a diretriz <directive
-    module="core">AllowOverride</directive> para <code>none</code>:</p>
+    <p>O uso de arquivos <code>.htaccess</code> pode ser desabilitado completamente
+    definindo a diretiva <directive module="core">AllowOverride</directive>
+    como <code>none</code>:</p>
 
-    <example>
-      AllowOverride None
-    </example>
+    <highlight language="config">
+AllowOverride None
+    </highlight>
 </section>
 
-<section id="how"><title>Como as diretrizes s&#227;o aplicadas</title>
+<section id="how"><title>Como as diretivas são aplicadas</title>
 
-    <p>As diretrizes de configura&#231;&#227;o que se encontram em um arquivo
-    <code>.htaccess</code> s&#227;o aplicadas para o diret&#243;rio no qual o
-    arquivo <code>.htaccess</code> se encontra, e para todos os
-    subdiret&#243;rios ali presentes. Mas, &#233; importante lembrar tamb&#233;m que
-    podem existir arquivos <code>.htaccess</code> no diret&#243;rios
-    superiores. As diretrizes s&#227;o aplicadas na ordem que s&#227;o
-    achadas. Logo, um arquivo <code>.htaccess</code> em um diret&#243;rio
-    em particular, pode sobrescrever as diretrizes encontradas em um
-    diret&#243;rio acima deste em sua respectiva &#225;rvore. Estes, por sua vez,
-    podem ter suas diretrizes sobrescritas por diretrizes ainda mais
-    acima, ou no pr&#243;prio arquivo de configura&#231;&#227;o principal do
-    servidor.</p>
+    <p>As diretivas de configuração encontradas em um arquivo <code>.htaccess</code>
+    são aplicadas ao diretório em que o arquivo <code>.htaccess</code>
+    se encontra e a todos os seus subdiretórios. No entanto, é importante
+    lembrar também que pode haver arquivos <code>.htaccess</code>
+    em diretórios superiores. As diretivas são aplicadas na ordem em que
+    são encontradas. Portanto, um arquivo <code>.htaccess</code> em um diretório
+    específico pode substituir diretivas encontradas em arquivos <code>.htaccess</code>
+    encontrados mais acima na árvore de diretórios. E estes, por sua vez, podem ter
+    substituído diretivas encontradas ainda mais acima, ou no próprio arquivo de configuração
+    principal do servidor.</p>
 
     <p>Exemplo:</p>
 
-    <p>No diret&#243;rio <code>/www/htdocs/example1</code> n&#243;s temos
+    <p>No diretório <code>/www/htdocs/example1</code> temos
     um arquivo <code>.htaccess</code> contendo o seguinte:</p>
 
-    <example>
-       Options +ExecCGI
-    </example>
+    <highlight language="config">
+Options +ExecCGI
+    </highlight>
 
-    <p>(Nota: voc&#234; deve ter "<code>AllowOverride Options</code>" para
-    permitir o uso da diretriz "<directive
-    module="core">Options</directive>" nos arquivos
-    <code>.htaccess</code> .)</p>
+    <p>(Observação: você deve ter "<code>AllowOverride Options</code>" em vigor
+    para permitir o uso da diretiva "<directive
+    module="core">Options</directive>" em arquivos
+    <code>.htaccess</code>.)</p>
 
-    <p>No diret&#243;rio <code>/www/htdocs/example1/example2</code> n&#243;s temos
+    <p>No diretório <code>/www/htdocs/example1/example2</code>, temos
     um arquivo <code>.htaccess</code> contendo:</p>
 
-    <example>
-       Options Includes
-    </example>
+    <highlight language="config">
+Options Includes
+    </highlight>
 
-    <p>Devido a esse segundo arquivo <code>.htaccess</code>, no
-    diret&#243;rio <code>/www/htdocs/example1/example2</code>, a execu&#231;&#227;o
-    de scripts CGI n&#227;o &#233; permitida, pois somente <code>Options
-    Includes</code> est&#225; em efeito, o que sobrescreve completamente
-    quaisquer outros ajustes previamente configurados.</p>
+    <p>Devido a esse segundo arquivo <code>.htaccess</code> no diretório
+    <code>/www/htdocs/example1/example2</code>, a execução de scripts CGI não é
+    permitida, pois somente <code>Options Includes</code> está em efeito, o que
+    sobrescreve completamente quaisquer outros ajustes previamente
+    configurados.</p>
+
+    <section id="merge"><title>Mesclagem de .htaccess com os arquivos de
+    configuração principais</title>
+
+    <p>Conforme discutido na documentação sobre <a
+    href="../sections.html">Seções de Configuração</a>,
+    os arquivos <code>.htaccess</code> podem substituir as seções <directive
+    type="section" module="core">Directory</directive> para
+    o diretório correspondente, mas serão substituídos por outros tipos
+    de seções de configuração dos arquivos de configuração principais. Este
+    fato pode ser usado para impor certas configurações, mesmo na
+    presença de uma configuração liberal de <directive
+    module="core">AllowOverride</directive>. Por exemplo, para
+    impedir a execução de scripts enquanto permite que qualquer outra coisa seja definida em
+    <code>.htaccess</code>, você pode usar:</p>
+
+    <highlight language="config">
+&lt;Directory "/www/htdocs"&gt;
+    AllowOverride All
+&lt;/Directory&gt;
+
+&lt;Location "/"&gt;
+    Options +IncludesNoExec -ExecCGI
+&lt;/Location&gt;
+    </highlight>
+
+    <note>Este exemplo pressupõe que <directive
+    module="core">DocumentRoot</directive> seja <code>/www/htdocs</code>.</note>
+    </section>
+
 </section>
 
-<section id="auth"><title>Exemplo de Autentica&#231;&#227;o</title>
+<section id="auth"><title>Exemplo de Autenticação</title>
 
-    <p>Se voc&#234; veio diretamente &#224; esta parte do documento para
-    aprender como fazer autentica&#231;&#227;o, &#233; importante notar uma
-    coisa. Existe uma concep&#231;&#227;o errada, mas muito comum, de que &#233;
-    necess&#225;rio o uso de arquivos <code>.htaccess</code> para implementar 
-    a autentica&#231;&#227;o por senha. Este n&#227;o &#233; o caso. Colocar 
-    diretrizes de senha em uma se&#231;&#227;o <directive module="core"
-    type="section">Directory</directive>, no seu arquivo principal de
-    configura&#231;&#227;o do servidor, &#233; a melhor maneira de se implementar
-    isto, e os arquivos <code>.htaccess</code> devem ser usados apenas
-    se voc&#234; n&#227;o tem acesso ao arquivo principal de configura&#231;&#227;o do
-    servidor. Veja <a href="#when">acima</a> a discuss&#227;o sobre quando
-    voc&#234; deve e quando n&#227;o deve usar os arquivos
-    <code>.htaccess</code>.</p>
+    <p>Se você veio direto para esta parte do documento para descobrir como
+    fazer autenticação, é importante observar uma coisa. Existe um
+    equívoco comum de que você precisa usar arquivos
+    <code>.htaccess</code> para implementar a autenticação
+    por senha. Este não é o caso. Colocar diretivas de autenticação
+    em uma seção <directive module="core" type="section">Directory</directive>
+    no arquivo de configuração principal do seu servidor, é a maneira preferida
+    de implementar isso, e os arquivos <code>.htaccess</code> devem ser usados ​​apenas
+    se você não tiver acesso ao arquivo de configuração principal do servidor. Veja <a
+    href="#when">acima</a> para uma discussão sobre quando você deve e não deve
+    usar arquivos <code>.htaccess</code>.</p>
 
-    <p>Dito isso, se voc&#234; ainda acredita que precisa usar um arquivo
-    <code>.htaccess</code>, a configura&#231;&#227;o a seguir provavelmente
-    funcionar&#225; para voc&#234;.</p>
+    <p>Dito isso, se você ainda acha que precisa usar um arquivo
+    <code>.htaccess</code>, você pode descobrir que uma configuração como
+    a seguinte pode funcionar para você.</p>
 
-    <p>Conte&#250;do de um arquivo <code>.htaccess</code>:</p>
+    <p>Conteúdo do arquivo <code>.htaccess</code>:</p>
 
-    <example>
-      AuthType Basic<br />
-      AuthName "Password Required"<br />
-      AuthUserFile /www/passwords/password.file<br />
-      AuthGroupFile /www/passwords/group.file<br />
-      Require Group admins
-    </example>
+    <highlight language="config">
+AuthType Basic
+AuthName "Password Required"
+AuthUserFile "/www/passwords/password.file"
+AuthGroupFile "/www/passwords/group.file"
+Require group admins
+    </highlight>
 
-    <p>Note que <code>AllowOverride AuthConfig</code> precisa estar
-    habilitado para que estas diretrizes tenham efeito.</p>
+    <p>Observe que <code>AllowOverride AuthConfig</code> precisa estar
+    em vigor para que estas diretivas tenham efeito.</p>
 
-    <p>Por favor veja o <a href="auth.html">tutorial de
-    autentica&#231;&#227;o</a> para uma discuss&#227;o mais completa sobre
-    autentica&#231;&#227;o e autoriza&#231;&#227;o.</p>
+    <p>Por favor veja o <a href="auth.html">tutorial de autenticação</a> para uma
+    discussão mais completa sobre autenticação e autorização.</p>
 </section>
 
-<section id="ssi"><title>Exemplo de Server Side Includes</title>
+<section id="ssi"><title>Exemplo de Inclusões no Lado do Servidor</title>
 
-    <p>Outro uso comum de arquivos <code>.htaccess</code> &#233; ativar o
-    Server Side Includes para um diret&#243;rio em particular. Isto pode
-    ser feito com as seguintes diretrizes de configura&#231;&#227;o, colocadas em
-    um arquivo <code>.htaccess</code> no diret&#243;rio desejado:</p>
+    <p>Outro uso comum de arquivos <code>.htaccess</code>é ativar as
+    Inclusões no Lado do Servidor (Server Side Includes) para um diretório em particular.
+    Isto pode ser feito com as seguintes diretivas de configuração, colocadas em
+    um arquivo <code>.htaccess</code> no diretório desejado:</p>
 
-    <example>
-       Options +Includes<br />
-       AddType text/html shtml<br />
-       AddHandler server-parsed shtml
-    </example>
+    <highlight language="config">
+Options +Includes
+AddType text/html "shtml"
+AddHandler server-parsed shtml
+    </highlight>
 
-    <p>Note que ambos <code>AllowOverride Options</code> e
+    <p>Observe que <code>AllowOverride Options</code> e
     <code>AllowOverride FileInfo</code> precisam estar habilitados
-    para essas diretrizes terem efeito.</p>
+    para que essas diretivas terem efeito.</p>
 
-    <p>Por favor veja o <a href="ssi.html">tutorial de SSI</a> para
-    uma discuss&#227;o mais completa sobre server-side includes.</p>
+    <p>Por favor, consulte o <a href="ssi.html">tutorial de SSI</a> para
+    uma discussão mais completa sobre inclusões no lado do servidor.</p>
+</section>
+
+<section id="rewrite"><title>Regras de Reescrita em arquivos .htaccess</title>
+<p>Ao usar <directive module="mod_rewrite">RewriteRule</directive> em arquivos
+<code>.htaccess</code>, esteja ciente de que o contexto por diretório
+muda um pouco as coisas. Em particular, as regras são consideradas relativas
+ao diretório atual, em vez de serem o URI original solicitado.
+Considere os seguintes exemplos:</p>
+
+<highlight language="config">
+# No httpd.conf
+RewriteRule "^/images/(.+)\.jpg" "/images/$1.png"
+
+# No .htaccess do diretório raiz
+RewriteRule "^images/(.+)\.jpg" "images/$1.png"
+
+# No .htaccess de images/
+RewriteRule "^(.+)\.jpg" "$1.png"
+</highlight>
+
+<p>Em um <code>.htaccess</code> no seu diretório de documentos, a barra inicial
+é removida do valor fornecido para <directive
+module="mod_rewrite">RewriteRule</directive>, e no subdiretório
+<code>images</code>, <code>/images/</code> é removido
+dele. Portanto, sua expressão regular precisa omitir essa parte
+também.</p>
+
+<p>Consulte a <a href="../rewrite/">documentação do mod_rewrite</a> para
+mais detalhes sobre o uso do <code>mod_rewrite</code>.</p>
+
 </section>
 
 <section id="cgi"><title>Exemplo de CGI</title>
 
-    <p>Finalmente, voc&#234; pode querer que um arquivo
-    <code>.htaccess</code> permita a execu&#231;&#227;o de programas CGI em um
-    diret&#243;rio em particular. Isto pode ser implementado com as
-    seguintes configura&#231;&#245;es:</p>
+    <p>Por fim, você pode usar um arquivo <code>.htaccess</code> para permitir
+    a execução de programas CGI em um diretório específico. Isso pode ser
+    implementado com a seguinte configuração:</p>
 
-    <example>
-       Options +ExecCGI<br />
-       AddHandler cgi-script cgi pl
-    </example>
+    <highlight language="config">
+Options +ExecCGI
+AddHandler cgi-script "cgi" "pl"
+    </highlight>
 
-    <p>Alternativamente, se voc&#234; desejar que todos os arquivos de um
-    dado diret&#243;rio, sejam considerados programas CGI, isso pode ser
-    feito com a seguinte configura&#231;&#227;o:</p>
+    <p>Alternativamente, se você deseja que todos os arquivos no diretório fornecido
+    sejam considerados programas CGI, isso pode ser feito com a seguinte
+    configuração:</p>
 
-    <example>
-       Options +ExecCGI<br />
-       SetHandler cgi-script
-    </example>
+    <highlight language="config">
+Options +ExecCGI
+SetHandler cgi-script
+    </highlight>
 
-    <p>Note que ambos <code>AllowOverride Options</code> e
-    <code>AllowOverride FileInfo</code> precisam estar habilitados
-    para que essas diretrizes tenham quaisquer efeito.</p>
+    <p>Observe que <code>AllowOverride Options</code> e <code>AllowOverride
+    FileInfo</code> devem estar em vigor para que essas diretivas tenham algum
+    efeito.</p>
 
-    <p>Por favor veja o <a href="cgi.html">tutorial de CGI
-    tutorial</a> para uma discuss&#227;o mais completa sobre programa&#231;&#227;o
-    e configura&#231;&#227;o CGI.</p>
+    <p>Consulte o <a href="cgi.html">tutorial de CGI</a> para uma discussão mais
+    completa sobre programação e configuração de CGI.</p>
+
 </section>
 
 <section id="troubleshoot"><title>Resolvendo Problemas</title>
 
-    <p>Quando voc&#234; adiciona diretrizes de configura&#231;&#227;o em um arquivo
-    <code>.htaccess</code>, e n&#227;o obt&#233;m o efeito desejado, existe uma
-    s&#233;rie de pontos que podem estar errados.</p>
+    <p>Quando você insere diretivas de configuração em um arquivo <code>.htaccess</code>
+    e não obtém o efeito desejado, há uma série de
+    coisas que podem estar dando errado.</p>
 
-    <p>Mais comumente, o problema &#233; que a diretriz <directive
-    module="core">AllowOverride</directive> n&#227;o est&#225; habilitada
-    corretamente para que as suas diretrizes de configura&#231;&#245;es sejam
-    honradas. Verifique se voc&#234; n&#227;o possui <code>AllowOverride
-    None</code> ajustado para o escopo do arquivo em quest&#227;o. Um bom
-    meio de testar isso &#233; colocar "lixo" em seu arquivo
-    <code>.htaccess</code> e recarreg&#225;-lo. Se n&#227;o for gerado nenhum
-    erro do servidor, certamente voc&#234; tem <code>AllowOverride
-    None</code> habilitado.</p>
+    <p>O problema mais comum é que a diretiva <directive
+    module="core">AllowOverride</directive> não está
+    definida de forma que suas diretivas de configuração sejam respeitadas. Certifique-se
+    de que você não tenha uma diretiva <code>AllowOverride None</code> em vigor
+    para o escopo do arquivo em questão. Um bom teste para isso é colocar lixo
+    no seu arquivo <code>.htaccess</code> e recarregar a página. Se um erro de servidor
+    não for gerado, então você quase certamente tem <code>AllowOverride
+    None</code> em vigor.</p>
 
-    <p>Se, por outro lado, voc&#234; est&#225; obtendo erros do servidor ao
-    tentar acessar documentos, verifique o registro de erros do
-    Apache. Ele provavelmente ir&#225; indicar que a diretriz usada em
-    seu arquivo <code>.htaccess</code> n&#227;o &#233; permitida.
-    Alternativamente, ele pode acusar erros de sintaxe que voc&#234; ter&#225;
-    que corrigir.</p>
+    <p>Se, por outro lado, você estiver recebendo erros de servidor ao tentar
+    acessar documentos, verifique seu log de erros httpd. Ele provavelmente lhe dirá
+    que a diretiva usada no seu arquivo <code>.htaccess</code> não é
+    permitida.</p>
+
+    <example>
+    [Fri Sep 17 18:43:16 2010] [alert] [client 192.168.200.51] /var/www/html/.htaccess: DirectoryIndex not allowed here
+    </example>
+
+    <p>Isso indicará que você usou uma diretiva que
+    nunca é permitida em arquivos <code>.htaccess</code> ou que você simplesmente
+    não definiu a diretiva <directive module="core">AllowOverride</directive> em
+    um nível suficiente para a diretiva usada. Consulte a
+    documentação dessa diretiva específica para determinar qual é
+    o caso.</p>
+
+    <p>Alternativamente, isso pode indicar que você teve um erro de sintaxe no seu
+    uso da própria diretiva.</p>
+
+    <example>
+    [Sat Aug 09 16:22:34 2008] [alert] [client 192.168.200.51] /var/www/html/.htaccess: RewriteCond: bad flag delimiters
+    </example>
+
+    <p>Neste caso, a mensagem de erro deve ser específica para o
+    erro de sintaxe específico que você cometeu.</p>
 
 </section>
 

--- a/docs/manual/index.xml.pt-br
+++ b/docs/manual/index.xml.pt-br
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE indexpage SYSTEM "./style/sitemap.dtd">
 <?xml-stylesheet type="text/xsl" href="./style/manual.pt-br.xsl"?>
-<!-- English Revision: 420993:1880986 (outdated) -->
+<!-- Brazilian Portuguese translation : leonardolara -->
+<!-- English Revision: 1880986 -->
 
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
@@ -23,70 +24,79 @@
 <indexpage metafile="index.xml.meta">
 <parentdocument href="http://httpd.apache.org/docs-project/" />
 
-<title>Documenta&#231;&#227;o do Servidor HTTP Apache Vers&#227;o
+<title>Documentação do Servidor HTTP Apache Versão
 &httpd.major;.&httpd.minor;</title>
 
-<category id="release"><title>Notas da Vers&#227;o</title>
+<category id="release"><title>Notas de Versão</title>
+    <page href="new_features_2_6.html">Novas funcionalidades no Apache 2.5/2.6</page>
     <page href="new_features_2_4.html">Novas funcionalidades no Apache 2.3/2.4</page>
     <page href="new_features_2_2.html">Novas funcionalidades no Apache 2.1/2.2</page>
     <page href="new_features_2_0.html">Novas funcionalidades no Apache 2.0</page>
-    <page href="upgrading.html">Atualizando da vers&#227;o 2.2 para 2.4</page>
-    <page href="license.html">Licen&#231;a Apache</page>
+    <page href="upgrading.html">Atualizando da versão 2.2 para 2.4</page>
+    <page href="license.html">Licença Apache</page>
 </category>
 
-<category id="manual"><title>Manual de Refer&#234;ncia</title>
+<category id="manual"><title>Manual de Referência</title>
     <page href="install.html">Compilando e Instalando</page>
     <page href="invoking.html">Iniciando</page>
     <page href="stopping.html">Parando ou Reiniciando</page>
-    <page href="mod/directives.html">Diretrizes de Configura&#231;&#227;o para execu&#231;&#227;o</page>
-    <page href="mod/quickreference.html">Refer&#234;ncia R&#225;pida de Diretrizes</page>
-    <page href="mod/">M&#243;dulos</page>
-    <page href="mpm.html">M&#243;dulos Multi-Processos (MPMs)</page>
+    <page href="mod/quickreference.html">Diretivas de Configuração em Tempo de Execução</page>
+    <page href="mod/">Módulos</page>
+    <page href="mpm.html">Módulos de Multiprocessamento (MPMs)</page>
     <page href="filter.html">Filtros</page>
-    <page href="handler.html">Handlers</page>
-    <page href="programs/">Servidor e Programas Suportados</page>
-    <page href="glossary.html">Gloss&#225;rio</page>
-</category>    
+    <page href="handler.html">Manipuladores</page>
+    <page href="expr.html">Analisador de expressões</page>
+    <page href="mod/overrides.html">Substituição de Índice de Classe para .htaccess</page>
+    <page href="programs/">Servidor e Programas de Suporte</page>
+    <page href="glossary.html">Glossário</page>
+</category>
 
-<category id="usersguide"><title>Guia do Usu&#225;rio</title>
-    <page href="bind.html">Portas de escuta</page>
-    <page href="configuring.html">Arquivos de Configura&#231;&#227;o</page>
-    <page href="sections.html">Se&#231;&#245;es de Configura&#231;&#227;o</page>
-    <page href="caching.html">Cach&#234; de Conte&#250;do</page>
-    <page href="content-negotiation.html">Negocia&#231;&#227;o de Conte&#250;do</page>
-    <page href="dso.html">Objetos Din&#226;micos Compartilhados (DSO)</page>
-    <page href="env.html">Vari&#225;veis de Ambiente</page>
+<category id="usersguide"><title>Guia do Usuário</title>
+    <page href="getting-started.html">Começando</page>
+    <page href="bind.html">Vinculação a Endereços e Portas</page>
+    <page href="configuring.html">Arquivos de Configuração</page>
+    <page href="sections.html">Seções de Configuração</page>
+    <page href="caching.html">Cache de Conteúdo</page>
+    <page href="content-negotiation.html">Negociação de Conteúdo</page>
+    <page href="dso.html">Objetos Compartilhados Dinâmicos (DSO)</page>
+    <page href="env.html">Variáveis de Ambiente</page>
     <page href="logs.html">Arquivos de Registro</page>
-    <page href="urlmapping.html">Mapeando URLs para o Sistema de Arquivos</page>
-    <page href="misc/perf-tuning.html">Ajustes de Performance</page>
-    <page href="misc/security_tips.html">Dicas de Seguran&#231;a</page>
-    <page href="server-wide.html">Configura&#231;&#245;es Globais do Servidor</page>
-    <page href="ssl/">Encriptamento SSL/TLS</page>
-    <page href="suexec.html">Execu&#231;&#227;o Suexec para CGI</page>
-    <page href="rewrite/">Guia para Reescrever URL</page>
-    <page href="vhosts/">Hosting Virtuais</page>
+    <page href="compliance.html">Conformidade com o Protocolo HTTP</page>
+    <page href="urlmapping.html">Mapeamento de URLs para o Sistema de Arquivos</page>
+    <page href="misc/perf-tuning.html">Ajustes de Desempenho</page>
+    <page href="misc/security_tips.html">Dicas de Segurança</page>
+    <page href="server-wide.html">Configurações do Servidor</page>
+    <page href="ssl/">Criptografia SSL/TLS</page>
+    <page href="suexec.html">Execução Suexec para CGI</page>
+    <page href="rewrite/">Reescrita de URL com mod_rewrite</page>
+    <page href="vhosts/">Hosts Virtuais</page>
 </category>
 
-<category id="howto"><title>How-To / Tutoriais</title>
-    <page href="howto/auth.html">Autentica&#231;&#227;o, Autoriza&#231;&#227;o, e 
-    Controle de Acesso</page>
-    <page href="howto/cgi.html">CGI: Conte&#250;do Din&#226;mico</page>
+<category id="howto"><title>Como Fazer / Tutoriais</title>
+ <page href="howto">Página de índice de Como Fazer </page>
+    <page href="howto/auth.html">Autenticação e Autorização</page>
+    <page href="howto/access.html">Controle de Acesso</page>
+    <page href="howto/cgi.html">CGI: Conteúdo Dinâmico</page>
     <page href="howto/htaccess.html">Arquivos .htaccess</page>
-    <page href="howto/ssi.html">Server Side Includes (SSI)</page>
-    <page href="howto/public_html.html">Diret&#243;rios Web para usu&#225;rios individuais
-    (public_html)</page>
+    <page href="howto/ssi.html">Inclusões do Lado do Servidor (SSI)</page>
+    <page href="howto/public_html.html">Diretórios Web para usuários individuais (public_html)</page>
+    <page href="howto/reverse_proxy.html">Guia de configuração de proxy reverso</page>
+    <page href="howto/http2.html">Guia do HTTP/2</page>
 </category>
 
-<category id="platform"><title>Notas Espec&#237;ficas para diferentes Platformas</title>
+<category id="platform"><title>Notas Específicas de Platformas</title>
     <page href="platform/windows.html">Microsoft Windows</page>
+    <page href="platform/rpm.html">Sistemas baseados em RPM (Redhat / CentOS / Fedora)</page>
     <page href="platform/netware.html">Novell NetWare</page>
 </category>
 
-<category id="other"><title>Outros T&#243;picos</title>
-    <page href="faq/">Perguntas Mais Frequentes</page>
+<category id="other"><title>Outros Tópicos</title>
+    <page href="http://wiki.apache.org/httpd/FAQ">Perguntas Mais Frequentes</page>
     <page href="sitemap.html">Mapa do Site</page>
-    <page href="developer/">Documenta&#231;&#227;o para Desenvolvedores</page>
+    <page href="developer/">Documentação para Desenvolvedores</page>
+    <page href="http://httpd.apache.org/docs-project/">Ajudando com a documentação</page>
     <page href="misc/">Outras Notas</page>
+    <page href="http://wiki.apache.org/httpd/">Wiki</page>
 </category>
 
 </indexpage>

--- a/docs/manual/new_features_2_0.xml.pt-br
+++ b/docs/manual/new_features_2_0.xml.pt-br
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <!DOCTYPE manualpage SYSTEM "./style/manualpage.dtd">
 <?xml-stylesheet type="text/xsl" href="./style/manual.pt-br.xsl"?>
-<!-- English Revision: 420990:1561569 (outdated) -->
-
+<!-- Brazilian Portuguese translation : leonardolara -->
+<!-- English Revision: 1561569 -->
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
@@ -22,217 +22,211 @@
 
 <manualpage metafile="new_features_2_0.xml.meta">
 
-<title>Descri&#231;&#227;o das novas funcionalidades do Apache 2.0</title>
+<title>Visão geral das novas funcionalidades no Servidor HTTP Apache 2.0</title>
 
 <summary>
-  <p>Esse documento descreve algumas das mudan&#231;as principais
-     entre as vers&#245;es 1.3 e 2.0 do Servidor HTTP Apache.</p>
+  <p>Este documento descreve algumas das principais alterações
+     entre as versões 1.3 e 2.0 do Servidor HTTP Apache.</p>
 </summary>
 
-<seealso><a href="upgrading.html">Atualizando da vers&#227;o 1.3 para 2.0</a></seealso>
+<seealso><a href="upgrading.html">Atualizando da versão 1.3 para 2.0</a></seealso>
 
   <section id="core">
-    <title>Principais Melhorias</title>
+    <title>Melhorias do Núcleo</title>
 
     <dl>
-      <dt>Threading Unix</dt>
+      <dt>Threads no Unix</dt>
 
       <dd>Em sistemas Unix com suporte a threads POSIX, o Apache pode
-      funcionar em modo h&#237;brido multiprocesso e multithread. N&#227;o funciona
-      em todas configura&#231;&#245;es, mas melhora a escalabilidade em muitas.</dd>
+      funcionar em modo híbrido multiprocessos e multithreads. Isto
+      melhora a escalabilidade para muitas configurações, mas não para todas.</dd>
 
-      <dt>Novo Sistema de Compila&#231;&#227;o</dt>
+      <dt>Novo Sistema de Compilação</dt>
 
-      <dd>O sistema de compila&#231;&#227;o foi reescrito do zero para utilizar o
+      <dd>O sistema de compilação foi reescrito do zero para utilizar o
       <code>autoconf</code> e o <code>libtool</code>, tornando a
-      configura&#231;&#227;o do sistema Apache mais similar a de outros
+      configuração do sistema Apache mais similar a de outros
       pacotes.</dd>
 
       <dt>Suporte Multi-protocolo</dt>
 
-      <dd>O Apache possui agora uma infraestrutura feita para suportar
-      m&#250;ltiplos protocolos. O m&#243;dulo <module>mod_echo</module> &#233;  um
-      exemplo ilustrativo de sua utiliza&#231;&#227;o.</dd>
+      <dd>O Servidor HTTP Apache possui agora uma infraestrutura feita para suportar
+      múltiplos protocolos. O módulo <module>mod_echo</module> foi
+      escrito como um exemplo.</dd>
 
-      <dt>Suporte Aperfei&#231;oado para Plataformas N&#227;o-Unix</dt>
+      <dt>Suporte Aperfeiç;oado para Plataformas
+      Não-Unix</dt>
 
-      <dd>O Apache 2.0 est&#225;  mais r&#225;pido e mais est&#225;vel em plataformas
-      N&#227;o-Unix como BeOS, OS/2 e Windows. Com a introdu&#231;&#227;o de m&#243;dulos
-      <a href="mpm.html">multi-processamento</a> (MPMs) espec&#237;ficos e a
-      Apache Portable Runtime (APR), essas plataformas est&#227;o implementando
-      as suas APIs nativas, evitando as camadas de emula&#231;&#227;o POSIX que se
-      mostravam lentas e defeituosas.</dd>
+      <dd>O Servidor HTTP Apache 2.0 está mais rápido e mais esável em plataformas
+      não-Unix como BeOS, OS/2 e Windows. Com a
+      introdução de
+      <a href="mpm.html">módulos multi-processamento</a> (MPMs) específicos de plataforma e a
+      do Apache Portable Runtime (APR), essas plataformas estão agora implementadas
+      em suas APIs nativas, evitando as camadas de emulação POSIX com problemas
+      frequentes e com baixo desempenho.</dd>
 
-      <dt>Nova API Apache</dt>
+      <dt>Nova API do Apache httpd</dt>
 
-      <dd>A API para m&#243;dulos mudou significativamente na vers&#227;o 2.0.
-      Muitos dos problemas de ordenamento/prioridade da vers&#227;o
-      1.3 foram resolvidos. A vers&#227;o 2.0 faz o ordenamento autom&#225;tico
-      "per-hook" para permitir mais flexibilidade. Novas chamadas foram
-      adicionadas para fornecer capacidades adicionais sem a necessidade
-      de se aplicar nenhum patch ao servidor Apache principal.</dd>
+      <dd>A API para módulos mudou significativamente na versão 2.0.
+      Muitos dos problemas de ordenação e priorização de módulos da versão
+      1.3 não devem mais aparecer. A versão 2.0 faz a maior parte dessas tarefas automaticamente,
+      e a ordenação de módulos agora é feita por gancho para permitir mais flexibilidade. Além disso,
+      novas chamadas foram adicionadas para fornecer capacidades adicionais de módulos sem
+      a necessidade de alteração no núcleo do Servidor HTTP Apache.</dd>
 
       <dt>Suporte IPv6</dt>
 
-      <dd>Em sistemas onde o IPv6 &#233; suportado pela biblioteca de base
-      Apache Portable Runtime, o Apache monitora por padr&#227;o
-      as interfaces IPv6. Em adi&#231;&#227;o as diretrizes  <directive
+      <dd>Em sistemas onde o IPv6 é suportado pela biblioteca subjacente
+      Apache Portable Runtime, o Apache httpd escuta por padrão
+      as interfaces IPv6. Além disso, as diretivas <directive
       module="mpm_common">Listen</directive>, <directive module="core"
       >NameVirtualHost</directive> e <directive module="core"
-      >VirtualHost</directive>, suportam correntes (strings) de
-      endere&#231;os num&#233;ricos do tipo IPv6. (ex. "<code>Listen
+      >VirtualHost</directive> suportam strings de
+      endereço numérico IPv6 (ex.: "<code>Listen
       [2001:db8::1]:8080</code>").</dd>
 
-      <dt>Filtrando</dt>
+      <dt>Filtragem</dt>
 
-      <dd>Os m&#243;dulos do Apache agora s&#227;o feito filtros que
-      agem na corrente do conte&#250;do na medida que este &#233; entregue, tanto
-      na entrada quando na sa&#237;da de dados do servidor. &#201; poss&#237;vel ent&#227;o,
-      por exemplo, que o retorno de dados de scripts CGI sejam analisados
-      pelas diretrizes do "Server Side Include" usando o filtro <code
-      >INCLUDES</code> do <module>mod_include</module>. O m&#243;dulo <module
-      >mod_ext_filter</module>, permite que programas externos trabalhem
-      como filtros do mesmo modo que aplica&#231;&#245;es CGI funcionam como
+      <dd>Módulos httpd do Apache agora podem ser escritos como filtros que atuam
+      no fluxo de conteúdo conforme ele é entregue de ou para o
+      servidor. Isso permite, por exemplo, que a saída de scripts CGI
+      seja analisada em busca de diretivas de Inclusão do Lado do Servidor usando o
+      filtro <code>INCLUDES</code> em <module>mod_include</module>. O
+      módulo <module>mod_ext_filter</module> permite que programas externos
+      atuem como filtros da mesma forma que programas CGI podem atuar como
       manipuladores.</dd>
 
-      <dt>Respostas de Erro Multi-linguais</dt>
+      <dt>Respostas de erro multilíngues</dt>
 
-      <dd>Mensagens de erro para o navegador agora s&#227;o fornecidas em
-      diversas l&#237;nguas, usando documentos SSI. Podem ser personalizadas
-      pelo administrador que desejar definir seus pr&#243;prios
-      padr&#245;es.</dd>
+      <dd>Mensagens de resposta de erro para o navegador agora são fornecidas em
+      vários idiomas, usando documentos SSI. Elas podem ser personalizadas
+      pelo administrador para obter uma aparência consistente.</dd>
 
-      <dt>Configura&#231;&#227;o Simplificada</dt>
+      <dt>Configuração simplificada</dt>
 
-      <dd>Muitas diretrizes confusas foram simplificadas. Entre elas,
-      <code>Port</code> e <code>BindAddress</code> n&#227;o existem
-      mais; apenas a diretriz <directive module="mpm_common">Listen</directive>
-      &#233; usada para direcionar endere&#231;os IP; a diretriz <directive
-      module="core">ServerName</directive> especifica o nome do servidor
-      e o n&#250;mero da porta apenas para redirecionamento e reconhecimento
-      de hospedeiros virtuais.</dd>
+      <dd>Muitas diretivas confusas foram simplificadas. As diretivas
+      <code>Port</code> e <code>BindAddress</code>, frequentemente confusas,
+      foram removidas; apenas a diretiva <directive module="mpm_common">Listen</directive>
+      é usada para vinculação de endereços IP; a diretiva <directive
+      module="core">ServerName</directive> especifica o
+      nome do servidor e o número da porta apenas para redirecionamento e
+      reconhecimento de host virtual.</dd>
 
-      <dt>Suporte Nativo ao Unicode do Windows NT</dt>
+      <dt>Suporte Unicode nativo do Windows NT</dt>
 
-      <dd>O Apache 2.0 para Windows NT agora usa utf-8 para codifica&#231;&#227;o
-      de todos os nomes de arquivos. A tradu&#231;&#227;o para o sistema
-      base Unicode, torna poss&#237;vel o suporte multi-lingual para todas
-      as instala&#231;&#245;es da fam&#237;lia NT, incluindo o Windows 2000 e Windows XP.
-      <em>Esse suporte n&#227;o se estende ao Windows 95, 98 ou ME, que
-      continuam usando o c&#243;digo de p&#225;ginas da m&#225;quina local para o
-      acesso ao sistema de arquivos.</em></dd>
+      <dd>O Apache httpd 2.0 no Windows NT agora usa utf-8 para todas as codificações
+      de nomes de arquivo. Eles são traduzidos diretamente para o sistema de arquivos
+      Unicode subjacente, fornecendo suporte multilíngue para todas as instalações
+      baseadas no Windows NT, incluindo Windows 2000 e Windows XP.
+      <em>Este suporte não se estende ao Windows 95, 98 ou ME, que
+      continuam a usar a página de código local da máquina para acesso
+      ao sistema de arquivos.</em></dd>
 
-      <dt>Biblioteca de Express&#245;es Regulares Atualizada</dt>
+      <dt>Biblioteca de Expressões Regulares Atualizada</dt>
 
-      <dd>O Apache 2.0 inclui a <a href="http://www.pcre.org/">Biblioteca
-      de Express&#245;es Regulares Compat&#237;veis Perl</a> (PCRE).  Todas as
-      avalia&#231;&#245;es de express&#245;es regulares usam a mais poderosa sintaxe
-      do Perl 5.</dd>
+      <dd>O Apache httpd 2.0 inclui a <a href="http://www.pcre.org/">Biblioteca
+      de Expressões Regulares Compatível com Perl</a> (PCRE). Todas as avaliações
+      de expressões regulares agora usam a sintaxe mais poderosa do
+      Perl 5.</dd>
 
     </dl>
   </section>
 
   <section id="module">
-    <title>Melhorias nos M&#243;dulos</title>
+    <title>Melhorias nos Módulos</title>
 
     <dl>
       <dt><module>mod_ssl</module></dt>
 
-      <dd>Novo m&#243;dulo no Apache 2.0. Esse m&#243;dulo &#233; uma interface
-      para os protocolos de codifica&#231;&#227;o SSL/TLS fornecidos pela
+      <dd>Novo módulo no Apache httpd 2.0. Este módulo é uma interface
+      para os protocolos de criptografia SSL/TLS fornecidos pelo
       OpenSSL.</dd>
 
       <dt><module>mod_dav</module></dt>
 
-      <dd>Novo m&#243;dulo no Apache 2.0. Este m&#243;dulo implementa as
-      especifica&#231;&#245;es de Autoria Distribu&#237;da e Vers&#245;es (Distributed
-      Authoring and Versioning - DAV) para HTTP, para a publica&#231;&#227;o
-      e a manuten&#231;&#227;o de conte&#250;do da web.</dd>
+      <dd>Novo módulo no Apache httpd 2.0. Este módulo implementa a especificação HTTP
+      Distributed Authoring and Versioning (DAV) para
+      publicação e manutenção de conteúdo web.</dd>
 
       <dt><module>mod_deflate</module></dt>
 
-      <dd>Novo m&#243;dulo no Apache 2.0.  Esse m&#243;dulo permite o suporte
-      a navegadores que solicitam que o conte&#250;do seja comprimido antes
-      da entrega, economizando banda da rede.</dd>
+      <dd>Novo módulo no Apache httpd 2.0. Este módulo permite que navegadores de suporte solicitem
+      que o conteúdo seja compactado antes da entrega,
+      economizando largura de banda da rede.</dd>
 
-      <dt><module>mod_auth_ldap</module></dt>
+      <dt><module outdated="true">mod_auth_ldap</module></dt>
 
-      <dd>Novo m&#243;dulo no Apache 2.0.41. Este m&#243;dulo permite que 
-      bancos de dados LDAP sejam usados para armazenar credenciais
-      para Autentica&#231;&#227;o B&#225;sica HTTP. Um m&#243;dulo que o acompanha <module
-      >mod_ldap</module>, fornece a concilia&#231;&#227;o de conex&#245;es e armazenamento
-      de resultados.</dd>
+      <dd>Novo módulo no Apache httpd 2.0.41. Este módulo permite que um banco de dados
+      LDAP seja usado para armazenar credenciais para Autenticação Básica
+      HTTP. Um módulo complementar, <module>mod_ldap</module>
+      fornece pool de conexões e cache de resultados.</dd>
 
       <dt><module>mod_auth_digest</module></dt>
 
-      <dd>Inclui suporte adicional para armazenamento de sess&#245;es
-      atrav&#233;s de processos que usam mem&#243;ria compartilhada.</dd>
+      <dd>Inclui suporte adicional para cache de sessão entre
+      processos que usam memória compartilhada.</dd>
 
       <dt><module>mod_charset_lite</module></dt>
 
-      <dd>Novo m&#243;dulo no Apache 2.0. Este modo experimental permite a
-      tradu&#231;&#227;o de tabelas de caracteres ou re-codifica&#231;&#227;o.</dd>
+      <dd>Novo módulo no Apache httpd 2.0. Este módulo experimental permite
+      a tradução ou recodificação de conjuntos de caracteres.</dd>
 
       <dt><module>mod_file_cache</module></dt>
 
-      <dd>Novo m&#243;dulo no Apache 2.0. Esse m&#243;dulo inclui a funcionalidade
-      do <code>mod_mmap_static</code> do Apache 1.3, al&#233;m de disponibilizar
-      outras possibilidades de armazenamento.</dd>
+      <dd>Novo módulo no Apache httpd 2.0. Este módulo inclui a
+      funcionalidade do <code>mod_mmap_static</code> no Servidor HTTP
+      Apache versão 1.3, além de adicionar mais recursos de cache.</dd>
 
       <dt><module>mod_headers</module></dt>
 
-      <dd>Este m&#243;dulo est&#225; muito mais flex&#237;vel no Apache 2.0. Pode
-      modificar pedidos de cabe&#231;alhos usados pelo <module>mod_proxy</module
-      >, e incondicionalmente pode ajustar cabe&#231;alhos de respostas.</dd>
+      <dd>Este módulo é muito mais flexível no Apache httpd 2.0. Agora, ele pode
+      modificar cabeçalhos de solicitação usados ​​por <module>mod_proxy</module> e
+      definir cabeçalhos de resposta condicionalmente.</dd>
 
       <dt><module>mod_proxy</module></dt>
 
-      <dd>O m&#243;dulo proxy foi totalmente reescrito para levar vantagem
-      da nova infraestrutura de filtro e implementar um proxy mais fiel e 
-      de acordo com o padr&#227;o HTTP/1.1. Al&#233;m disso, uma nova se&#231;&#227;o
-      de configura&#231;&#227;o <directive module="mod_proxy" type="section"
-      >Proxy</directive> fornece controles mais leg&#237;veis (e internamente
-      mais r&#225;pidos) para sites com proxies; configura&#231;&#245;es
-      sobrecarregadas <code>&lt;Directory "proxy:..."&gt;</code>, n&#227;o
-      s&#227;o suportadas. O m&#243;dulo agora &#233; dividido em suporte
-      de protocolos espec&#237;ficos incluindo <code>proxy_connect</code>,
-      <code>proxy_ftp</code> e <code>proxy_http</code>.</dd>
+      <dd>O módulo proxy foi completamente reescrito para aproveitar
+      a nova infraestrutura de filtros e implementar um proxy
+      mais confiável e compatível com HTTP/1.1. Além disso, as novas seções de configuração
+      <directive module="mod_proxy" type="section">Proxy</directive>
+      fornecem um controle mais legível (e internamente
+      mais rápido) de sites proxy; configurações sobrecarregadas <code>&lt;Directory
+      "proxy:..."&gt;</code> não são suportadas. O módulo
+      agora está dividido em módulos de suporte a protocolos específicos, incluindo
+      <code>proxy_connect</code>, <code>proxy_ftp</code> e
+      <code>proxy_http</code>.</dd>
 
       <dt><module>mod_negotiation</module></dt>
 
-      <dd>A nova diretriz <directive module="mod_negotiation"
-      >ForceLanguagePriority</directive> pode ser usada para assegurar que
-      o cliente receba um &#250;nico documento em todos os casos, ao inv&#233;s de
-      respostas "NOT ACCEPTABLE" ou "MULTIPLE CHOICES". Novos algoritmos
-      de negocia&#231;&#227;o e vis&#245;es m&#250;ltiplas (MultiViews) foram organizados para
-      obter resultados mais consistentes e uma nova forma de tipo de mapa
-      (map type) que podem incluir o conte&#250;do de documentos &#233; fornecido.</dd>
+      <dd>Uma nova diretiva <directive module="mod_negotiation"
+      >ForceLanguagePriority</directive> pode ser usada para garantir que
+      o cliente receba um único documento em todos os casos, em vez de
+      respostas NOT ACCEPTABLE ou MULTIPLE CHOICES. Além disso, os
+      algoritmos de negociação e MultiViews foram aprimorados para
+      fornecer resultados mais consistentes e uma nova forma de mapa de tipos que
+      pode incluir o conteúdo do documento é fornecida.</dd>
 
       <dt><module>mod_autoindex</module></dt>
 
-      <dd>As listagens de diret&#243;rios autom&#225;ticas podem ser
-      configuradas para usar tabelas HTML para formata&#231;&#245;es mais limpas
-      e permitir controles mais acurados de classifica&#231;&#227;o, incluindo
-      ordena&#231;&#227;o por vers&#227;o e filtro da lista de
-      diret&#243;rios atrav&#233;s de caracteres-coringa.</dd>
+      <dd>Listagens de diretórios autoindexadas agora podem ser configuradas para
+      usar tabelas HTML para uma formatação mais limpa e permitir um controle mais refinado
+      da classificação, incluindo classificação por versão e filtragem
+      por curinga da listagem de diretórios.</dd>
 
       <dt><module>mod_include</module></dt>
 
-      <dd>Novas diretrizes permitem que as tags padr&#245;es <em>start</em> e
-      <em>end</em> para elementos SSI, possam ser alteradas e permitir que
-      as configura&#231;&#245;es de formatos de erro e hora sejam inclu&#237;dos no
-      arquivo de configura&#231;&#227;o principal, ao inv&#233;s de serem adicionadas
-      ao documento SSI. Resultados de an&#225;lises de express&#245;es regulares
-      e agrupamento (baseadas na sintaxe de express&#245;es regulares do Perl)
-      podem ser obtidas usando as vari&#225;veis do m&#243;dulo <module
-      >mod_include</module>, de <code>$0</code> a <code>$9</code>.</dd>
+      <dd>Novas diretivas permitem que as tags iniciais e finais padrão para elementos SSI
+      sejam alteradas e permitem que a configuração de erros e formatos de hora
+      ocorra no arquivo de configuração principal, em vez de no
+      documento SSI. Resultados da análise e agrupamento de expressões regulares
+      (agora baseados na sintaxe de expressões regulares do Perl) podem ser recuperados
+      usando as variáveis ​​<code>$0</code> do <module>mod_include</module>
+      .. <code>$9</code>.</dd>
 
       <dt><module>mod_auth_dbm</module></dt>
 
-      <dd>Agora suporta m&#250;ltiplos tipos de banco de dados similares ao DBM,
-      usando a diretriz <a href="../2.0/mod/mod_auth_dbm.html#AuthDBMType">
-	  <code>AuthDBMType</code></a>
-      .</dd>
+      <dd>Agora oferece suporte a vários tipos de bancos de dados semelhantes ao DBM usando
+      a diretiva <directive>AuthDBMType</directive>.</dd>
 
     </dl>
   </section>

--- a/docs/manual/new_features_2_2.xml.pt-br
+++ b/docs/manual/new_features_2_2.xml.pt-br
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <!DOCTYPE manualpage SYSTEM "./style/manualpage.dtd">
 <?xml-stylesheet type="text/xsl" href="./style/manual.pt-br.xsl"?>
-<!-- English Revision: 151408:1561569 (outdated) -->
-
+<!-- Brazilian Portuguese translation : leonardolara -->
+<!-- English Revision: 1561569 -->
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
@@ -22,107 +22,245 @@
 
 <manualpage metafile="new_features_2_2.xml.meta">
 
-<title>Descri&#231;&#227;o das novas funcionalidades do Apache 2.2</title>
+<title>Visão geral das novas funcionalidades do Servidor HTTP Apache 2.2</title>
 
 <summary>
-  <p>Esse documento descreve algumas das principais mudan&#231;as
-     entre as vers&#245;es 2.0 e 2.2 do Servidor HTTP Apache.
-     Para a lista de mudan&#231;as desde a vers&#227;o 1.3, veja a p&#225;gina
-     de documenta&#231;&#227;o <a href="new_features_2_0.html">novas funcionalidades
-     do Apache 2.0</a>.</p>
+  <p>Este documento descreve algumas das principais alterações
+     entre as versões 2.0 e 2.2 do Servidor HTTP Apache. Para novas funcionalidades desde a
+     versão 1.3, consulte o document sobre as <a href="new_features_2_0.html">novas
+     funcionalidades do Apache 2.0</a>.</p>
 </summary>
 
   <section id="core">
-    <title>Principais Melhorias</title>
+    <title>Melhorias do Núcleo</title>
     <dl>
 
-      <dt>Authn/Authz</dt>
-      <dd>...</dd>
+    <dt>Authn/Authz</dt>
+    <dd>Os módulos de autenticação e autorização incluídos foram
+        refatorados. O novo módulo mod_authn_alias (já removido da versão 2.3/2.4)
+        pode simplificar bastante certas configurações de autenticação.
+        Veja <a href="#module">as alterações no nome do módulo</a> e
+        <a href="#developer">as alterações para desenvolvedores</a> para mais
+        informações sobre como essas alterações afetam usuários e
+        escritores de módulos.</dd>
 
-      <dt>Caching</dt>
-      <dd>...</dd>
+    <dt>Cache</dt>
+    <dd><module>mod_cache</module>, <module>mod_cache_disk</module> e
+        mod_mem_cache (já removido da versão 2.3/2.4) passaram por muitas alterações e
+        agora são considerados de qualidade de produção. <program>htcacheclean</program>
+        foi introduzido para limpar as configurações do
+        <module>mod_cache_disk</module>.</dd>
 
-      <dt>Proxying</dt>
-      <dd>O novo m&#243;dulo <module>mod_proxy_balancer</module> fornece
-          servi&#231;os de carregamento de balenceamento para <module
-          >mod_proxy</module>. O novo m&#243;dulo <module>mod_proxy_ajp</module
-          > oferece suporte para o <code>Protocolo Apache JServ
-          vers&#227;o 1.3</code>, usado pelo <a
-          href="http://tomcat.apache.org/">Apache Tomcat</a>.</dd>
+    <dt>Configuração</dt>
+    <dd>O layout de configuração padrão foi simplificado e
+        modularizado. Trechos de configuração que podem ser usados ​​para
+        habilitar recursos comumente usados ​​agora estão incluídos no Apache e
+        podem ser facilmente adicionados à configuração principal do servidor.</dd>
 
-      <dt>Filtragem Inteligente (Smart Filtering)</dt>
-      <dd>O <module>mod_filter</module> introduz configura&#231;&#227;o din&#226;mica para
-          o filtro de sa&#237;da de dados. Permitindo que os filtros sejam
-	  condicionalmente inseridos, baseando-se nos cabe&#231;alhos <em
-	  >Request</em> ou <em>Response</em> ou em vari&#225;veis do
-	  ambiente, ele acaba com os problemas de depend&#234;ncias e pedidos
-          da arquitetura 2.0.</dd>
+    <dt>Parada gradual</dt>
+        <dd>Os MPMs <module>prefork</module>, <module>worker</module> e
+        <module>event</module> agora permitem que o <program>httpd</program>
+        seja encerrado gradualmente por meio do sinal
+        <a href="stopping.html#gracefulstop"><code>graceful-stop</code></a>.
+        A diretiva <directive
+        module="mpm_common">GracefulShutdownTimeout</directive>
+        foi adicionada para especificar um tempo limite opcional, após o qual
+        o <program>httpd</program> será encerrado independentemente do status
+        de quaisquer solicitações atendidas.</dd>
+
+    <dt>Proxy</dt>
+    <dd>O novo módulo <module>mod_proxy_balancer</module> fornece
+        serviços de balanceamento de carga para o <module>mod_proxy</module>.
+        O novo módulo <module>mod_proxy_ajp</module> adiciona suporte ao
+        <code>Protocolo Apache JServ versão 1.3</code> usado pelo
+        <a href="http://tomcat.apache.org/">Apache Tomcat</a>.</dd>
+
+    <dt>Biblioteca de Expressões Regulares Atualizada</dt>
+    <dd>A versão 5.0 da
+        <a href="http://www.pcre.org/">Biblioteca de Expressões Regulares
+        Compatível com Perl</a> (PCRE) agora está incluída. <program>httpd</program> pode ser
+        configurado para usar uma instalação de sistema da PCRE passando o sinalizador
+        <code>--with-pcre</code> para configurar.</dd>
+
+    <dt>Filtragem Inteligente</dt>
+    <dd><module>mod_filter</module> introduz a configuração dinâmica
+        à cadeia de filtros de saída. Ele permite que filtros sejam
+        inseridos condicionalmente, com base em qualquer cabeçalho de Solicitação ou Resposta ou variável de ambiente
+        e dispensa as dependências e
+        problemas de ordenação mais problemáticos da arquitetura 2.0.</dd>
+
+    <dt>Suporte a Arquivos Grandes</dt>
+        <dd><program>httpd</program> agora é compatível com arquivos maiores
+        que 2 GB em sistemas Unix modernos de 32 bits. Suporte para lidar com corpos de requisição
+        maiores que 2 GB também foi adicionado.</dd>
+
+    <dt>MPM de Eventos</dt>
+        <dd>O MPM <module>event</module> usa uma thread separada para lidar com
+        requisições Keep Alive e aceitar conexões. Requisições Keep Alive
+        tradicionalmente exigem que o httpd dedique um worker para lidar com elas.
+        Este worker dedicado não pode ser usado novamente até que o tempo limite de Keep Alive
+        seja atingido.</dd>
+
+    <dt>Suporte a Banco de Dados SQL</dt>
+        <dd><module>mod_dbd</module>, juntamente com o framework <code>apr_dbd</code>,
+        traz suporte SQL direto para módulos que precisam dele.
+        Suporta pool de conexões em MPMs com threads.</dd>
 
     </dl>
   </section>
 
   <section id="module">
-    <title>Melhorias nos M&#243;dulos</title>
+    <title>Melhorias nos Módulos</title>
     <dl>
-      <dt><module>mod_authnz_ldap</module></dt>
-      <dd>Este m&#243;dulo &#233; uma migra&#231;&#227;o do <code>mod_auth_ldap</code>,
-          da vers&#227;o 2.0 para a estrutura 2.2 de <code>Authn/Authz</code>.
-	  As novas funcionalidades incluem o uso de atributos LDAP e
-	  filtros de procura complexos na diretriz <directive module="mod_authz_core"
-          >Require</directive>.</dd>
+      <dt>Authn/Authz</dt>
+      <dd>Os módulos no diretório aaa foram renomeados e oferecem
+          melhor suporte para autenticação digest. Por exemplo,
+          <code>mod_auth</code> agora está dividido em
+          <module>mod_auth_basic</module> e
+          <module>mod_authn_file</module>; <code>mod_auth_dbm</code> agora
+          é chamado de <module>mod_authn_dbm</module>; <code>mod_access</code>
+          foi renomeado para <module>mod_authz_host</module>. Há também um novo
+          módulo mod_authn_alias (já removido da versão 2.3/2.4) para simplificar
+          certas configurações de autenticação.
+      </dd>
+
+      <dt><module outdated="true">mod_authnz_ldap</module></dt>
+      <dd>Este módulo é uma portabilidade do módulo
+          <code>mod_auth_ldap</code> 2.0 para o framework <code>Authn/Authz</code>
+          2.2. Os novos recursos incluem o uso de valores de atributos LDAP e
+          filtros de pesquisa complexos na diretiva
+          <directive module="mod_authz_core">Require</directive>.</dd>
+
+      <dt><module>mod_authz_owner</module></dt>
+      <dd>Um novo módulo que autoriza o acesso a arquivos com base
+          no proprietário do arquivo no sistema de arquivos</dd>
+
+      <dt><module>mod_version</module></dt>
+      <dd>Um novo módulo que permite habilitar blocos de configuração com base no
+          número da versão do servidor em execução.</dd>
 
       <dt><module>mod_info</module></dt>
-      <dd>Adicionado um novo argumento <code>?config</code> que
-          mostra a configura&#231;&#227;o das diretrizes analisadas pelo
-	  Apache, incluindo o nome do arquivo e o n&#250;mero da linha.
-	  Esse m&#243;dulo tamb&#233;m mostra a ordem de todos os ganchos de
-          pedidos (request hooks) e informa&#231;&#245;es adicionais sobre
-          a compila&#231;&#227;o, similar ao comando <code>httpd -V</code>.</dd>
+      <dd>Adicionado um novo argumento <code>?config</code> que mostrará
+          as diretivas de configuração conforme analisadas pelo Apache, incluindo
+          o nome do arquivo e o número da linha. O módulo também
+          mostra a ordem de todos os ganchos de solicitação e informações
+          de compilação adicionais, semelhante a <code>httpd -V</code>.</dd>
+
+      <dt><module>mod_ssl</module></dt>
+      <!-- Need Info on SSLEngine Support? -->
+      <dd>Adicionado suporte para
+          <a href="http://www.ietf.org/rfc/rfc2817.txt">RFC 2817</a>, que
+          permite que as conexões sejam atualizadas de texto simples para criptografia TLS.</dd>
+
+      <dt><module>mod_imagemap</module></dt>
+      <dd><code>mod_imap</code> foi renomeado para
+          <module>mod_imagemap</module> para evitar confusão para o usuário.</dd>
+    </dl>
+
+  </section>
+
+  <section id="programs">
+    <title>Aprimoramentos do Programa</title>
+    <dl>
+      <dt><program>httpd</program></dt>
+      <dd>Uma nova opção de linha de comando <code>-M</code> foi adicionada,
+          listando todos os módulos carregados com base na configuração
+          atual. Ao contrário da opção <code>-l</code>, esta lista
+          inclui DSOs carregados via <module>mod_so</module>.</dd>
+
+      <dt><program>httxt2dbm</program></dt>
+      <dd>Um novo programa usado para gerar arquivos dbm a partir de entrada de texto,
+          para uso na <directive module="mod_rewrite">RewriteMap</directive>
+          com o tipo de mapa <code>dbm</code>.</dd>
     </dl>
   </section>
 
   <section id="developer">
-    <title>Mudan&#231;as ao Desenvolvedor de M&#243;dulos</title>
+    <title>Alterações do Desenvolvedor de Módulos</title>
     <dl>
-      <dt>API do APR 1.0</dt>
+      <dt>API do <glossary>APR</glossary> 1.0</dt>
 
-      <dd>O Apache 2.2 utiliza a API do APR 1.0. Todas as fun&#231;&#245;es e
-          s&#237;mbolos antigos foram removidos do <code>APR</code> e
-	  <code>APR-Util</code>. Para mais detalhes, visite o
-          <a href="http://apr.apache.org/">Website do APR</a>.</dd>
+      <dd>O Apache 2.2 utiliza a API APR 1.0. Todas as funções e símbolos obsoletos
+          foram removidos do <code>APR</code> e do
+          <code>APR-Util</code>. Para mais detalhes, consulte o
+          <a href="http://apr.apache.org/">Site do APR</a>.</dd>
 
-      <dt>Registros de Erros de Conex&#227;o (logs)</dt>
+      <dt>Authn/Authz</dt>
+      <dd>Os módulos de autenticação e autorização incluídos foram
+          renomeados da seguinte forma:
+          <ul>
+          <li><code>mod_auth_*</code> -> Módulos que implementam um mecanismo
+          de autenticação HTTP</li>
+          <li><code>mod_authn_*</code> -> Módulos que fornecem um provedor
+          de autenticação backend</li>
+          <li><code>mod_authz_*</code> -> Módulos que implementam
+          autorização (ou acesso)</li>
+          <li><code>mod_authnz_*</code> -> Módulo que implementa
+          autenticação e autorização</li>
+          </ul>
+          Há um novo esquema de provedor de backend de autenticação
+          que facilita muito a construção de novos backends de
+          autenticação.</dd>
 
-      <dd>Uma nova fun&#231;&#227;o <code>ap_log_cerror</code>, foi adicionada
-          para registrar erros que ocorrem na conex&#227;o do cliente.
-	  Quando documentado no di&#225;rio de log, a mensagem inclui o
-	  endere&#231;o IP do cliente.</dd>
+      <dt>Registro de Erros de Conexão</dt>
 
-      <dt>Adicionado Gancho de Teste de Configura&#231;&#227;o</dt>
+      <dd>Uma nova função, <code>ap_log_cerror</code>, foi adicionada para registrar
+          erros que ocorrem com a conexão do cliente. Quando registrada,
+          a mensagem inclui o endereço IP do cliente.</dd>
 
-      <dd>Um novo gancho (hook), <code>test_config</code> foi
-          adicionado para auxiliar m&#243;dulos que querem executar
-	  c&#243;digos especiais apenas quando o usu&#225;rio passa o
-	  par&#226;metro <code>-t</code> para o httpd.</dd>
+      <dt>Gancho de Configuração de Teste Adicionado</dt>
 
-      <dt>Ajustar o Stacksize dos "Threaded MPM's"</dt>
+      <dd>Um novo gancho, <code>test_config</code>, foi adicionado para auxiliar
+          módulos que desejam executar código especial somente quando o usuário passa
+          <code>-t</code> para <program>httpd</program>.</dd>
 
-      <dd>Uma nova diretriz chamada <code>ThreadStackSize</code>,
-          foi adicionada para ajustar o tamanho das stacks em todos
-          os threadeds MPMs. Essa &#233; uma pr&#225;tica necess&#225;rio para alguns
-	  m&#243;dulos de terceiros em plataformas com tamanhos de stacks
-	  pequenos por padr&#227;o.</dd>
+      <dt>Definir Tamanho da Pilha do MPM com Threads</dt>
 
-      <dt>Negocia&#231;&#227;o de Protocolo para filtros de sa&#237;da</dt>
+      <dd>Uma nova diretiva, <directive module="mpm_common">ThreadStackSize</directive>,
+          foi adicionada para definir o tamanho da pilha
+          em todos os MPMs com threads. Isso é necessário
+          para alguns módulos de terceiros em plataformas com tamanho de
+          pilha de threads padrão pequeno.</dd>
 
-      <dd>No passado, todo filtro era respons&#225;vel por garantir
-          a gera&#231;&#227;o de cabe&#231;alhos de resposta correto que os afetava.
-	  Os filtros agora podem delegar o gerenciamento de protocolos
-	  comuns para <module>mod_filter</module>, usando chamadas
-	  de <code>ap_register_output_filter_protocol</code> ou
+      <dt>Manipulação de protocolo para filtros de saída</dt>
+
+      <dd>No passado, cada filtro era responsável por garantir
+          que gerasse os cabeçalhos de resposta corretos onde os
+          afetasse. Os filtros agora podem delegar o gerenciamento de protocolo comum para
+          <module>mod_filter</module>, usando as chamadas
+          <code>ap_register_output_filter_protocol</code> ou
           <code>ap_filter_protocol</code>.</dd>
 
-    </dl>
+      <dt>Gancho Monitor adicionado</dt>
+      <dd>O gancho Monitor permite que os módulos executem tarefas regulares/agendadas
+          no processo pai (raiz).</dd>
 
+      <dt>Alterações na API de expressões regulares</dt>
+
+      <dd>O cabeçalho <code>pcreposix.h</code> não está mais disponível;
+          ele foi substituído pelo novo cabeçalho <code>ap_regex.h</code>. A
+          implementação POSIX.2 <code>regex.h</code> exposta pelo antigo cabeçalho
+          agora está disponível no namespace <code>ap_</code>
+          de <code>ap_regex.h</code>. Chamadas para <code>regcomp</code>,
+          <code>regexec</code> e assim por diante podem ser substituídas por chamadas para
+          <code>ap_regcomp</code>, <code>ap_regexec</code>.</dd>
+
+      <dt>DBD Framework (API de Banco de Dados SQL)</dt>
+
+      <dd><p>Com o Apache 1.x e 2.0, os módulos que exigiam um backend SQL
+          tiveram que assumir a responsabilidade de gerenciá-lo eles mesmos. Além
+          de reinventar a roda, isso pode ser muito ineficiente,
+          por exemplo, quando vários módulos mantêm cada um suas próprias conexões.</p>
+
+      <p>O Apache 2.1 e versões posteriores fornecem a API <code>ap_dbd</code> para
+      gerenciar conexões de banco de dados (incluindo estratégias otimizadas
+      para MPMs com e sem thread), enquanto o APR 1.2 e versões posteriores fornecem
+      a API <code>apr_dbd</code> para interagir com o banco de dados.</p>
+
+      <p>Novos módulos DEVEM agora usar essas APIs para todas as operações
+      de banco de dados SQL. Os aplicativos existentes DEVEM ser atualizados para usá-las
+      quando possível, de forma transparente ou como uma opção recomendada
+      para seus usuários.</p></dd>
+    </dl>
   </section>
 </manualpage>

--- a/docs/manual/style/lang-targets.xml
+++ b/docs/manual/style/lang-targets.xml
@@ -197,7 +197,7 @@
 <!-- Portuguese                                                           -->
 <!-- ==================================================================== -->
 <property value=".xml.pt-br" name="inputext.pt-br"/>
-<property value=".html.pt-br" name="outputext.pt-br"/>
+<property value=".html.pt-br.utf8" name="outputext.pt-br"/>
 
 <target description="- builds Portuguese HTML files" name="pt-br">
     <html.generic lang="pt-br"/>
@@ -213,7 +213,9 @@
 <target description="- builds the Portuguese Konqueror Web Archive" depends="-off-pt-br" name="war-pt-br">
     <war.generic lang="pt-br"/>
 </target>
-
+<target description="- builds the Portuguese CHM file" name="chm-pt-br">
+    <chm.generic lang="pt-br"/>
+</target>
 <!-- Russian                                                              -->
 <!-- ==================================================================== -->
 <property value=".xml.ru" name="inputext.ru"/>

--- a/docs/manual/style/lang/pt-br.xml
+++ b/docs/manual/style/lang/pt-br.xml
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE language SYSTEM "../lang.dtd">
-<!-- English Revision: 333005 -->
-
+<!-- Brazilian Portuguese translation : leonardolara -->
+<!-- English Revision: 1919560 -->
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
@@ -21,87 +21,89 @@
 
 <language id="pt-br">
     <name>Portuguese</name>
-    <charset>ISO-8859-1</charset>
+    <charset>UTF-8</charset>
     <source-ext>.xml.pt-br</source-ext>
-    <target-ext>.html.pt-br</target-ext>
+    <target-ext>.html.pt-br.utf8</target-ext>
 
-    <!-- no sitemap yet
     <chm>
         <lang>0x416 Portuguese (Brazil)</lang>
         <toc-font>,8,0</toc-font>
         <charset>windows-1252</charset>
         <settings>Portuguese (Brazil)</settings>
     </chm>
-    -->
 
-    <!-- only English ATM
     <man>
-        <charset>ISO-8859-1</charset>
+        <charset>UTF-8</charset>
     </man>
-    -->
 
     <!-- Some strings might be used in other contexts, than stated in the -->
     <!-- comments...                                                      -->
     <messages>
         <!-- language link titles -->
-        <message id="nativename">Portugu&#234;s (Brasil)</message>
+        <message id="nativename">Português (Brasil)</message>
 
         <!-- Used for the moduleindex -->
-        <message id="corefeatures">Principais Funcionalidades e M&#243;dulos de Multi-Processos (MPM)</message>
-        <message id="othermodules">Outros M&#243;dulos</message>
-        <message id="obsoletemodules">M&#243;dulos Obsoletos</message>
+        <message id="corefeatures">Principais Funcionalidades e Módulos de
+            Multiprocessamento (MPM)</message>
+        <message id="othermodules">Outros Módulos</message>
+        <message id="obsoletemodules">Módulos Obsoletos</message>
 
         <!-- Used for the modulesynopsis and sitemap -->
-        <message id="obsoleteapachemodule">M&#243;dulo Obsoleto Apache</message>
-        <message id="apachemodule">M&#243;dulo Apache</message>
+        <message id="obsoleteapachemodule">Módulo Apache Obsoleto</message>
+        <message id="apachemodule">Módulo Apache</message>
         <message id="apachecore">Principais Funcionalidades do Apache</message>
-        <message id="apachempmcommon">Diretrizes Comuns Apache MPM</message>
+        <message id="apachempmcommon">Diretivas Comuns Apache MPM</message>
         <message id="apachempm">Apache MPM</message>
 
         <!-- Used in description box for modulesynopsis -->
-        <message id="description">Descri&#231;&#227;o</message>
-        <message id="seealso">Veja tamb&#233;m</message>
-        <message id="topics">T&#243;picos</message>
+        <message id="description">Descrição</message>
+        <message id="seealso">Veja também</message>
+        <message id="topics">Tópicos</message>
         <message id="status">Status</message>
-        <message id="moduleidentifier">Identificador de M&#243;dulo</message>
-        <message id="sourcefile">Arquivo Fonte</message>
+        <message id="moduleidentifier">Identificador&nbsp;de&nbsp;Módulo</message>
+        <message id="sourcefile">Arquivo&nbsp;Fonte</message>
         <message id="compatibility">Compatibilidade</message>
-        <message id="before-since">Available in Apache HTTP Server </message>
-        <message id="after-since"> and later.</message>
+        <message id="before-since">Disponível no Servidor HTTP Apache </message>
+        <message id="after-since"> e posteriores.</message>
 
         <!-- Used in manualpage -->
-        <message id="relatedmodules">M&#243;dulos Relacionados</message>
-        <message id="relateddirectives">Diretrizes Relacionadas</message>
-        <message id="foundabug">Bugfix checklist</message>
-        <message id="httpdchangelog">httpd changelog</message>
-        <message id="httpdknownissues">Known issues</message>
-        <message id="httpdreportabug">Report a bug</message>
-        <message id="permalink">Permanent link</message>
+        <message id="relatedmodules">Módulos Relacionados</message>
+        <message id="relateddirectives">Diretivas Relacionadas</message>
+        <message id="lowercase">abcdefghijklmnopqrstuvwxyz</message>
+        <message id="uppercase">ABCDEFGHIJKLMNOPQRSTUVWXYZ</message>
+        <message id="name-section">NOME</message>
+        <message id="hyphenation"></message>
+        <message id="foundabug">Lista de verificação de problemas</message>
+        <message id="httpdchangelog">Registro de alterações httpd</message>
+        <message id="httpdknownissues">Problemas conhecidos</message>
+        <message id="httpdreportabug">Reporte um problema</message>
+        <message id="permalink">Link permanente</message>
 
         <!-- Used in description box for directives -->
         <message id="syntax">Sintaxe</message>
-        <message id="default">Padr&#227;o</message>
+        <message id="default">Padrão</message>
         <message id="context">Contexto</message>
-        <message id="override">Sobrescreve</message>
+        <message id="override">Override</message>
         <message id="status">Status</message>
-        <message id="module">M&#243;dulo</message>
+        <message id="module">Módulo</message>
 
         <!-- Status descriptions -->
         <message id="base" letter="B">Base</message>
         <message id="mpm" letter="M">MPM</message>
         <message id="core" letter="C">Core</message>
-        <message id="extension" letter="E">Extension</message>
+        <message id="extension" letter="E">Extensão</message>
         <message id="experimental" letter="X">Experimental</message>
-        <message id="external" letter="T">External</message>
+        <message id="external" letter="T">Externo</message>
 
         <!-- Used in directive context lists -->
-        <message id="serverconfig" letter="s">configura&#231;&#227;o do servidor</message>
-        <message id="virtualhost" letter="v">hospedeiro virtual</message>
-        <message id="directory" letter="d">diret&#243;rio</message>
+        <message id="serverconfig" letter="s">configuração do servidor</message>
+        <message id="virtualhost" letter="v">host virtual</message>
+        <message id="directory" letter="d">diretório</message>
         <message id="htaccess" letter="h">.htaccess</message>
+        <message id="proxy" letter="p">seção de proxy</message>
 
         <!-- Used for directive lists -->
-        <message id="directives">Diretrizes</message>
+        <message id="directives">Diretivas</message>
         <!-- the optional attribute replace-space-with takes a string.
              if present, the space between <directive name> and 'Directive'
              in directivesynopsis headings will be replaced by the given string.
@@ -109,57 +111,58 @@
         <!-- the optional attribute before-name takes a string.
              if "yes", the 'Directive' word is place before the name instead of
              being placed behind. See fr.xml for an example. -->
-        <message id="directive">Diretrizes</message>
-        <message id="nodirectives">Esse m&#243;dulo n&#227;o fornece nenhuma diretriz.</message>
+        <message id="directive">Diretivas</message>
+        <message id="nodirectives">Este módulo não tem
+             diretivas.</message>
 
         <!-- Used in summaries -->
-        <message id="summary">Sum&#225;rio</message>
+        <message id="summary">Sumário</message>
 
         <!-- Used for glossary link titles -->
-        <message id="glossarylink">ver gloss&#225;rio</message>
+        <message id="glossarylink">ver glossário</message>
 
         <!-- Used in headers and footers -->
         <message id="apachetitle">- Servidor HTTP Apache</message>
-        <message id="apachehttpserver">Servidor HTTP Apache Vers&#227;o
+        <message id="apachehttpserver">Servidor HTTP Apache Versão
             &httpd.major;.&httpd.minor;</message>
-        <message id="apachedocalt">[DOCUMENTA&#199;&#195;O APACHE]</message>
+        <message id="apachedocalt">[DOCUMENTAÇÃO APACHE]</message>
         <message id="search">Busca Google</message> <!-- search button -->
-        <message id="index">&#205;ndice</message> <!-- deprecated -->
-        <message id="home">In&#237;cio</message> <!-- deprecated -->
-        <message id="comments">Coment�rios</message>
+        <message id="index">Índice</message> <!-- deprecated -->
+        <message id="home">Início</message> <!-- deprecated -->
+        <message id="comments">Comentários</message>
 
         <!-- breadcrumb links -->
         <message id="apache">Apache</message>
         <message id="http-server">Servidor HTTP</message>
-        <message id="documentation">Documenta&#231;&#227;o</message>
-        <message id="version">Vers&#227;o &httpd.major;.&httpd.minor;</message>
+        <message id="documentation">Documentação</message>
+        <message id="version">Versão &httpd.major;.&httpd.minor;</message>
 
         <!-- super menu -->
-        <message id="modules">M&#243;dulos</message>
+        <message id="modules">Módulos</message>
         <message id="faq">FAQ</message>
-        <message id="glossary">Gloss&#225;rio</message>
+        <message id="glossary">Glossário</message>
         <message id="sitemap">Mapa do site</message>
 
         <!-- footer line -->
         <message id="before-license">Licenciado sob a</message>
         <message id="after-license"></message>
-        <message id="langavail">L&#237;nguas Dispon&#237;veis</message>
+        <message id="langavail">Idiomas Disponíveis</message>
 
         <!-- not up to date -->
-        <message id="outofdate">Esta tradu&#231;&#227;o pode estar desatualizada.
-        Confira a vers&#227;o em Ingl&#234;s para mudan&#231;as recentes.</message>
+        <message id="outofdate">Esta tradução pode estar desatualizada.
+        Confira a versão em inglês para alterações recentes.</message>
         <!-- directive not translated yet -->
-        <message id="nottranslated">The documentation for this directive has
-            not been translated yet. Please have a look at the English
-            version.</message>
+        <message id="nottranslated">A documentação para esta diretiva ainda
+            não foi traduzida. Por favor consulte a versão em
+            inglês.</message>
 
         <!-- retirement -->
-        <message id="retired.headline">Please note</message>
+        <message id="retired.headline">Favor observar</message>
         <message id="retired.description">
-            <p>This document refers to the <strong>2.0</strong> version of Apache httpd, which <strong>is no longer maintained</strong>. Upgrade, and refer to the current version of httpd instead, documented at:</p>
+            <p>Este documento refere-se à versão <strong>2.0</strong> do Apache httpd, que <strong>não é mais mantida</strong>. Atualize e refira-se à versão atual do httpd, documentada em:</p>
         </message>
-        <message id="retired.current">Current release version of Apache HTTP Server documentation</message>
-        <message id="retired.document">You may follow <link>this link</link> to go to the current version of this document.</message>
+        <message id="retired.current">Versão atual da documentação do Servidor HTTP Apache</message>
+        <message id="retired.document">Favor seguir <link>este atalho</link> para a versão atual deste documento.</message>
 
     </messages>
 </language>

--- a/docs/manual/style/manual.pt-br.xsl
+++ b/docs/manual/style/manual.pt-br.xsl
@@ -18,7 +18,7 @@
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:output method="xml" encoding="ISO-8859-1" indent="no" doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN" doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"/>
+<xsl:output method="xml" encoding="UTF-8" indent="no" doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN" doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"/>
 
 <!-- Read the localized messages from the specified language file -->
 <xsl:variable name="message" select="document('lang/pt-br.xml')/language/messages/message"/>
@@ -26,7 +26,7 @@
 <xsl:variable name="allmodules" select="document('xsl/util/allmodules.xml')/items/item[@lang=$doclang]"/>
 
 <!-- some meta information have to be passed to the transformation -->
-<xsl:variable name="output-encoding">ISO-8859-1</xsl:variable>
+<xsl:variable name="output-encoding">UTF-8</xsl:variable>
 <xsl:variable name="is-chm" select="false()"/>
 <xsl:variable name="is-zip" select="false()"/>
 <xsl:variable name="is-retired" select="false()"/>


### PR DESCRIPTION
For PT-BR language only:
Updates targets to assume and generate UTF-8 files.
Creates CHM target.
Improves/fixes translations.
Sync translated pages with EN-revision.