### PR TITLE
docs: fix typos in STATUS, LAYOUT, README.CHANGES, README.cmake

### DIFF
--- a/LAYOUT
+++ b/LAYOUT
@@ -58,7 +58,7 @@ docs/ ................. Documentation and Examples
 
 include/ ................ 
 
-modules/ ................ Manditory and Add-In Apache stock modules
+modules/ ................ Mandatory and Add-In Apache stock modules
 
   aaa/ .................... 
 

--- a/README.CHANGES
+++ b/README.CHANGES
@@ -1,6 +1,6 @@
 Changes can be documented in two ways now: Either by directly editing the
 CHANGES file like it was done until now or by storing each entry for the
-CHANGES file correctly formated in a separate file in the changes-entries
+CHANGES file correctly formatted in a separate file in the changes-entries
 directory.
 
 The benefit of the single file per change approach is that it eases backporting

--- a/README.cmake
+++ b/README.cmake
@@ -289,7 +289,7 @@ This can be resolved in several different ways:
   a service.
 
 * Maintain a script which combines required binaries into a common 
-  location, such as the httpd installion bin directory, and use that
+  location, such as the httpd installation bin directory, and use that
   script after building or otherwise installing or updating support
   libraries.
 

--- a/STATUS
+++ b/STATUS
@@ -71,7 +71,7 @@ THINGS THAT SHOULD BE CONSIDERED EARLY IN THE 2.6/3.0 DEVELOPMENT CYCLE:
 
   * Add performance testing to the test framework.
 
-  * Competely untangle core filesystem behavior where a filesystem htdocs/
+  * Completely untangle core filesystem behavior where a filesystem htdocs/
     resource wasn't indicated by the request URI.
 
   * Refactor r->uri into a %escaped raw form presented by the client, and


### PR DESCRIPTION
Fix four typos in documentation/project files:

- \`STATUS:74\`: \`Competely\` → \`Completely\`
- \`LAYOUT:61\`: \`Manditory\` → \`Mandatory\`
- \`README.CHANGES:3\`: \`formated\` → \`formatted\`
- \`README.cmake:292\`: \`installion\` → \`installation\`

Found using codespell.