### PR TITLE
[2.4.x] mod_unixd: Merge r1617196, r1617201, r1618778, r1897269, r1927804 from trunk

### DIFF
--- a/changes-entries/CoreDumpDirectory-freebsd11.txt
+++ b/changes-entries/CoreDumpDirectory-freebsd11.txt
@@ -1,0 +1,2 @@
+  *) mod_unixd: CoreDumpDirectory requires enabling tracing on FreeBSD 11+.
+     PR 65819.  [David CARLIER <devnexen gmail.com>]

--- a/changes-entries/pr69767.txt
+++ b/changes-entries/pr69767.txt
@@ -1,0 +1,3 @@
+  *) mod_unixd: Drop test that effective user ID is zero in
+     a chroot configuration.  PR 69767.
+     [Bastien Roucaries <rouca debian.org>]

--- a/configure.in
+++ b/configure.in
@@ -463,6 +463,7 @@ pwd.h \
 grp.h \
 strings.h \
 sys/prctl.h \
+sys/procctl.h \
 sys/processor.h \
 sys/sem.h \
 sys/sdt.h \
@@ -520,6 +521,7 @@ getgrnam \
 initgroups \
 bindprocessor \
 prctl \
+procctl \
 timegm \
 getpgid \
 fopen64 \

--- a/modules/arch/unix/mod_unixd.c
+++ b/modules/arch/unix/mod_unixd.c
@@ -150,8 +150,7 @@ AP_DECLARE(int) ap_unixd_setup_child(void)
 
     if (NULL != ap_unixd_config.chroot_dir) {
         if (geteuid()) {
-            rv = errno;
-            ap_log_error(APLOG_MARK, APLOG_ALERT, errno, NULL, APLOGNO(02158)
+            ap_log_error(APLOG_MARK, APLOG_ALERT, 0, NULL, APLOGNO(02158)
                          "Cannot chroot when not started as root");
             return rv;
         }

--- a/modules/arch/unix/mod_unixd.c
+++ b/modules/arch/unix/mod_unixd.c
@@ -152,7 +152,7 @@ AP_DECLARE(int) ap_unixd_setup_child(void)
         if (geteuid()) {
             ap_log_error(APLOG_MARK, APLOG_ALERT, 0, NULL, APLOGNO(02158)
                          "Cannot chroot when not started as root");
-            return rv;
+            return EPERM;
         }
 
         if (chdir(ap_unixd_config.chroot_dir) != 0) {

--- a/modules/arch/unix/mod_unixd.c
+++ b/modules/arch/unix/mod_unixd.c
@@ -134,9 +134,13 @@ static int set_group_privs(void)
     return 0;
 }
 
-
 static int
 unixd_drop_privileges(apr_pool_t *pool, server_rec *s)
+{
+    return ap_unixd_setup_child();
+}
+
+AP_DECLARE(int) ap_unixd_setup_child(void)
 {
     int rv = set_group_privs();
 
@@ -326,58 +330,6 @@ unixd_pre_config(apr_pool_t *pconf, apr_pool_t *plog,
     return OK;
 }
 
-AP_DECLARE(int) ap_unixd_setup_child(void)
-{
-    if (set_group_privs()) {
-        return -1;
-    }
-
-    if (NULL != ap_unixd_config.chroot_dir) {
-        if (geteuid()) {
-            ap_log_error(APLOG_MARK, APLOG_ALERT, errno, NULL, APLOGNO(02164)
-                         "Cannot chroot when not started as root");
-            return -1;
-        }
-        if (chdir(ap_unixd_config.chroot_dir) != 0) {
-            ap_log_error(APLOG_MARK, APLOG_ALERT, errno, NULL, APLOGNO(02165)
-                         "Can't chdir to %s", ap_unixd_config.chroot_dir);
-            return -1;
-        }
-        if (chroot(ap_unixd_config.chroot_dir) != 0) {
-            ap_log_error(APLOG_MARK, APLOG_ALERT, errno, NULL, APLOGNO(02166)
-                         "Can't chroot to %s", ap_unixd_config.chroot_dir);
-            return -1;
-        }
-        if (chdir("/") != 0) {
-            ap_log_error(APLOG_MARK, APLOG_ALERT, errno, NULL, APLOGNO(02167)
-                         "Can't chdir to new root");
-            return -1;
-        }
-    }
-
-    /* Only try to switch if we're running as root */
-    if (!geteuid() && (
-#ifdef _OSD_POSIX
-        os_init_job_environment(NULL, ap_unixd_config.user_name, ap_exists_config_define("DEBUG")) != 0 ||
-#endif
-        setuid(ap_unixd_config.user_id) == -1)) {
-        ap_log_error(APLOG_MARK, APLOG_ALERT, errno, NULL, APLOGNO(02168)
-                    "setuid: unable to change to uid: %ld",
-                    (long) ap_unixd_config.user_id);
-        return -1;
-    }
-#if defined(HAVE_PRCTL) && defined(PR_SET_DUMPABLE)
-    /* this applies to Linux 2.4+ */
-    if (ap_coredumpdir_configured) {
-        if (prctl(PR_SET_DUMPABLE, 1)) {
-            ap_log_error(APLOG_MARK, APLOG_ALERT, errno, NULL, APLOGNO(02169)
-                         "set dumpable failed - this child will not coredump"
-                         " after software errors");
-        }
-    }
-#endif
-    return 0;
-}
 
 static void unixd_dump_config(apr_pool_t *p, server_rec *s)
 {

--- a/modules/arch/unix/mod_unixd.c
+++ b/modules/arch/unix/mod_unixd.c
@@ -152,12 +152,6 @@ AP_DECLARE(int) ap_unixd_setup_child(void)
     }
 
     if (NULL != ap_unixd_config.chroot_dir) {
-        if (geteuid()) {
-            ap_log_error(APLOG_MARK, APLOG_ALERT, 0, NULL, APLOGNO(02158)
-                         "Cannot chroot when not started as root");
-            return EPERM;
-        }
-
         if (chdir(ap_unixd_config.chroot_dir) != 0) {
             rv = errno;
             ap_log_error(APLOG_MARK, APLOG_ALERT, errno, NULL, APLOGNO(02159)


### PR DESCRIPTION
```
unixd_drop_privileges and ap_unixd_setup_child are almost the same,
so let's remove the redundant code.


geteuid is always successful,
so remove errno reference.


Follow up r1617201:
Return EPERM if the uid is not root on chroot-ing.

Pointed out by trawick on
<CAKUrXK6EGmG1ZD4+UFZ05yznTe6twOU3n57YeO-Ney-_VV_dCQ@mail.gmail.com>


mod_unixd: Make CoreDumpDirectory work for FreeBSD 11+. PR 65819.

FreeBSD 11+ coredumping requires tracing enabled via procctl(PROC_TRACE_CTL).

Submitted by: David CARLIER <devnexen gmail.com>
Reviewed by: ylavic (by inspection)


* modules/arch/unix/mod_unixd.ci (ap_unixd_setup_child):
  Do not test euid=0 before going chroot

Nowaday chroot need CAP_SYS_CHROOT capability in its user namespace, and could
work without root.

Will allow to use chroot with lesser permission.

Submitted by: Bastien Roucariès <rouca debian.org>
PR: 69767
Github: closes #549


```
(cherry picked from commit 4e5e8a3b0bb4fd71ea338b8499c839ac2d146206)
(cherry picked from commit cd503763ee564c30ab9301dcd94ddf09011a88e6)
(cherry picked from commit 89b58e85526bb7580b5df6da67a9894f118bd910)
(cherry picked from commit af558302645384b998333f214d0af37cb3a4ff26)
(cherry picked from commit 5c9c78d7859f6a45e8267f7017313002316c3257)
