### PR TITLE
mod_ssl: Set auth type to "ClientCert" after authentication

### DIFF
--- a/changes-entries/ssl-authtype.txt
+++ b/changes-entries/ssl-authtype.txt
@@ -1,0 +1,2 @@
+*) mod_ssl: Set auth type to "ClientCert" when client certificate authentication
+   has been performed.  [Michael Osipov <michaelo apache.org>]

--- a/modules/ssl/ssl_engine_kernel.c
+++ b/modules/ssl/ssl_engine_kernel.c
@@ -1130,8 +1130,10 @@ int ssl_hook_Access(request_rec *r)
     if ((dc->nOptions & SSL_OPT_FAKEBASICAUTH) == 0 && dc->szUserName) {
         const char *val = ssl_var_lookup(r->pool, r->server, r->connection,
                                          r, dc->szUserName);
-        if (val && val[0])
+        if (val && val[0]) {
             r->user = apr_pstrdup(r->pool, val);
+            r->ap_auth_type = "ClientCert";
+        }
         else
             ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, r, APLOGNO(02227)
                           "Failed to set r->user to '%s'", dc->szUserName);


### PR DESCRIPTION
When client certificate authentication has been performed r->ap_auth_type was never populated and env AUTH_TYPE was empty.
We now set auth type to "ClientCert".

PR: 45058
GitHub: closes #645