### PR TITLE
Removed modules/md/md_tailscale.c from CMakeList.txt so mod_md can be built on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -521,7 +521,7 @@ SET(mod_md_extra_sources
   modules/md/md_ocsp.c               modules/md/md_util.c               
   modules/md/mod_md_config.c         modules/md/mod_md_drive.c
   modules/md/mod_md_os.c             modules/md/mod_md_status.c
-  modules/md/mod_md_ocsp.c           modules/md/md_tailscale.c
+  modules/md/mod_md_ocsp.c
 )
 SET(mod_optional_hook_export_extra_defines AP_DECLARE_EXPORT) # bogus reuse of core API prefix
 SET(mod_proxy_extra_defines          PROXY_DECLARE_EXPORT)


### PR DESCRIPTION
The file modules/md/md_tailscale.c is no longer part of modules/md and causes the build to fail on Windows (using cmake), when building with all the prerequisites for mod_md are included.