### PR TITLE
Add missing module_index in the APLOG_MARK note for ap_log_error

### DIFF
--- a/include/http_log.h
+++ b/include/http_log.h
@@ -341,7 +341,7 @@ void ap_logs_child_init(apr_pool_t *p, server_rec *s);
  * @param fmt The format string
  * @param ... The arguments to use to fill out fmt.
  * @note ap_log_error is implemented as a macro
- * @note Use APLOG_MARK to fill out file and line
+ * @note Use APLOG_MARK to fill out file, line, and module_index
  * @note If a request_rec is available, use that with ap_log_rerror()
  * in preference to calling this function.  Otherwise, if a conn_rec is
  * available, use that with ap_log_cerror() in preference to calling


### PR DESCRIPTION
The `APLOG_MARK` documentation correctly states all three. The rest of the logging function notes seem correct too.

https://nightlies.apache.org/httpd/trunk/doxygen/group__APACHE__CORE__LOG.html#ga655e126996849bcb82e4e5a14c616f4a