### PR TITLE
[2.4.x] Fix Windows CI for CMake 4.3 and VS 2026, and update GH Actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -275,9 +275,6 @@ jobs:
         echo "${{ matrix.env }}" >> $GITHUB_ENV
         echo JOBID=`echo "OS=$ImageOS ${{ matrix.notest-cflags }} ${{ matrix.env }} ${{ matrix.config }}" \
            | md5sum - | sed 's/ .*//'` >> $GITHUB_ENV
-    # https://github.com/actions/runner-images/issues/9491#issuecomment-1989718917
-    - name: Workaround ASAN issue in Ubuntu 22.04
-      run: sudo sysctl vm.mmap_rnd_bits=28
     - name: apt refresh
       run: sudo apt-get -o Acquire::Retries=5 update
     - name: Install prerequisites
@@ -300,7 +297,7 @@ jobs:
     - name: Configure environment
       run: ./test/travis_before_linux.sh
       timeout-minutes: 15
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: config.log-${{ env.JOBID }}
@@ -308,7 +305,7 @@ jobs:
           /home/runner/build/**/config.log
     - name: Build and test
       run: ./test/travis_run_linux.sh
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: error_log-${{ env.JOBID }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,8 +36,16 @@ jobs:
     env: 
       VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
     steps:
+      - name: Prepare Environment
+        run: |
+          $root = &(Join-Path ${env:ProgramFiles(x86)} "\Microsoft Visual Studio\Installer\vswhere.exe") -property installationpath -latest
+          Import-Module (Join-Path $root "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
+          Enter-VsDevShell -VsInstallPath $root -DevCmdArguments "-arch=${{ matrix.arch }}"
+
+          ls env: | foreach { "$($_.Name)=$($_.Value)" >> $env:GITHUB_ENV }
+
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
               core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -46,20 +54,17 @@ jobs:
       - name: Install dependencies
         run: vcpkg install --triplet ${{ matrix.triplet }} apr[private-headers] apr-util pcre2 openssl
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Configure CMake
-        shell: cmd
         run: |
-            call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=${{ matrix.arch }}
-            cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} ^
-                -G "${{ matrix.generator }}" ^
-                -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake ^
-                -DAPR_INCLUDE_DIR=C:/vcpkg/installed/${{ matrix.triplet }}/include ^
+            cmake --version
+            cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} `
+                -G "${{ matrix.generator }}" `
+                -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake `
+                -DAPR_INCLUDE_DIR=C:/vcpkg/installed/${{ matrix.triplet }}/include `
                 "-DAPR_LIBRARIES=C:/vcpkg/installed/${{ matrix.triplet }}/lib/libapr-1.lib;C:/vcpkg/installed/${{ matrix.triplet }}/lib/libaprutil-1.lib"
 
       - name: Build
-        shell: cmd
         run: |
-            call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=${{ matrix.arch }}
             cmake --build ${{github.workspace}}/build --config ${{ matrix.build-type }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,11 @@
 #
 # Read README.cmake before using this.
 
-PROJECT(HTTPD C)
+# CMAKE_MINIMUM_REQUIRED should be the first directive in the file:
+# https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
+CMAKE_MINIMUM_REQUIRED(VERSION 3.16...3.29)
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+PROJECT(HTTPD C)
 
 INCLUDE(CheckSymbolExists)
 INCLUDE(CheckCSourceCompiles)


### PR DESCRIPTION
Backports 08138ac986851217ff8f03b495d12ceca9051e24, 767d9550e7c9036fa1604c15f975f7c590d95752, ca0ff167c823344132fa08f8554154ea43593b7e, and a3ee602db550d1377b53a9eb82749ac804e31fdb.