### PR TITLE
mod_proxy_balancer: use apr_isspace when scanning Cookie header

### DIFF
--- a/modules/proxy/mod_proxy_balancer.c
+++ b/modules/proxy/mod_proxy_balancer.c
@@ -171,10 +171,10 @@ static char *get_cookie_param(request_rec *r, const char *name)
             if (start_cookie == cookies ||
                 start_cookie[-1] == ';' ||
                 start_cookie[-1] == ',' ||
-                isspace(start_cookie[-1])) {
+                apr_isspace(start_cookie[-1])) {
 
                 start_cookie += strlen(name);
-                while(*start_cookie && isspace(*start_cookie))
+                while(*start_cookie && apr_isspace(*start_cookie))
                     ++start_cookie;
                 if (*start_cookie++ == '=' && *start_cookie) {
                     /*


### PR DESCRIPTION
1. get_cookie_param() scans the client-supplied Cookie request header and passes raw `char` bytes (`start_cookie[-1]` and `*start_cookie`) straight to `isspace()`.
2. on platforms where `char` is signed, a cookie byte >= 0x80 reaches `isspace()` as a negative int, which is outside the unsigned-char / EOF domain the ctype functions are defined for, so the result is undefined.

This is reachable on any balancer with a sticky session (`get_cookie_param` is called from find_session_route via `balancer->s->sticky`), so the byte is fully attacker-controlled. Switched both calls to `apr_isspace`, which indexes through `unsigned char` and is already what the surrounding proxy/http/server code uses everywhere else.