### PR TITLE
reject invalid NameWidth values to prevent unsafe memcpy size

### DIFF
--- a/modules/generators/mod_autoindex.c
+++ b/modules/generators/mod_autoindex.c
@@ -462,8 +462,8 @@ static const char *add_opts(cmd_parms *cmd, void *d, int argc, char *const argv[
             else {
                 int width = atoi(&w[10]);
 
-                if (width && (width < 5)) {
-                    return "NameWidth value must be greater than 5";
+                if (width < 5) {
+                    return "NameWidth value must be at least 5";
                 }
                 d_cfg->name_width = width;
                 d_cfg->name_adjust = K_NOADJUST;


### PR DESCRIPTION
This change fixes a potential memory safety issue in mod_autoindex caused by insufficient validation of the NameWidth directive.

Previously values less than 5 were not properly rejected due to a conditional check that allowed 0 to bypass validation