### PR TITLE
fix: add missing .gz extension for application/gzip media type

### DIFF
--- a/docs/conf/mime.types
+++ b/docs/conf/mime.types
@@ -118,7 +118,7 @@ application/font-tdpfr				pfr
 application/gml+xml				gml
 application/gpx+xml				gpx
 application/gxf					gxf
-# application/gzip
+application/gzip				gz
 # application/h224
 # application/held+xml
 # application/http


### PR DESCRIPTION
See https://www.rfc-editor.org/rfc/rfc6713.html#section-3