### PR TITLE
Adds test for missing header in h2 proxy

### DIFF
--- a/test/modules/http2/test_600_h2proxy.py
+++ b/test/modules/http2/test_600_h2proxy.py
@@ -1,3 +1,7 @@
+import re
+import socket
+import textwrap
+
 import pytest
 
 from .env import H2Conf, H2TestEnv
@@ -198,3 +202,29 @@ class TestH2Proxy:
         # stream (exit_code != 0) or give a 503 response.
         if r.exit_code == 0:
             assert r.response['status'] in [502, 503]
+
+    # test missing host header
+    def test_h2_600_33(self, env):
+        conf = H2Conf(env, extras={
+            'base': [
+                'ProxyPreserveHost on',
+                f'ProxyPass /test/ h2c://127.0.0.1:{env.http_port}/',
+            ],
+        })
+        conf.install()
+        assert env.apache_restart() == 0
+
+        with socket.create_connection(('localhost', int(env.http_port))) as sock:
+            sock.sendall("GET /test/\r\n\r\n".encode())
+            sock.shutdown(socket.SHUT_WR)
+            sock.recv(1024)
+        log_message = re.compile(
+            r'.*HTTP/0\.9 request \(with no Host header\)'
+            r' and preserve host set, forcing hostname.*'
+        )
+        assert env.httpd_error_log.scan_recent(log_message, timeout=5)
+        env.httpd_error_log.ignore_recent(matches=[
+            r'.*HTTP/0\.9 request \(with no Host header\).*',
+        ], lognos=[
+            "AH10511"
+        ])


### PR DESCRIPTION
This PR adds a regression test to the pyhttpd test suite covering the changes of apache/httpd@3492480 and apache/httpd@f40ebca