### PR TITLE
CMake: backport minimum version required change, and apply workaround for error Unexpected enablement value "i"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -606,6 +606,9 @@ FOREACH (modinfo ${MODULE_LIST})
 
 ENDFOREACH()
 
+#workaround for error: Unexpected enablement value "i" for mod_authnz_ldap
+UNSET(i)
+
 SET(install_targets)
 SET(install_bin_pdb)
 SET(install_modules) # special handling vs. other installed targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,11 @@
 #
 # Read README.cmake before using this.
 
-PROJECT(HTTPD C)
+# CMAKE_MINIMUM_REQUIRED should be the first directive in the file:
+# https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
+CMAKE_MINIMUM_REQUIRED(VERSION 3.16...3.29)
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+PROJECT(HTTPD C)
 
 INCLUDE(CheckSymbolExists)
 INCLUDE(CheckCSourceCompiles)


### PR DESCRIPTION
into branch `2.4.x`