### PR TITLE
Fix cross build

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -406,7 +406,7 @@ dnl ### need to move some of the arguments "up here"
 dnl ## Check for programs
 
 AC_PATH_PROG(RM, rm)
-AC_PATH_PROG(PKGCONFIG, pkg-config)
+AC_PATH_TOOL(PKGCONFIG, pkg-config)
 AC_PATH_PROG(RSYNC, rsync)
 AC_PATH_PROG(SVN, svn)
 AC_PROG_AWK


### PR DESCRIPTION
./configure fails finding .pc files, because it uses the build architecture pkg-config. It should be using AC_PATH_TOOL (or better PKG_PROG_PKG_CONFIG) rather than AC_PATH_PROG.

@rpluem 