### PR TITLE
Fix Windows builds in GH Actions

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,7 +20,6 @@ on:
 
 jobs:
   build:
-    if: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,7 +52,10 @@ jobs:
       - name: Configure CMake
         shell: cmd
         run: |
-            call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=${{ matrix.arch }}
+            where /R "C:\Program Files\Microsoft Visual Studio" VsDevCmd.bat > vs_setup_path
+            set /p SETUP_VS=< vs_setup_path
+            call "%SETUP_VS%" -arch=${{ matrix.arch }}
+
             cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} ^
                 -G "${{ matrix.generator }}" ^
                 -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake ^
@@ -62,5 +65,7 @@ jobs:
       - name: Build
         shell: cmd
         run: |
-            call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=${{ matrix.arch }}
+            set /p SETUP_VS=< vs_setup_path
+            call "%SETUP_VS%" -arch=${{ matrix.arch }}
+            del vs_setup_path
             cmake --build ${{github.workspace}}/build --config ${{ matrix.build-type }}


### PR DESCRIPTION
I noticed the discussion on the dev list about the WIndows CI failures. This was caused by the changes to the default `windows-latest` container. The new one uses VS 2026 with a newer CMake and a different path.

Similar changes were already implemented in [commons-daemon](https://github.com/apache/commons-daemon/commit/ddceb90fdff59144fb11249287aeb365e5fe7c19).