### PR TITLE
add length validation for Lock-Token to prevent underflow

### DIFF
--- a/modules/dav/main/mod_dav.c
+++ b/modules/dav/main/mod_dav.c
@@ -3587,6 +3587,9 @@ static int dav_method_unlock(request_rec *r)
     dav_resource *resource;
     const dav_hooks_locks *locks_hooks;
     int result;
+    apr_size_t len;
+    int has_open;
+    int has_close;
     const char *const_locktoken_txt;
     char *locktoken_txt;
     dav_locktoken *locktoken = NULL;

--- a/modules/dav/main/mod_dav.c
+++ b/modules/dav/main/mod_dav.c
@@ -3587,9 +3587,6 @@ static int dav_method_unlock(request_rec *r)
     dav_resource *resource;
     const dav_hooks_locks *locks_hooks;
     int result;
-    apr_size_t len;
-    int has_open;
-    int has_close;
     const char *const_locktoken_txt;
     char *locktoken_txt;
     dav_locktoken *locktoken = NULL;
@@ -3609,25 +3606,9 @@ static int dav_method_unlock(request_rec *r)
         return HTTP_BAD_REQUEST;
     }
 
-    locktoken_txt = apr_pstrdup(r->pool, const_locktoken_txt);
-    len = strlen(locktoken_txt);
-
-    has_open = (len > 0 && locktoken_txt[0] == '<');
-    has_close = (len > 0 && locktoken_txt[len - 1] == '>');
-
-    if (has_open && has_close && len >= 2) {
-        locktoken_txt[len - 1] = '\0';
-        locktoken_txt++;
-
-        if (*locktoken_txt == '\0') {
-            /* ### should provide more specifics... */
-            return HTTP_BAD_REQUEST;
-        }
-    }
-    else {
-        /* ### should provide more specifics... */
-        return HTTP_BAD_REQUEST;
-    }
+    err = dav_parse_locktoken(r->pool, const_locktoken_txt, &locktoken_txt);
+    if (err != NULL)
+        return err->status;
 
     if ((err = (*locks_hooks->parse_locktoken)(r->pool, locktoken_txt,
                                                &locktoken)) != NULL) {

--- a/modules/dav/main/mod_dav.c
+++ b/modules/dav/main/mod_dav.c
@@ -3607,17 +3607,24 @@ static int dav_method_unlock(request_rec *r)
     }
 
     locktoken_txt = apr_pstrdup(r->pool, const_locktoken_txt);
-    if (locktoken_txt[0] != '<') {
-        /* ### should provide more specifics... */
-        return HTTP_BAD_REQUEST;
-    }
-    locktoken_txt++;
+    len = strlen(locktoken_txt);
 
