### PR TITLE
Harden CI workflow permissions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,6 +20,9 @@ on:
       - '**.md'
       - changes-entries/*
 
+permissions:
+  contents: read
+
 env:
   MARGS: "-j2"
   CFLAGS: "-g"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,6 +18,9 @@ on:
       - CHANGES
       - changes-entries/*
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
This tightens the GitHub Actions CI workflow permissions without changing the Linux or Windows build behavior.

The workflows only need repository read access for checkout and build/test execution, so this sets the default `GITHUB_TOKEN` permission to `contents: read`.

I verified the workflow YAML still parses, `git diff --check` passes, and `zizmor` no longer reports the previous excessive-permissions findings. The remaining findings are action pinning warnings, which I left out of this focused change.
