### PR TITLE
Add integer overflow checks to apreq parameter and cookie allocation

### DIFF
--- a/server/apreq_cookie.c
+++ b/server/apreq_cookie.c
@@ -140,6 +140,11 @@ APREQ_DECLARE(apreq_cookie_t *) apreq_cookie_make(apr_pool_t *p,
     apreq_cookie_t *c;
     apreq_value_t *v;
 
+    if (nlen > APR_SIZE_MAX - sizeof *c - 1
+        || nlen + sizeof *c + 1 > APR_SIZE_MAX - vlen) {
+        return NULL;
+    }
+
     c = apr_palloc(p, nlen + vlen + 1 + sizeof *c);
 
     if (c == NULL)

--- a/server/apreq_param.c
+++ b/server/apreq_param.c
@@ -35,6 +35,11 @@ APREQ_DECLARE(apreq_param_t *) apreq_param_make(apr_pool_t *p,
     apreq_param_t *param;
     apreq_value_t *v;
 
+    if (nlen > APR_SIZE_MAX - sizeof *param - 1
+        || nlen + sizeof *param + 1 > APR_SIZE_MAX - vlen) {
+        return NULL;
+    }
+
     param = apr_palloc(p, nlen + vlen + 1 + sizeof *param);
 
     if (param == NULL)
@@ -74,6 +79,12 @@ APREQ_DECLARE(apr_status_t) apreq_param_decode(apreq_param_t **param,
     if (nlen == 0) {
         *param = NULL;
         return APR_EBADARG;
+    }
+
+    if (nlen > APR_SIZE_MAX - sizeof *p - 1
+        || nlen + sizeof *p + 1 > APR_SIZE_MAX - vlen) {
+        *param = NULL;
+        return APR_ENOMEM;
     }
 
     p = apr_palloc(pool, nlen + vlen + 1 + sizeof *p);
@@ -130,7 +141,15 @@ APREQ_DECLARE(char *) apreq_param_encode(apr_pool_t *pool,
 {
     apr_size_t dlen;
     char *data;
-    data = apr_palloc(pool, 3 * (param->v.nlen + param->v.dlen) + 2);
+    {
+        apr_size_t sum = param->v.nlen;
+        if (sum > APR_SIZE_MAX - param->v.dlen)
+            return NULL;
+        sum += param->v.dlen;
+        if (sum > (APR_SIZE_MAX - 2) / 3)
+            return NULL;
+        data = apr_palloc(pool, 3 * sum + 2);
+    }
     dlen = apreq_encode(data, param->v.name, param->v.nlen);
     data[dlen++] = '=';
     dlen += apreq_encode(data + dlen, param->v.data, param->v.dlen);

--- a/server/util.c
+++ b/server/util.c
@@ -2073,7 +2073,11 @@ AP_DECLARE(char *) ap_escape_path_segment_buffer(char *copy, const char *segment
 
 AP_DECLARE(char *) ap_escape_path_segment(apr_pool_t *p, const char *segment)
 {
-    return ap_escape_path_segment_buffer(apr_palloc(p, 3 * strlen(segment) + 1), segment);
+    apr_size_t len = strlen(segment);
+    if (len > (APR_SIZE_MAX - 1) / 3) {
+        abort();
+    }
+    return ap_escape_path_segment_buffer(apr_palloc(p, 3 * len + 1), segment);
 }
 
 AP_DECLARE(char *) ap_os_escape_path(apr_pool_t *p, const char *path, int partial)
@@ -2082,10 +2086,18 @@ AP_DECLARE(char *) ap_os_escape_path(apr_pool_t *p, const char *path, int partia
      * Allocate another +1 to allow the caller to add a trailing '/' (see
      * comment in 'ap_sub_req_lookup_dirent')
      */
-    char *copy = apr_palloc(p, 3 * strlen(path) + 3 + 1);
-    const unsigned char *s = (const unsigned char *)path;
-    unsigned char *d = (unsigned char *)copy;
+    apr_size_t len = strlen(path);
+    char *copy;
+    const unsigned char *s;
+    unsigned char *d;
     unsigned c;
+
+    if (len > (APR_SIZE_MAX - 4) / 3) {
+        abort();
+    }
+    copy = apr_palloc(p, 3 * len + 3 + 1);
+    s = (const unsigned char *)path;
+    d = (unsigned char *)copy;
 
     if (!partial) {
         const char *colon = ap_strchr_c(path, ':');
@@ -2133,7 +2145,11 @@ AP_DECLARE(char *) ap_escape_urlencoded_buffer(char *copy, const char *buffer)
 
 AP_DECLARE(char *) ap_escape_urlencoded(apr_pool_t *p, const char *buffer)
 {
-    return ap_escape_urlencoded_buffer(apr_palloc(p, 3 * strlen(buffer) + 1), buffer);
+    apr_size_t len = strlen(buffer);
+    if (len > (APR_SIZE_MAX - 1) / 3) {
+        abort();
+    }
+    return ap_escape_urlencoded_buffer(apr_palloc(p, 3 * len + 1), buffer);
 }
 
 /* ap_escape_uri is now a macro for os_escape_path */


### PR DESCRIPTION
`apreq_param_make()`, `apreq_param_decode()`, `apreq_param_encode()`, and `apreq_cookie_make()` compute allocation sizes as `nlen + vlen + constant` without checking for integer overflow. On platforms where `size_t` is 32-bit, large parameter or cookie values can cause the sum to wrap, resulting in undersized allocation.

This adds overflow checks before each `apr_palloc` call:

- `apreq_param_make` (`server/apreq_param.c:38`): checks `nlen + vlen + 1 + sizeof *param`
- `apreq_param_decode` (`server/apreq_param.c:84`): same pattern
- `apreq_param_encode` (`server/apreq_param.c:144`): checks `nlen + dlen` addition and `3 * sum` multiplication
- `apreq_cookie_make` (`server/apreq_cookie.c:143`): checks `nlen + vlen + 1 + sizeof *c`

On overflow, each function returns `NULL` (or `APR_ENOMEM` for `apreq_param_decode`), consistent with existing allocation failure handling.