-    if (locktoken_txt[strlen(locktoken_txt) - 1] != '>') {
+    has_open = (len > 0 && locktoken_txt[0] == '<');
+    has_close = (len > 0 && locktoken_txt[len - 1] == '>');
+
+    if (has_open && has_close && len >= 2) {
+        locktoken_txt[len - 1] = '\0';
+        locktoken_txt++;
+
+        if (*locktoken_txt == '\0') {
+            /* ### should provide more specifics... */
+            return HTTP_BAD_REQUEST;
+        }
+    }
+    else {
         /* ### should provide more specifics... */
         return HTTP_BAD_REQUEST;
     }
-    locktoken_txt[strlen(locktoken_txt) - 1] = '\0';
 
     if ((err = (*locks_hooks->parse_locktoken)(r->pool, locktoken_txt,
                                                &locktoken)) != NULL) {

--- a/modules/dav/main/mod_dav.h
+++ b/modules/dav/main/mod_dav.h
@@ -1331,6 +1331,9 @@ struct dav_hooks_propdb
 
 DAV_DECLARE(time_t) dav_get_timeout(request_rec *r);
 DAV_DECLARE(time_t) dav_get_timeout_string(request_rec *r, const char *s);
+DAV_DECLARE(dav_error *) dav_parse_locktoken(apr_pool_t *p,
+                                             const char *input,
+                                             char **output);
 
 /*
 ** Opaque, provider-specific information for a lock database.
@@ -2757,4 +2760,3 @@ DAV_DECLARE(const dav_resource_type_provider *) dav_get_resource_type_providers(
 
 #endif /* _MOD_DAV_H_ */
 /** @} */
-

--- a/modules/dav/main/ms_wdv.c
+++ b/modules/dav/main/ms_wdv.c
@@ -205,27 +205,13 @@ static dav_error *mswdv_combined_lock(request_rec *r)
      * section 4.5 suggests using Lock-Token without brakets.
      */
     if (lock_token_hdr) {
-        apr_size_t len = strlen(lock_token_hdr);
-        int has_open = (len > 0 && lock_token_hdr[0] == '<');
-        int has_close = (len > 0 && lock_token_hdr[len - 1] == '>');
+        char *parsed_locktoken;
 
-        /*
-         * Defensive parsing: never read len - 1 or compute len - 2 unless
-         * length is known to be valid, and reject malformed one-sided
-         * bracket usage before token parsing.
-         */
-        if (has_open && has_close && len >= 2) {
-            lock_token_hdr = apr_pstrndup(r->pool, lock_token_hdr + 1, len - 2);
-        }
-        else if (has_open || has_close) {
-            failmsg = "Malformed Lock-Token header.";
-            goto done;
-        }
+        err = dav_parse_locktoken(r->pool, lock_token_hdr, &parsed_locktoken);
+        if (err != NULL)
+            goto out;
 
-        if (*lock_token_hdr == '\0') {
-            failmsg = "Malformed Lock-Token header.";
-            goto done;
-        }
+        lock_token_hdr = parsed_locktoken;
     }
 
     if (lock_timeout_hdr) {

--- a/modules/dav/main/ms_wdv.c
+++ b/modules/dav/main/ms_wdv.c
@@ -36,13 +36,21 @@ static void delete_if_fixup(request_rec *r)
     const char *if_hdr;
     const char *cp;
     apr_size_t len;
+    int has_open;
+    int has_close;
 
     if ((if_hdr =  apr_table_get(r->headers_in, "If")) == NULL)
         goto out;
 
     /* check for parenthesis enclosed value */
     len = strlen(if_hdr);
-    if (if_hdr[0] != '(' || if_hdr[len - 1]!= ')')
+    /*
+     * Guard len-based indexing to avoid reading if_hdr[len - 1]
+     * on empty input.
+     */
+    has_open = (len > 0 && if_hdr[0] == '(');
+    has_close = (len > 0 && if_hdr[len - 1] == ')');
+    if (!has_open || !has_close)
         goto out;
 
     for (cp = if_hdr; *cp; cp++) {
@@ -201,10 +209,20 @@ static dav_error *mswdv_combined_lock(request_rec *r)
         int has_open = (len > 0 && lock_token_hdr[0] == '<');
         int has_close = (len > 0 && lock_token_hdr[len - 1] == '>');
 
+        /*
+         * Defensive parsing: never read len - 1 or compute len - 2 unless
+         * length is known to be valid, and reject malformed one-sided
+         * bracket usage before token parsing.
+         */
         if (has_open && has_close && len >= 2) {
             lock_token_hdr = apr_pstrndup(r->pool, lock_token_hdr + 1, len - 2);
         }
         else if (has_open || has_close) {
+            failmsg = "Malformed Lock-Token header.";
+            goto done;
+        }
+
+        if (*lock_token_hdr == '\0') {
             failmsg = "Malformed Lock-Token header.";
             goto done;
         }
@@ -837,4 +855,3 @@ DAV_DECLARE(apr_status_t) dav_mswdv_input(ap_filter_t *f,
 
     return APR_SUCCESS;
 }
-

--- a/modules/dav/main/ms_wdv.c
+++ b/modules/dav/main/ms_wdv.c
@@ -198,9 +198,16 @@ static dav_error *mswdv_combined_lock(request_rec *r)
      */
     if (lock_token_hdr) {
         apr_size_t len = strlen(lock_token_hdr);
+        int has_open = (len > 0 && lock_token_hdr[0] == '<');
+        int has_close = (len > 0 && lock_token_hdr[len - 1] == '>');
 
-        if (lock_token_hdr[0] == '<' || lock_token_hdr[len - 1] == '>')
+        if (has_open && has_close && len >= 2) {
             lock_token_hdr = apr_pstrndup(r->pool, lock_token_hdr + 1, len - 2);
+        }
+        else if (has_open || has_close) {
+            failmsg = "Malformed Lock-Token header.";
+            goto done;
+        }
     }
 
     if (lock_timeout_hdr) {

--- a/modules/dav/main/util.c
+++ b/modules/dav/main/util.c
@@ -599,12 +599,8 @@ DAV_DECLARE(dav_error *) dav_parse_locktoken(apr_pool_t *p,
     int has_open;
     int has_close;
 
-    if (output == NULL) {
-        return dav_new_error(p, HTTP_INTERNAL_SERVER_ERROR, 0, 0,
-                             "DAV lock token parser called with NULL output pointer.");
-    }
     *output = NULL;
-
+    
     if (input == NULL) {
         return dav_new_error(p, HTTP_BAD_REQUEST, 0, 0,
                              "No Lock-Token specified in header.");
@@ -617,14 +613,15 @@ DAV_DECLARE(dav_error *) dav_parse_locktoken(apr_pool_t *p,
 
     if (len < 2 || !has_open || !has_close) {
         return dav_new_error(p, HTTP_BAD_REQUEST, 0, 0,
-                             "Malformed Lock-Token header.");
+                             "Malformed Lock-Token");
     }
 
-    token = apr_pstrndup(p, input + 1, len - 2);
+    token = apr_pmemdup(p, input + 1, len - 2);
+    token[len - 2] = '\0';
 
     if (*token == '\0') {
         return dav_new_error(p, HTTP_BAD_REQUEST, 0, 0,
-                             "Malformed Lock-Token header.");
+                             "Malformed Lock-Token");
     }
 
     *output = token;

--- a/modules/dav/main/util.c
+++ b/modules/dav/main/util.c
@@ -590,6 +590,47 @@ DAV_DECLARE(time_t) dav_get_timeout_string(request_rec *r,
     return DAV_TIMEOUT_INFINITE;
 }
 
+DAV_DECLARE(dav_error *) dav_parse_locktoken(apr_pool_t *p,
+                                             const char *input,
+                                             char **output)
+{
+    char *token;
+    apr_size_t len;
+    int has_open;
+    int has_close;
+
+    if (output == NULL) {
+        return dav_new_error(p, HTTP_INTERNAL_SERVER_ERROR, 0, 0,
+                             "DAV lock token parser called with NULL output pointer.");
+    }
+    *output = NULL;
+
+    if (input == NULL) {
+        return dav_new_error(p, HTTP_BAD_REQUEST, 0, 0,
+                             "No Lock-Token specified in header.");
+    }
+
+    len = strlen(input);
+
+    has_open = (len > 0 && input[0] == '<');
+    has_close = (len > 0 && input[len - 1] == '>');
+
+    if (len < 2 || !has_open || !has_close) {
+        return dav_new_error(p, HTTP_BAD_REQUEST, 0, 0,
+                             "Malformed Lock-Token header.");
+    }
+
+    token = apr_pstrndup(p, input + 1, len - 2);
+
+    if (*token == '\0') {
+        return dav_new_error(p, HTTP_BAD_REQUEST, 0, 0,
+                             "Malformed Lock-Token header.");
+    }
+
+    *output = token;
+    return NULL;
+}
+
 /* ---------------------------------------------------------------
 **
 ** If Header processing

--- a/modules/dav/main/util.c
+++ b/modules/dav/main/util.c
@@ -616,8 +616,7 @@ DAV_DECLARE(dav_error *) dav_parse_locktoken(apr_pool_t *p,
                              "Malformed Lock-Token");
     }
 
-    token = apr_pmemdup(p, input + 1, len - 2);
-    token[len - 2] = '\0';
+    token = apr_pstrememdup(p, input + 1, len - 2);
 
     if (*token == '\0') {
         return dav_new_error(p, HTTP_BAD_REQUEST, 0, 0,


### PR DESCRIPTION
This change improves the handling of the Lock-Token request header in mod_dav by adding proper length validation before performing string indexing and trimming operations

The existing implementation processes the `Lock-Token` header without verifying that the string length is sufficient before

-Accessing `lock_token_hdr[len - 1]`
-Computing `len - 2` for `apr_pstrndup`