### PR TITLE
[2.4.x] mod_file_cache: Merge r1930632, r1930633 from trunk

### DIFF
--- a/changes-entries/pr69901.txt
+++ b/changes-entries/pr69901.txt
@@ -1,0 +1,3 @@
+  *) mod_file_cache: Fix crashes for mmap'ed files under threaded
+     MPMs. PR 69901. barr.israel <barr.israel campus.technion.ac.il>
+

--- a/modules/cache/mod_file_cache.c
+++ b/modules/cache/mod_file_cache.c
@@ -275,9 +275,8 @@ static int mmap_handler(request_rec *r, a_file *file)
     apr_mmap_t *mm;
     apr_bucket_brigade *bb = apr_brigade_create(r->pool, c->bucket_alloc);
 
-    apr_mmap_dup(&mm, file->mm, r->pool);
-    b = apr_bucket_mmap_create(mm, 0, (apr_size_t)file->finfo.size,
-                               c->bucket_alloc);
+    b = apr_bucket_immortal_create((const char *)file->mm->mm,
+                                  (apr_size_t)file->finfo.size, c->bucket_alloc);
     APR_BRIGADE_INSERT_TAIL(bb, b);
     b = apr_bucket_eos_create(c->bucket_alloc);
     APR_BRIGADE_INSERT_TAIL(bb, b);

--- a/modules/cache/mod_file_cache.c
+++ b/modules/cache/mod_file_cache.c
@@ -272,7 +272,6 @@ static int mmap_handler(request_rec *r, a_file *file)
 #if APR_HAS_MMAP
     conn_rec *c = r->connection;
     apr_bucket *b;
-    apr_mmap_t *mm;
     apr_bucket_brigade *bb = apr_brigade_create(r->pool, c->bucket_alloc);
 
     b = apr_bucket_immortal_create((const char *)file->mm->mm,


### PR DESCRIPTION
```
mod_file_cache: Fix crashes for mmap'ed files under threaded MPM.

* modules/cache/mod_file_cache.c (mmap_handler): fix file getting
  unmapped erroneously when server is under load in multi-thread
  multi-core configuration

PR: 69901
Submitted by: barr.israel <barr.israel campus.technion.ac.il>
Github: closes #582


Follow up to r1930632 -

* modules/cache/mod_file_cache.c (mmap_handler): Remove unused
  variable.


```
(cherry picked from commit 59c3f0e23106c70de8085d0404cd266486de8fd9)
(cherry picked from commit efd77789fccf65cf37c4f940b3637aac7b5e27d9)
