### PR TITLE
md_crypt/md_ocsp: free BIGNUMs correctly

### DIFF
--- a/modules/md/md_crypt.c
+++ b/modules/md/md_crypt.c
@@ -1244,7 +1244,7 @@ const char *md_cert_get_serial_number(const md_cert_t *cert, apr_pool_t *p)
         serial = BN_bn2hex(bn);
         s = apr_pstrdup(p, serial);
         OPENSSL_free((void*)serial);
-        OPENSSL_free((void*)bn);
+        BN_free(bn);
     }
     return s;
 }
@@ -2254,7 +2254,7 @@ apr_status_t md_cert_get_ari_cert_id(const char **pari_cert_id,
     memset(&ser_buf, 0, sizeof(ser_buf));
     bn = ASN1_INTEGER_to_BN(serial, NULL);
     sder_len = BN_bn2bin(bn, sbuf);
-    OPENSSL_free((void*)bn);
+    BN_free(bn);
     if (sder_len < 1)
         return APR_EINVAL;
     ser_buf.len = (apr_size_t)sder_len;

--- a/modules/md/md_ocsp.c
+++ b/modules/md/md_ocsp.c
@@ -532,7 +532,7 @@ static const char *certid_summary(const OCSP_CERTID *certid, apr_pool_t *p)
         bn = ASN1_INTEGER_to_BN(aserial, NULL);
         s = BN_bn2hex(bn);
         serial = apr_pstrdup(p, s);
-        OPENSSL_free((void*)bn);
+        BN_free(bn);
         OPENSSL_free((void*)s);
     }
     return apr_psprintf(p, "certid[der=%s, issuer=%s, key=%s, serial=%s]",


### PR DESCRIPTION
OpenSSL BIGNUMs should be freed with BN_free() since they (usually) have an allocated bn->d array of BN_ULONG, which the call to OPENSSL_free() leaks.