### PR TITLE
Prevent Y2038 bug by using SSL_SESSION_get_time_ex

### DIFF
--- a/modules/ssl/ssl_engine_kernel.c
+++ b/modules/ssl/ssl_engine_kernel.c
@@ -1965,10 +1965,17 @@ int ssl_callback_NewSessionCacheEntry(SSL *ssl, SSL_SESSION *session)
     idlen = session->session_id_length;
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x30300000
     rc = ssl_scache_store(s, id, idlen,
                           apr_time_from_sec(SSL_SESSION_get_time_ex(session)
                                           + timeout),
                           session, conn->pool);
+#else
+      rc = ssl_scache_store(s, id, idlen,
+                          apr_time_from_sec(SSL_SESSION_get_time(session)
+                                          + timeout),
+                          session, conn->pool);
+#endif
 
     ssl_session_log(s, "SET", id, idlen,
                     rc == TRUE ? "OK" : "BAD",

--- a/modules/ssl/ssl_engine_kernel.c
+++ b/modules/ssl/ssl_engine_kernel.c
@@ -1966,7 +1966,7 @@ int ssl_callback_NewSessionCacheEntry(SSL *ssl, SSL_SESSION *session)
 #endif
 
     rc = ssl_scache_store(s, id, idlen,
-                          apr_time_from_sec(SSL_SESSION_get_time(session)
+                          apr_time_from_sec(SSL_SESSION_get_time_ex(session)
                                           + timeout),
                           session, conn->pool);
 


### PR DESCRIPTION
The previous function is deprecated, see:
* https://github.com/openssl/openssl/commit/00a6d0743a38e179f5f9b5de4b73be9fcec0bb4c
* https://github.com/openssl/openssl/issues/23648
* https://github.com/openssl/openssl/pull/21206