### PR TITLE
Fixed small typo apu_* instead of apr_*

### DIFF
--- a/server/log.c
+++ b/server/log.c
@@ -735,7 +735,7 @@ static int log_apr_status(const ap_errorlog_info *info, const char *arg,
         apr_strerror(status, buf + len, buflen - len);
     }
     else if (status < (APR_UTIL_START_STATUS + APR_UTIL_ERRSPACE_SIZE)) {
-        apu_strerror(status, buf + len, buflen - len);
+        apr_strerror(status, buf + len, buflen - len);
     }
     else {
         apr_strerror(status, buf + len, buflen - len);


### PR DESCRIPTION
Building httpd this morning I got this error:

log.c: In function 'log_apr_status':
log.c:738:9: error: implicit declaration of function 'apu_strerror'; did you mean 'apr_strerror'? [-Wimplicit-function-declaration]
  738 |         apu_strerror(status, buf + len, buflen - len);
      |         ^~~~~~~~~~~~
      |         apr_strerror

Simple fix, updating to apr_strerror as suggested the build completes without any further issues.