### PR TITLE
Adds regression test for CGI env var override 

### DIFF
--- a/test/modules/core/htdocs/cgi/env_parameters.py
+++ b/test/modules/core/htdocs/cgi/env_parameters.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+import os
+import json
+
+print("Content-Type: application/json")
+print()
+
+data = {
+    "REQUEST_METHOD": os.getenv("REQUEST_METHOD", ""),
+    "QUERY_STRING": os.getenv("QUERY_STRING", ""),
+}
+
+print(json.dumps(data, indent=2))

--- a/test/modules/core/test_003_cgi_env_vars.py
+++ b/test/modules/core/test_003_cgi_env_vars.py
@@ -1,0 +1,33 @@
+import pytest
+
+from pyhttpd.conf import HttpdConf
+
+class TestCGIEnvVars:
+
+    @pytest.fixture(autouse=True, scope='class')
+    def _class_scope(self, env):
+        conf = HttpdConf(env, extras={
+            'base': f"""
+        <Directory "{env.gen_dir}">
+            AllowOverride None
+            Options +ExecCGI
+        </Directory>
+        SetEnv REQUEST-METHOD OVERRIDDEN
+        SetEnv QUERY.STRING OVERRIDDEN
+        """,
+        })
+        conf.add_vhost_cgi()
+        conf.install()
+        assert env.apache_restart() == 0
+
+    def test_cgi_003_01(self, env):
+        """
+        CVE-2025-65082:
+        Configuration-defined env vars must not override
+        server-calculated CGI env vars.
+        """
+        url = env.mkurl("http", "cgi", "/env_parameters.py?x=123")
+        r = env.curl_get(url)
+        assert r.response["status"] == 200
+        assert r.response["json"]["REQUEST_METHOD"] == "GET"
+        assert r.response["json"]["QUERY_STRING"] == "x=123"


### PR DESCRIPTION
This change adds a regression test to the pyhttpd test suite to ensure that configuration-defined environment variables with invalid names cannot override server-calculated CGI environment variables, as described [here](https://www.cve.org/CVERecord?id=CVE-2025-65082).