### PR TITLE
mod_proxy, mod_proxy_http: add options to tackle headers with underscores

### DIFF
--- a/modules/proxy/mod_proxy.c
+++ b/modules/proxy/mod_proxy.c
@@ -1591,6 +1591,8 @@ static void * create_proxy_config(apr_pool_t *p, server_rec *s)
     ps->id = apr_psprintf(p, "p%x", 1); /* simply for storage size */
     ps->viaopt = via_off; /* initially backward compatible with 1.3.1 */
     ps->viaopt_set = 0; /* 0 means default */
+    ps->underscored_headers = underscored_headers_allow; /* don't introduce breaking change */
+    ps->underscored_headers_set = 0;
     ps->req = 0;
     ps->max_balancers = 0;
     ps->bal_persist = 0;
@@ -1752,6 +1754,8 @@ static void * merge_proxy_config(apr_pool_t *p, void *basev, void *overridesv)
     ps->id = (overrides->id == NULL) ? base->id : overrides->id;
     ps->viaopt = (overrides->viaopt_set == 0) ? base->viaopt : overrides->viaopt;
     ps->viaopt_set = overrides->viaopt_set || base->viaopt_set;
+    ps->underscored_headers = (overrides->underscored_headers_set == 0) ? base->underscored_headers : overrides->underscored_headers;
+    ps->underscored_headers_set = overrides->underscored_headers_set || base->underscored_headers_set;
     ps->req = (overrides->req_set == 0) ? base->req : overrides->req;
     ps->req_set = overrides->req_set || base->req_set;
     ps->bgrowth = (overrides->bgrowth_set == 0) ? base->bgrowth : overrides->bgrowth;
@@ -2578,6 +2582,25 @@ static const char*
 }
 
 static const char*
+    set_underscored_headers(cmd_parms *parms, void *dummy, const char *arg)
+{
+    proxy_server_conf *psf =
+    ap_get_module_config(parms->server->module_config, &proxy_module);
+
+    if (strcasecmp(arg, "Allow") == 0)
+        psf->underscored_headers = underscored_headers_allow;
+    else if (strcasecmp(arg, "Drop") == 0)
+        psf->underscored_headers = underscored_headers_drop;
+    else if (strcasecmp(arg, "Reject") == 0)
+        psf->underscored_headers = underscored_headers_reject;
+    else
+        return "ProxyUnderscoredHeaders must be one of: Allow | Drop | Reject";
+
+    psf->underscored_headers_set = 1;
+    return NULL;
+}
+
+static const char*
     set_bad_opt(cmd_parms *parms, void *dummy, const char *arg)
 {
     proxy_server_conf *psf =
@@ -3066,6 +3089,8 @@ static const command_rec proxy_cmds[] =
      "The default intranet domain name (in absence of a domain in the URL)"),
     AP_INIT_TAKE1("ProxyVia", set_via_opt, NULL, RSRC_CONF,
      "Configure Via: proxy header header to one of: on | off | block | full"),
