### PR TITLE
Add --enable-sigusr2 to use SIGUSR2 rather than SIGWINCH for graceful stop

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -830,6 +830,24 @@ if test "$apache_need_shared" = "yes"; then
   shared_build="shared-build"
 fi
 
+ap_graceful_sig=WINCH
+AC_ARG_ENABLE(sigusr2,
+ APACHE_HELP_STRING(--enable-sigusr2,Use SIGUSR2 for graceful stop),
+[
+ case $APR_VERSION in
+ 0.*|1.[[0-6]].*) AC_MSG_ERROR([APR 1.7 or later is required to use SIGUSR2]) ;;
+ esac
+ ap_graceful_sig=USR2
+])
+AC_MSG_NOTICE([using signal SIG$ap_graceful_sig for graceful stop])
+
+AC_DEFINE_UNQUOTED([AP_SIG_GRACEFUL_STOP], [SIG$ap_graceful_sig],
+        [Signal to use for graceful stop])
+AC_DEFINE_UNQUOTED([AP_SIG_GRACEFUL_STOP_STRING],
+        ["SIG$ap_graceful_sig"], [Signal name in use for graceful stop])
+AC_DEFINE_UNQUOTED([AP_SIG_GRACEFUL_STOP_SHORT],
+        [$ap_graceful_sig], [Short signal name in use for graceful stop])
+
 dnl enable_so tells us if *any* modules can be built as DSOs
 
 if test "$enable_so" = "yes" -o "$enable_so" = "static"; then

--- a/include/mpm_common.h
+++ b/include/mpm_common.h
@@ -80,14 +80,20 @@ extern "C" {
 /* Signal used to gracefully restart (as a quoted string) */
 #define AP_SIG_GRACEFUL_STRING "SIGUSR1"
 
+#ifndef AP_SIG_GRACEFUL_STOP
 /* Signal used to gracefully stop */
 #define AP_SIG_GRACEFUL_STOP SIGWINCH
+#endif
 
+#ifndef AP_SIG_GRACEFUL_STOP_SHORT
 /* Signal used to gracefully stop (without SIG prefix) */
 #define AP_SIG_GRACEFUL_STOP_SHORT WINCH
+#endif
 
+#ifndef AP_SIG_GRACEFUL_STOP_STRING
 /* Signal used to gracefully stop (as a quoted string) */
 #define AP_SIG_GRACEFUL_STOP_STRING "SIGWINCH"
+#endif
 
 /**
  * Callback function used for ap_reclaim_child_processes() and

--- a/server/mpm/prefork/prefork.c
+++ b/server/mpm/prefork/prefork.c
@@ -541,10 +541,10 @@ static void child_main(int child_num_arg, int child_bucket)
 
         status = apr_pollset_add(pollset, pfd);
         if (status != APR_SUCCESS) {
-            /* If the child processed a SIGWINCH before setting up the
-             * pollset, this error path is expected and harmless,
-             * since the listener fd was already closed; so don't
-             * pollute the logs in that case. */
+            /* If the child processed a graceful-stop signal before
+             * setting up the pollset, this error path is expected and
+             * harmless, since the listener fd was already closed; so
+             * don't pollute the logs in that case. */
             if (!die_now) {
                 ap_log_error(APLOG_MARK, APLOG_EMERG, status, ap_server_conf, APLOGNO(00157)
                              "Couldn't add listener to pollset; check system or user limits");


### PR DESCRIPTION
```
Add --enable-sigusr2 to use SIGUSR2 rather than SIGWINCH for graceful
stop, which requires APR 1.7+.

* configure.in: Add --enable-sigusr2; define AP_SIG_GRACEFUL_STOP* in ap_config.h.

* include/ap_mpm.h: Define AP_SIG_GRACEFUL_STOP* conditionally.

* server/mpm/prefork/prefork.c (child_main): Don't mention SIGWINCH.

PR: 50669
```