### PR TITLE
Add integer overflow checks to URL escape allocation functions

### DIFF
--- a/server/util.c
+++ b/server/util.c
@@ -1816,8 +1816,10 @@ AP_DECLARE(char *) ap_escape_shell_cmd(apr_pool_t *p, const char *str)
     char *cmd;
     unsigned char *d;
     const unsigned char *s;
+    apr_size_t len = strlen(str);
 
-    cmd = apr_palloc(p, 2 * strlen(str) + 1);        /* Be safe */
+    ap_assert(len <= (APR_SIZE_MAX - 1) / 2);
+    cmd = apr_palloc(p, 2 * len + 1);
     d = (unsigned char *)cmd;
     s = (const unsigned char *)str;
     for (; *s; ++s) {
@@ -2073,7 +2075,9 @@ AP_DECLARE(char *) ap_escape_path_segment_buffer(char *copy, const char *segment
 
 AP_DECLARE(char *) ap_escape_path_segment(apr_pool_t *p, const char *segment)
 {
-    return ap_escape_path_segment_buffer(apr_palloc(p, 3 * strlen(segment) + 1), segment);
+    apr_size_t len = strlen(segment);
+    ap_assert(len <= (APR_SIZE_MAX - 1) / 3);
+    return ap_escape_path_segment_buffer(apr_palloc(p, 3 * len + 1), segment);
 }
 
 AP_DECLARE(char *) ap_os_escape_path(apr_pool_t *p, const char *path, int partial)
@@ -2082,10 +2086,16 @@ AP_DECLARE(char *) ap_os_escape_path(apr_pool_t *p, const char *path, int partia
      * Allocate another +1 to allow the caller to add a trailing '/' (see
      * comment in 'ap_sub_req_lookup_dirent')
      */
-    char *copy = apr_palloc(p, 3 * strlen(path) + 3 + 1);
-    const unsigned char *s = (const unsigned char *)path;
-    unsigned char *d = (unsigned char *)copy;
+    apr_size_t len = strlen(path);
+    char *copy;
+    const unsigned char *s;
+    unsigned char *d;
     unsigned c;
+
+    ap_assert(len <= (APR_SIZE_MAX - 4) / 3);
+    copy = apr_palloc(p, 3 * len + 3 + 1);
+    s = (const unsigned char *)path;
+    d = (unsigned char *)copy;
 
     if (!partial) {
         const char *colon = ap_strchr_c(path, ':');
@@ -2133,7 +2143,9 @@ AP_DECLARE(char *) ap_escape_urlencoded_buffer(char *copy, const char *buffer)
 
 AP_DECLARE(char *) ap_escape_urlencoded(apr_pool_t *p, const char *buffer)
 {
-    return ap_escape_urlencoded_buffer(apr_palloc(p, 3 * strlen(buffer) + 1), buffer);
+    apr_size_t len = strlen(buffer);
+    ap_assert(len <= (APR_SIZE_MAX - 1) / 3);
+    return ap_escape_urlencoded_buffer(apr_palloc(p, 3 * len + 1), buffer);
 }
 
 /* ap_escape_uri is now a macro for os_escape_path */


### PR DESCRIPTION
`ap_escape_path_segment`, `ap_os_escape_path`, and `ap_escape_urlencoded` in `server/util.c` allocate output buffers using `3 * strlen(input) + constant` without checking for integer overflow. On platforms where `size_t` is 32-bit, inputs exceeding ~1.33GB cause the multiplication to wrap, resulting in undersized allocation.

The HTML escape function `ap_escape_html2` in the same file already has overflow protection at line 2148:

    if (i + j > APR_SIZE_MAX - 6) {
        abort();
    }

This applies the same pattern to the three URL escape functions for consistency. Each now checks `len > (APR_SIZE_MAX - constant) / 3` before the multiplication, calling `abort()` on overflow.