### PR TITLE
[2.4.x] mod_dav_fs: Merge r1926172 from trunk

### DIFF
--- a/changes-entries/pr60746.txt
+++ b/changes-entries/pr60746.txt
@@ -1,0 +1,2 @@
+  *) mod_dav_fs: Return a 404 for DELETE if deletion fails because the
+     resource no longer exists.  PR 60746.  [Joe Orton]

--- a/modules/dav/fs/repos.c
+++ b/modules/dav/fs/repos.c
@@ -1486,8 +1486,16 @@ static dav_error * dav_fs_remove_resource(dav_resource *resource,
 
     /* not a collection; remove the file and its properties */
     if ((status = apr_file_remove(info->pathname, info->pool)) != APR_SUCCESS) {
-        /* ### put a description in here */
-        return dav_new_error(info->pool, HTTP_FORBIDDEN, 0, status, NULL);
+        if (APR_STATUS_IS_ENOENT(status)) {
+            /* Return a 404 if there is a race with another DELETE,
+             * per RFC 4918§9.6. */
+            return dav_new_error(info->pool, HTTP_NOT_FOUND, 0, status,
+                                 "Cannot remove already-removed resource.");
+        }
+        else {
+            return dav_new_error(info->pool, HTTP_FORBIDDEN, 0, status,
+                                 "Cannot remove resource");
+        }
     }
 
     /* update resource state */


### PR DESCRIPTION
```
* modules/dav/fs/repos.c (dav_fs_remove_resource):
  Return a 404 if apr_file_remove() fails with an ENOENT error,
  likely due to a race with another DELETE.

PR: 60746
Github: closes #535

(cherry picked from commit 39265983d176647fff3c8467a2823244d6f03ee4)

```
