### PR TITLE
mod_systemd: validate LISTEN_FDS environment variable before atoi()

### DIFF
--- a/modules/arch/unix/mod_systemd.c
+++ b/modules/arch/unix/mod_systemd.c
@@ -139,8 +139,16 @@ static int ap_find_systemd_socket(process_rec * process, apr_port_t port) {
         return -1;
     }
 
-    fdcount = atoi(getenv("LISTEN_FDS"));
-    for (fd = SD_LISTEN_FDS_START; fd < SD_LISTEN_FDS_START + fdcount; fd++) {
+const char *listen_fds_env = getenv("LISTEN_FDS");
+if (!listen_fds_env) {
+    ap_log_perror(APLOG_MARK, APLOG_CRIT, 0, process->pool, APLOGNO(02488)
+                  "find_systemd_socket: LISTEN_FDS environment variable is missing");
+    return -1;
+}
+
+fdcount = atoi(listen_fds_env);
+
+  for (fd = SD_LISTEN_FDS_START; fd < SD_LISTEN_FDS_START + fdcount; fd++) {
         if (sd_is_socket_inet(fd, 0, 0, -1, port) > 0) {
             return fd;
         }


### PR DESCRIPTION
In ap_find_systemd_socket(), getenv("LISTEN_FDS") was called and passed directly to atoi() without verifying if getenv() returned NULL. If the LISTEN_FDS environment variable is missing, this results in undefined behavior and can cause a segmentation fault.

Fix:
- Store the result of getenv() in a local variable.
- Check for NULL before calling atoi().
- Log an error and return -1 if LISTEN_FDS is missing.

This prevents a potential crash (Denial of Service) when running under systemd without the LISTEN_FDS environment variable set.