### PR TITLE
fix message length validation in ajp_msg_check_header

### DIFF
--- a/modules/proxy/ajp_msg.c
+++ b/modules/proxy/ajp_msg.c
@@ -166,7 +166,7 @@ apr_status_t ajp_msg_check_header(ajp_msg_t *msg, apr_size_t *len)
     msglen  = ((head[2] & 0xff) << 8);
     msglen += (head[3] & 0xFF);
 
-    if (msglen > msg->max_size) {
+    if (msglen > msg->max_size - AJP_HEADER_LEN) {
         ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, APLOGNO(01081)
                      "ajp_msg_check_header() incoming message is "
                      "too big %" APR_SIZE_T_FMT ", max is %" APR_SIZE_T_FMT,


### PR DESCRIPTION
ajp_msg_check_header() validates msglen against msg->max_size,
but ajp_ilink_receive() reads the body starting at buf + AJP_HEADER_LEN.

This means msglen values up to msg->max_size can pass validation while
writing past the end of the allocated buffer.

Restrict msglen to msg->max_size - AJP_HEADER_LEN to ensure the body
fits within msg->buf.