### PR TITLE
fix overflow in allocation size calculation in apreq_param_make

### DIFF
--- a/server/apreq_param.c
+++ b/server/apreq_param.c
@@ -34,8 +34,18 @@ APREQ_DECLARE(apreq_param_t *) apreq_param_make(apr_pool_t *p,
 {
     apreq_param_t *param;
     apreq_value_t *v;
+    apr_size_t size;
 
-    param = apr_palloc(p, nlen + vlen + 1 + sizeof *param);
+    /* Check for overflow in size computation */
+    if (nlen > APR_SIZE_MAX - vlen)
+        return NULL;
+
+    size = nlen + vlen;
+    if (size > APR_SIZE_MAX - sizeof(*param) - 1)
+        return NULL;
+
+    size += sizeof(*param) + 1;
+    param = apr_palloc(p, size);
 
     if (param == NULL)
         return NULL;


### PR DESCRIPTION
## Summary
Fix integer overflow in `apreq_param_make()` when computing the allocation size.

## Root Cause
The allocation size was calculated using unchecked arithmetic:

    nlen + vlen + 1 + sizeof(*param)

For sufficiently large values, this addition can overflow `apr_size_t`, leading to an incorrect (wrapped) allocation size.

## Fix
Add bounds checks before performing the allocation:

- Ensure `nlen + vlen` does not overflow
- Ensure the final size including structure and terminator fits in `apr_size_t`
- Use the validated size for allocation

## Behavior
- Valid inputs: unchanged
- Overflow cases: function returns `NULL` (already handled by callers)

## Impact
Ensures allocation size calculations are safe and do not rely on implicit assumptions about input sizes.