### PR TITLE
Fix pre-1.1.0 OpenSSL compat macros in ssl_private.h

### DIFF
--- a/modules/ssl/ssl_private.h
+++ b/modules/ssl/ssl_private.h
@@ -290,8 +290,9 @@
 #define EVP_PKEY_up_ref(pk)        (CRYPTO_add(&(pk)->references, +1, CRYPTO_LOCK_EVP_PKEY))
 #define ASN1_STRING_get0_data(x)   ((x)->data)
 #define ASN1_STRING_length(x)      ((int)(x)->length)
-#define X509_get0_before(x)        X509_get_before(x)
-#define X509_get0_after(x)         X509_get_after(x)
+#define X509_get0_serialNumber(x) X509_get_serialNumber(x)
+#define X509_get0_notBefore(x)        X509_get_notBefore(x)
+#define X509_get0_notAfter(x)         X509_get_notAfter(x)
 #else
 void init_bio_methods(void);
 void free_bio_methods(void);


### PR DESCRIPTION
Fixes pre-1.1.0 compat macros for X509_get0_notBefore/notAfter/serialNumber

The compat macros added in 83d565f for pre-1.1.0 OpenSSL used incorrect names (X509_get0_before/X509_get0_after) which don't match the actual API names used in the code (X509_get0_notBefore/X509_get0_notAfter). This caused link failures when building against OpenSSL 1.0.2.

Also add missing X509_get0_serialNumber compat macro which was used in ssl_engine_log.c but never shimmed for pre-1.1.0.

## Testing

Verified this fixes link failures when building httpd 2.4.68 against OpenSSL 1.0.2 (undefined references to X509_get0_serialNumber, X509_get0_notBefore, X509_get0_notAfter). Build completes successfully with this patch applied.