### PR TITLE
Do not test euid=0 before going chroot

### DIFF
--- a/modules/arch/unix/mod_unixd.c
+++ b/modules/arch/unix/mod_unixd.c
@@ -152,12 +152,6 @@ AP_DECLARE(int) ap_unixd_setup_child(void)
     }
 
     if (NULL != ap_unixd_config.chroot_dir) {
-        if (geteuid()) {
-            ap_log_error(APLOG_MARK, APLOG_ALERT, 0, NULL, APLOGNO(02158)
-                         "Cannot chroot when not started as root");
-            return EPERM;
-        }
-
         if (chdir(ap_unixd_config.chroot_dir) != 0) {
             rv = errno;
             ap_log_error(APLOG_MARK, APLOG_ALERT, errno, NULL, APLOGNO(02159)


### PR DESCRIPTION
Nowaday chroot need CAP_SYS_CHROOT capability in its user namespace, and could work without root.

Will allow to use chroot with lesser permission.