### PR TITLE
fix file getting unmapped erroneously when server is under load in multi-threaded multi-core configuration

### DIFF
--- a/modules/cache/mod_file_cache.c
+++ b/modules/cache/mod_file_cache.c
@@ -275,9 +275,8 @@ static int mmap_handler(request_rec *r, a_file *file)
     apr_mmap_t *mm;
     apr_bucket_brigade *bb = apr_brigade_create(r->pool, c->bucket_alloc);
 
-    apr_mmap_dup(&mm, file->mm, r->pool);
-    b = apr_bucket_mmap_create(mm, 0, (apr_size_t)file->finfo.size,
-                               c->bucket_alloc);
+    b = apr_bucket_immortal_create((const char *)file->mm->mm,
+                                  (apr_size_t)file->finfo.size, c->bucket_alloc);
     APR_BRIGADE_INSERT_TAIL(bb, b);
     b = apr_bucket_eos_create(c->bucket_alloc);
     APR_BRIGADE_INSERT_TAIL(bb, b);


### PR DESCRIPTION
As I described in my bugzilla report: [link](https://bz.apache.org/bugzilla/show_bug.cgi?id=69901).
the mod_file_cache module is not thread safe and causes files to get unmapped erroneously when the server is under load in a multi-threaded multi-core configuration.

The bug is caused by concurrent access to the apr_mmap_t ring of the file during creation/destruction of the mmap buckets.
This PR fixes this bug by using immortal buckets, which do not require adding a new apr_mmap_t to the ring.  
Since the files are mapped for the entirety of the server runtime, they will always outlive the immortal buckets, which live until the end of the request.  

I have stress tested this version with 0 failed transactions for over 30 minutes(compared to <0.1s before siege bailed out due to too many failures with the original code)