### PR TITLE
util_ldap: prevent double-free by nullifying pointer after free()

### DIFF
--- a/modules/ldap/util_ldap_cache_mgr.c
+++ b/modules/ldap/util_ldap_cache_mgr.c
@@ -80,18 +80,25 @@ void util_ald_free(util_ald_cache_t *cache, const void *ptr)
 {
 #if APR_HAS_SHARED_MEMORY
     if (cache->rmm_addr) {
-        if (ptr)
+        if (ptr) {
             /* Free in shared memory */
-            apr_rmm_free(cache->rmm_addr, apr_rmm_offset_get(cache->rmm_addr, (void *)ptr));
+            apr_rmm_free(cache->rmm_addr,
+                         apr_rmm_offset_get(cache->rmm_addr, (void *)ptr));
+            ptr = NULL;
+        }
     }
     else {
-        if (ptr)
+        if (ptr) {
             /* Cache shm is not used */
             free((void *)ptr);
+            ptr = NULL;
+        }
     }
 #else
-    if (ptr)
+    if (ptr) {
         free((void *)ptr);
+        ptr = NULL;
+    }
 #endif
 }
 


### PR DESCRIPTION
In util_ald_free(), memory referenced by `ptr` is freed without resetting the pointer. If this function (or cleanup routines) are invoked multiple times on the same pointer, a double-free can occur, leading to memory corruption.

Fix by wrapping free() in braces and setting the pointer to NULL after freeing in both shared-memory and non-shared-memory branches. This improves memory safety and prevents accidental reuse of freed pointers.