### PR TITLE
mod_ssl: Drop szCryptoDevice from SSLModConfigRec for non-ENGINE builds

### DIFF
--- a/modules/ssl/ssl_engine_config.c
+++ b/modules/ssl/ssl_engine_config.c
@@ -693,14 +693,17 @@ const char *ssl_cmd_SSLCryptoDevice(cmd_parms *cmd,
     }
 
     if (strcEQ(arg, "builtin")) {
+#if !MODSSL_HAVE_ENGINE_API
+        ap_log_error(APLOG_MARK, APLOG_WARNING, 0, cmd->server, APLOGNO(10542)
+                     "'SSLCryptoDevice builtin' is deprecated and has no effect");
+#else
         mc->szCryptoDevice = NULL;
     }
-#if MODSSL_HAVE_ENGINE_API
     else if ((e = ENGINE_by_id(arg))) {
         mc->szCryptoDevice = arg;
         ENGINE_free(e);
-    }
 #endif
+    }
     else {
         err = "SSLCryptoDevice: Invalid argument; must be one of: "
               "'builtin' (none)";

--- a/modules/ssl/ssl_engine_init.c
+++ b/modules/ssl/ssl_engine_init.c
@@ -1546,6 +1546,12 @@ static int ssl_no_passwd_prompt_cb(char *buf, int size, int rwflag,
                                      && ERR_GET_REASON(ec) != X509_R_UNKNOWN_KEY_TYPE))
 #endif
 
+#if MODSSL_HAVE_ENGINE_API
+#define LOG_SOURCE(mc_) ((mc_)->szCryptoDevice ? (mc_)->szCryptoDevice : "provider")
+#else
+#define LOG_SOURCE(mc_) "provider"
+#endif
+
 static apr_status_t ssl_init_server_certs(server_rec *s,
                                           apr_pool_t *p,
                                           apr_pool_t *ptemp,
@@ -1623,9 +1629,7 @@ static apr_status_t ssl_init_server_certs(server_rec *s,
                 if (SSL_CTX_use_certificate(mctx->ssl_ctx, cert) < 1) {
                     ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s, APLOGNO(10137)
                                  "Failed to configure certificate %s from %s, check %s",
-                                 key_id, mc->szCryptoDevice ?
-                                             mc->szCryptoDevice : "provider",
-                                 certfile);
+                                 key_id, LOG_SOURCE(mc), certfile);
                     ssl_log_ssl_error(SSLLOG_MARK, APLOG_EMERG, s);
                     return APR_EGENERAL;
                 }
@@ -1637,8 +1641,7 @@ static apr_status_t ssl_init_server_certs(server_rec *s,
             if (SSL_CTX_use_PrivateKey(mctx->ssl_ctx, pkey) < 1) {
                 ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s, APLOGNO(10130)
                              "Failed to configure private key %s from %s",
-                             keyfile, mc->szCryptoDevice ?
-                                          mc->szCryptoDevice : "provider");
+                             keyfile, LOG_SOURCE(mc));
                 ssl_log_ssl_error(SSLLOG_MARK, APLOG_EMERG, s);
                 return APR_EGENERAL;
             }

--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -704,7 +704,9 @@ typedef struct {
     apr_array_header_t   *aRandSeed;
 #endif
 
+#if MODSSL_HAVE_ENGINE_API
     const char     *szCryptoDevice; /* ENGINE device (if available) */
+#endif
 
 #ifdef HAVE_OCSP_STAPLING
     const ap_socache_provider_t *stapling_cache;


### PR DESCRIPTION
```
* modules/ssl/ssl_private.h (SSLModConfigRec): Make szCryptoDevice
  conditional on ENGINE API support.

* modules/ssl/ssl_engine_config.c (ssl_cmd_SSLCryptoDevice): Log a warning if the directive is used in a non-ENGINE OpenSSL build; only touch szCryptoDevice for with-ENGINE builds.

* modules/ssl/ssl_engine_init.c (ssl_init_server_certs): Only use szCryptoDevice for with-ENGINE builds.
```