### PR TITLE
CI: Update GH Actions before Node.js 20 deprecation + minor tweaks

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -344,9 +344,6 @@ jobs:
         echo "${{ matrix.env }}" >> $GITHUB_ENV
         echo JOBID=`echo "OS=$ImageOS ${{ matrix.notest-cflags }} ${{ matrix.env }} ${{ matrix.config }}" \
            | md5sum - | sed 's/ .*//'` >> $GITHUB_ENV
-    # https://github.com/actions/runner-images/issues/9491#issuecomment-1989718917
-    - name: Workaround ASAN issue in Ubuntu 22.04
-      run: sudo sysctl vm.mmap_rnd_bits=28
     - name: apt refresh
       run: sudo apt-get -o Acquire::Retries=5 update
     - name: Install prerequisites
@@ -375,7 +372,7 @@ jobs:
     - name: Configure environment
       run: ./test/travis_before_linux.sh
       timeout-minutes: 15
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: config.log-${{ env.JOBID }}
@@ -383,7 +380,7 @@ jobs:
           /home/runner/build/**/config.log
     - name: Build and test
       run: ./test/travis_run_linux.sh
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: error_log-${{ env.JOBID }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -57,15 +57,13 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Configure CMake
-        shell: cmd
         run: |
-            cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} ^
-                -G "${{ matrix.generator }}" ^
-                -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake ^
-                -DAPR_INCLUDE_DIR=C:/vcpkg/installed/${{ matrix.triplet }}/include ^
+            cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} `
+                -G "${{ matrix.generator }}" `
+                -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake `
+                -DAPR_INCLUDE_DIR=C:/vcpkg/installed/${{ matrix.triplet }}/include `
                 "-DAPR_LIBRARIES=C:/vcpkg/installed/${{ matrix.triplet }}/lib/libapr-1.lib;C:/vcpkg/installed/${{ matrix.triplet }}/lib/libaprutil-1.lib"
 
       - name: Build
-        shell: cmd
         run: |
             cmake --build ${{github.workspace}}/build --config ${{ matrix.build-type }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Configure CMake
         run: |
+            cmake --version
             cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} `
                 -G "${{ matrix.generator }}" `
                 -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -45,7 +45,7 @@ jobs:
           ls env: | foreach { "$($_.Name)=$($_.Value)" >> $env:GITHUB_ENV }
 
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
               core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');


### PR DESCRIPTION
The current CI triggers warnings because in two weeks Node.js 20 actions will stop working. This PR updates all affected actions.

Additionally, it drops `shell: cmd` and uses PowerShell for the Windows workflow since it has already been introduced there (see 767d9550e7c9036fa1604c15f975f7c590d95752).

Finally, it removes the fix for Ubuntu 22.04 since it's no longer used.