### PR TITLE
improve bounds checking for line length validation

### DIFF
--- a/modules/filters/mod_substitute.c
+++ b/modules/filters/mod_substitute.c
@@ -239,7 +239,9 @@ static apr_status_t do_pattmatch(ap_filter_t *f, apr_bucket *inb,
                              * are constanting allocing space and copying
                              * strings.
                              */
-                            if (vb.strlen + len + replen > cfg->max_line_length)
+                            if (vb.strlen > cfg->max_line_length
+                                    || len > cfg->max_line_length - vb.strlen
+                                    || replen > cfg->max_line_length - vb.strlen - len)
                                 return APR_ENOMEM;
                             ap_varbuf_strmemcat(&vb, buff, len);
                             ap_varbuf_strmemcat(&vb, replacement, replen);
@@ -251,7 +253,7 @@ static apr_status_t do_pattmatch(ap_filter_t *f, apr_bucket *inb,
                              * Check if we still have space for this string and
                              * the replacement string.
                              */
-                            if (space_left < len + replen)
+                            if (len > space_left || replen > space_left - len)
                                 return APR_ENOMEM;
                             space_left -= len + replen;
                             /*
@@ -338,7 +340,8 @@ static apr_status_t do_pattmatch(ap_filter_t *f, apr_bucket *inb,
                             /* Note that the last param in ap_varbuf_regsub below
                              * must stay positive. If it gets 0, it would mean
                              * unlimited space available. */
-                            if (vb.strlen + regm[0].rm_so >= cfg->max_line_length)
+                            if (vb.strlen >= cfg->max_line_length
+                                    || (apr_size_t)regm[0].rm_so > cfg->max_line_length - vb.strlen)
                                 return APR_ENOMEM;
                             /* copy bytes before the match */
                             if (regm[0].rm_so > 0)


### PR DESCRIPTION
Improves bounds checking logic in `mod_substitute` within Apache HTTP Server

Replaces combined arithmetic validation with step-wise boundary checks

Ensures `vb.strlen`, `len`, and `replen` remain within `max_line_length` limits

Updates conditions to avoid reliance on aggregated expressions for validation

Applies consistent bounds checking pattern across related code paths

Adjusts checks involving `space_left` to use safe comparisons

Refines validation of `regm[0].rm_so` against remaining buffer space

Prevents operations from exceeding configured buffer limits