### PR TITLE
Adds test for disabled note option in RequestHeader

### DIFF
--- a/test/modules/core/env.py
+++ b/test/modules/core/env.py
@@ -12,7 +12,7 @@ class CoreTestSetup(HttpdTestSetup):
     def __init__(self, env: 'HttpdTestEnv'):
         super().__init__(env=env)
         self.add_source_dir(os.path.dirname(inspect.getfile(CoreTestSetup)))
-        self.add_modules(["cgid","include"])
+        self.add_modules(["cgid","include","userdir","suexec","headers"])
 
 
 class CoreTestEnv(HttpdTestEnv):

--- a/test/modules/core/htdocs/userdir/testuser/public_html/cgi-bin/.htaccess
+++ b/test/modules/core/htdocs/userdir/testuser/public_html/cgi-bin/.htaccess
@@ -1,0 +1,1 @@
+RequestHeader note internal_note "empty_note"

--- a/test/modules/core/htdocs/userdir/testuser/public_html/cgi-bin/test.cgi
+++ b/test/modules/core/htdocs/userdir/testuser/public_html/cgi-bin/test.cgi
@@ -1,0 +1,4 @@
+#!/bin/sh
+echo "Content-Type: text/plain"
+echo
+echo "OK"

--- a/test/modules/core/test_005_userdir_headers.py
+++ b/test/modules/core/test_005_userdir_headers.py
@@ -1,0 +1,43 @@
+import os
+import re
+import pytest
+
+from pyhttpd.conf import HttpdConf
+
+class TestUserdirHeaders:
+
+    @pytest.fixture(autouse=True, scope='class')
+    def _class_scope(self, env):
+
+        userdir_base = os.path.join(env.server_dir, "htdocs", "userdir")
+
+        conf = HttpdConf(env, extras={
+            'base': f"""
+        UserDir "{userdir_base}/*/public_html"
+ 
+        <Directory "{userdir_base}/*/public_html">
+            AllowOverride FileInfo
+            Options +ExecCGI
+            SetHandler cgi-script
+        </Directory>
+        """
+        })
+        conf.add_vhost_test1()
+        conf.install()
+        assert env.apache_restart() == 0
+
+    def test_core_005_01_requestheader_note_rejected(self, env):
+        url = env.mkurl("http", "test1", "/~testuser/cgi-bin/test.cgi")
+        r = env.curl_get(url)
+
+        # Check error log for the rejection message
+        re_rejection = re.compile(r".*RequestHeader does not support the 'note' action.*")
+
+        directive_rejected = False
+        try:
+            directive_rejected = env.httpd_error_log.scan_recent(re_rejection)
+        except TimeoutError:
+            pass
+
+        assert directive_rejected, \
+            "RequestHeader note directive was not rejected"


### PR DESCRIPTION
This PR adds a regression test to the pyhttpd test suite covering the change of apache/httpd@9d26b95