### PR TITLE
Fix incorrect pool reference in h2_request_rcreate

### DIFF
--- a/modules/http2/h2_mplx.c
+++ b/modules/http2/h2_mplx.c
@@ -603,7 +603,8 @@ const h2_stream *h2_mplx_c2_stream_get(h2_mplx *m, int stream_id)
     h2_stream *s = NULL;
     
     H2_MPLX_ENTER_ALWAYS(m);
-    s = h2_ihash_get(m->streams, stream_id);
+    if (m->streams)
+        s = h2_ihash_get(m->streams, stream_id);
     H2_MPLX_LEAVE(m);
 
     return s;

--- a/modules/http2/h2_stream.c
+++ b/modules/http2/h2_stream.c
@@ -659,7 +659,7 @@ apr_status_t h2_stream_set_request_rec(h2_stream *stream,
     if (stream->rst_error) {
         return APR_ECONNRESET;
     }
-    status = h2_request_rcreate(&req, stream->pool, r,
+    status = h2_request_rcreate(&req, r->pool, r,
                                 &stream->session->hd_scratch);
     if (status == APR_SUCCESS) {
         ap_log_rerror(APLOG_MARK, APLOG_DEBUG, status, r, 


### PR DESCRIPTION
Two serious h2 bugs:

First one involves the way h2 defers r->pool cleanups until the connection closes.  This is simply insane, with a one-line repair to tie r->pool to the rcreate pool instead of the long-lived stream pool. This is trivially DOSable by someone with a clue.

Second one avoids a segfault during certain kinds of subrequest lookup processing.