+    AP_INIT_TAKE1("ProxyUnderscoredHeaders", set_underscored_headers, NULL, RSRC_CONF,
+     "Handling of headers with underscores to backend: allow | drop | reject"),
     AP_INIT_ITERATE("ProxyErrorOverride", set_proxy_error_override, NULL, RSRC_CONF|ACCESS_CONF,
      "use our error handling pages instead of the servers' we are proxying"),
     AP_INIT_FLAG("ProxyPreserveHost", set_preserve_host, NULL, RSRC_CONF|ACCESS_CONF,

--- a/modules/proxy/mod_proxy.h
+++ b/modules/proxy/mod_proxy.h
@@ -173,6 +173,11 @@ typedef struct {
       via_block,
       via_full
     } viaopt;                   /* how to deal with proxy Via: headers */
+    enum {
+        underscored_headers_allow,
+        underscored_headers_drop,
+        underscored_headers_reject
+    } underscored_headers;
     apr_size_t recv_buffer_size;
     apr_size_t io_buffer_size;
     long maxfwd;
@@ -194,6 +199,7 @@ typedef struct {
 
     unsigned int req_set:1;
     unsigned int viaopt_set:1;
+    unsigned int underscored_headers_set:1;
     unsigned int recv_buffer_size_set:1;
     unsigned int io_buffer_size_set:1;
     unsigned int maxfwd_set:1;

--- a/modules/proxy/mod_proxy_http.c
+++ b/modules/proxy/mod_proxy_http.c
@@ -28,6 +28,34 @@ static int (*ap_proxy_clear_connection_fn)(request_rec *r, apr_table_t *headers)
 static apr_status_t ap_proxygetline(apr_bucket_brigade *bb, char *s, int n,
                                     request_rec *r, int flags, int *read);
 
+static int filter_underscored_headers(request_rec *r, proxy_server_conf *conf)
+{
+    const apr_array_header_t *hdrs_arr = apr_table_elts(r->headers_in);
+    const apr_table_entry_t *hdrs = (const apr_table_entry_t *) hdrs_arr->elts;
+    int i;
+
+    if (conf->underscored_headers == underscored_headers_allow)
+        return OK;
+
+    for (i = 0; i < hdrs_arr->nelts; i++) {
+        if (!hdrs[i].key) continue;
+        if (!ap_strchr(hdrs[i].key, '_')) continue;
+        if (conf->underscored_headers == underscored_headers_drop) {
+            ap_log_rerror(APLOG_MARK, APLOG_TRACE1, 0, r,
+                          "dropped underscored header '%s'", hdrs[i].key);
+            apr_table_unset(r->headers_in, hdrs[i].key);
+        }
+        if (conf->underscored_headers == underscored_headers_reject) {
+            ap_log_rerror(APLOG_MARK, APLOG_INFO, 0, r,
+                          "rejected request for underscored header '%s'",
+                          hdrs[i].key);
+            return HTTP_BAD_REQUEST;
+        }
+    }
+
+    return OK;
+}
+
 static const char *get_url_scheme(const char **url, int *is_ssl)
 {
     const char *u = *url;
@@ -1965,6 +1993,13 @@ static int proxy_http_handler(request_rec *r, proxy_worker *worker,
         return DECLINED;
     }
     ap_log_rerror(APLOG_MARK, APLOG_TRACE1, 0, r, "HTTP: serving URL %s", url);
+
+    /* check if any request header contains underscore (_), 
+       drop such header or reject the whole request accordingly to conf
+    */
+    if ((status = filter_underscored_headers(r, conf)) != OK) {
+        return status;
+    }
 
     /* create space for state information */
     if ((status = ap_proxy_acquire_connection(scheme, &backend,


### PR DESCRIPTION
mod_proxy and mod_proxy_http currently pass request headers from user-agent to the backend, (url in `ProxyPass`) including those contains underscores. (`_`)

this may cause security issues with certain backends, per [Section 17.10 of RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#section-17.10).

an example of such issue could be described as below:

> Python's WSGI standard ([PEP 3333](https://peps.python.org/pep-3333/#environ-variables)) defined that WSGI server should pass HTTP request headers to WSGI application with `HTTP_` prefixed keys in `environ` dictionary. this behaviour is similar to CGI.
> during this procedure, all alphabets are uppercased and dashes (`-`) are converted to underscore (`_`), says, `X-Forwarded-For` is converted to `HTTP_X_FORWARDED_FOR`.
> while underscore itself is remain unconverted, e.g. `X_Forwarded_For` is also mapped to `HTTP_X_FORWARDED_FOR`.
> A malign actor may set `X_Forwarded_For` or something like `X-Forwarded_For` to trick the backend with a fake remote-IP, as frontend (apache) only 'always set' `X-Forwarded-For`, not the malformed version with underscores.

this patch introduces a new configuration entry `ProxyUnderscoredHeaders`, which has 3 possible options listed below, to mitigate such issues.

- `Allow`: allow all headers to be passed to the backend including those with underscores (default)
- `Drop`: remove headers with underscores in keys and pass remains to the backend
- `Reject`: reject the request with *400 Bad Request* if headers with underscores were found

the `Allow` option, as default, avoids breaking changes to current behaviour, while `Drop` and `Reject` could be used to help mitigate such security issues.

also notice that nginx has a similar option named [underscores_in_headers](https://nginx.org/en/docs/http/ngx_http_core_module.html#underscores_in_headers).