### PR TITLE
mod_ssl: Expose serialNumber (2.5.4.5) as standard env var from certi…

### DIFF
--- a/modules/ssl/ssl_engine_vars.c
+++ b/modules/ssl/ssl_engine_vars.c
@@ -720,6 +720,7 @@ static const struct {
     { "G",     NID_givenName,              1 },
     { "S",     NID_surname,                1 },
     { "D",     NID_description,            1 },
+    { "SerialNumber", NID_serialNumber,    1 },
 #ifdef NID_userId
     { "UID",   NID_userId,                 1 },
 #endif


### PR DESCRIPTION
…ficate DN

serialNumber (2.5.4.5) is a standard LDAP attribute embedded in the subject's and/or issuer's DN, extract it by standard means from the DN and expose via StdEnvVars.

This fixes BZ #35154.