### PR TITLE
Adds test for SSI query string injection

### DIFF
--- a/test/modules/core/env.py
+++ b/test/modules/core/env.py
@@ -12,7 +12,7 @@ class CoreTestSetup(HttpdTestSetup):
     def __init__(self, env: 'HttpdTestEnv'):
         super().__init__(env=env)
         self.add_source_dir(os.path.dirname(inspect.getfile(CoreTestSetup)))
-        self.add_modules(["cgid"])
+        self.add_modules(["cgid","include"])
 
 
 class CoreTestEnv(HttpdTestEnv):

--- a/test/modules/core/htdocs/ssi/exec.shtml
+++ b/test/modules/core/htdocs/ssi/exec.shtml
@@ -1,0 +1,1 @@
+<!--#exec cmd="echo SSI_OK" -->

--- a/test/modules/core/test_004_ssi.py
+++ b/test/modules/core/test_004_ssi.py
@@ -1,0 +1,32 @@
+import pytest
+import textwrap
+
+from pyhttpd.conf import HttpdConf
+
+class TestSSIInjection:
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _class_scope(self, env):
+        conf = HttpdConf(env, extras={
+            "base": textwrap.dedent(f"""
+            <Directory "{env.gen_dir}">
+                Options +Includes
+                AddType text/html .shtml
+                AddOutputFilter INCLUDES .shtml
+            </Directory>
+            """)
+        })
+        conf.install()
+        assert env.apache_restart() == 0
+
+    def test_ssi_004_01(self, env):
+        """
+        CVE-2025-58098:
+        Server Side Includes must not add query string to #exec cmd=...
+        """
+        url = env.mkurl("http", "htdocs", "/ssi/exec.shtml?INJECTED")
+        r = env.curl_get(url)
+
+        body = r.response["body"].decode("utf-8")
+        assert "SSI_OK" in body
+        assert "INJECTED" not in body


### PR DESCRIPTION
This change adds a regression test to the pyhttpd test suite to ensure that Server Side Includes cannot inject query string to #exec cmd=..., as described [here](https://www.cve.org/CVERecord?id=CVE-2025-58098). 

IMHO the nature of the SSI wouldn't require a new folder structure for mod_include, thats why I used core module. If you think is not a good approach I can create inside pyhttpd a new folder structure with the relevant classes and configurations for the mod_include.