### PR TITLE
[2.4.x] mod_proxy_balancer: Merge r1887192 from trunk

### DIFF
--- a/changes-entries/pr63074.txt
+++ b/changes-entries/pr63074.txt
@@ -1,0 +1,2 @@
+  *) mod_proxy_balancer: Include nonce in XML output.  PR 63074.
+     Federico Mennite <federico.mennite lifeware.ch>

--- a/modules/proxy/mod_proxy_balancer.c
+++ b/modules/proxy/mod_proxy_balancer.c
@@ -1456,6 +1456,7 @@ static void balancer_display_page(request_rec *r, proxy_server_conf *conf,
             ap_rputs("    <httpd:balancer>\n", r);
             /* Start proxy_balancer */
             ap_rvputs(r, "      <httpd:name>", balancer->s->name, "</httpd:name>\n", NULL);
+            ap_rvputs(r, "      <httpd:nonce>", balancer->s->nonce, "</httpd:nonce>\n", NULL);
             if (*balancer->s->sticky) {
                 ap_rvputs(r, "      <httpd:stickysession>", ap_escape_html(r->pool, balancer->s->sticky),
                           "</httpd:stickysession>\n", NULL);


### PR DESCRIPTION
```
* modules/proxy/mod_proxy_balancer.c (balancer_display_page):
  Include nonce in XML output.

PR: 63074
Submitted by: Federico Mennite <federico.mennite lifeware.ch>


```
(cherry picked from commit 2d78b26ab9c201eed992f23b758d3f67f3055f2c)
