### PR TITLE
mod_http2: reset truncated HTTP/2 responses; spare header-only ones

### DIFF
--- a/modules/http2/h2_c2.c
+++ b/modules/http2/h2_c2.c
@@ -805,7 +805,20 @@ static apr_status_t c2_process(h2_conn_ctx_t *conn_ctx, conn_rec *c)
      * request pool may have been deleted. */
     r = NULL;
     if (conn_ctx->beam_out) {
-        h2_beam_close(conn_ctx->beam_out, c);
+        if (conn_ctx->has_final_response
+            && !h2_beam_is_complete(conn_ctx->beam_out)
+            && !conn_ctx->header_only) {
+            /* A final response was started but its body never completed (no
+             * EOS), e.g. the CGI/handler timed out mid-body. Abort so the
+             * stream is RST_STREAM'd. Closing here would mark the beam complete
+             * and s_c2_done() would see nothing to reset, leaving the client
+             * hanging. Header-only responses (204/304/HEAD) carry no body EOS
+             * and are closed normally, not reset (PR 69580). */
+            h2_beam_abort(conn_ctx->beam_out, c);
+        }
+        else {
+            h2_beam_close(conn_ctx->beam_out, c);
+        }
     }
 
     ap_log_cerror(APLOG_MARK, APLOG_TRACE1, 0, c,

--- a/modules/http2/h2_c2.c
+++ b/modules/http2/h2_c2.c
@@ -397,6 +397,7 @@ static apr_status_t h2_c2_filter_out(ap_filter_t* f, apr_bucket_brigade* bb)
                 ap_bucket_response *resp = e->data;
                 if (resp->status >= HTTP_OK) {
                     conn_ctx->has_final_response = 1;
+                    conn_ctx->header_only = AP_STATUS_IS_HEADER_ONLY(resp->status);
                     break;
                 }
             }

--- a/modules/http2/h2_c2_filter.c
+++ b/modules/http2/h2_c2_filter.c
@@ -549,6 +549,7 @@ static apr_status_t pass_response(h2_conn_ctx_t *conn_ctx, ap_filter_t *f,
 
     if (response->status >= HTTP_OK) {
         conn_ctx->has_final_response = 1;
+        conn_ctx->header_only = AP_STATUS_IS_HEADER_ONLY(response->status);
     }
     ap_log_cerror(APLOG_MARK, APLOG_DEBUG, 0, parser->c,
                   APLOGNO(03197) "h2_c2(%s): passed response %d",
@@ -757,6 +758,7 @@ apr_status_t h2_c2_filter_response_out(ap_filter_t *f, apr_bucket_brigade *bb)
     }
 
     if (r->header_only || AP_STATUS_IS_HEADER_ONLY(r->status)) {
+        conn_ctx->header_only = 1;
         ap_log_cerror(APLOG_MARK, APLOG_TRACE1, 0, f->c,
                       "h2_c2(%s): headers only, cleanup output brigade", conn_ctx->id);
         b = body_bucket? body_bucket : APR_BRIGADE_FIRST(bb);

--- a/modules/http2/h2_conn_ctx.h
+++ b/modules/http2/h2_conn_ctx.h
@@ -60,6 +60,7 @@ struct h2_conn_ctx_t {
     apr_pollfd_t pfd;                /* c1: poll socket input, c2: NUL */
 
     int has_final_response;          /* final HTTP response passed on out */
+    int header_only;                 /* c2: final response is header-only (204/304/HEAD), no body EOS will come */
     apr_status_t last_err;           /* APR_SUCCES or last error encountered in filters */
 
     apr_off_t bytes_sent;            /* c2: bytes acutaly sent via c1 */

--- a/modules/http2/h2_mplx.c
+++ b/modules/http2/h2_mplx.c
@@ -1005,7 +1005,13 @@ static void s_c2_done(h2_mplx *m, conn_rec *c2, h2_conn_ctx_t *conn_ctx)
         if (conn_ctx->beam_out)
           h2_beam_abort(conn_ctx->beam_out, c2);
     }
-    else if (!conn_ctx->beam_out || !h2_beam_is_complete(conn_ctx->beam_out)) {
+    else if (!conn_ctx->beam_out
+             || (!h2_beam_is_complete(conn_ctx->beam_out)
+                 && !conn_ctx->header_only)) {
+        /* A header-only response (204/304/HEAD) produces no body EOS, so an
+         * incomplete out beam is expected for it, not a truncation. This is the
+         * same case the c1 output path skips via AP_STATUS_IS_HEADER_ONLY().
+         * Only reset a response that began a body and never finished it. */
         ap_log_cerror(APLOG_MARK, APLOG_TRACE1, conn_ctx->last_err, c2,
                       "h2_c2(%s-%d): processing finished with incomplete output",
                       conn_ctx->id, conn_ctx->stream_id);

--- a/test/modules/http2/htdocs/cgi/h2cgi_slow.py
+++ b/test/modules/http2/htdocs/cgi/h2cgi_slow.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# Start a response (status + headers + a little body), then go silent for
+# longer than the server's `Timeout`. Over HTTP/2 this makes Apache's content
+# filter time out reading from the CGI (AH01220): the response was started but
+# never completed (no EOS). A correct server RST_STREAMs the stream; a buggy
+# one leaves the client hanging. Used by test_105_timeout.py.
+import sys
+import time
+
+sys.stdout.write("Content-Type: application/octet-stream\r\n\r\n")
+sys.stdout.write("X" * 16384)
+sys.stdout.flush()
+time.sleep(30)

--- a/test/modules/http2/test_105_timeout.py
+++ b/test/modules/http2/test_105_timeout.py
@@ -1,5 +1,6 @@
 import socket
 import time
+from datetime import timedelta
 
 import pytest
 
@@ -165,13 +166,52 @@ class TestTimeout:
         assert piper.response, f'{piper}'
         assert piper.response['status'] == 408, f"{piper.response}"
 
-    # A header-only response (204/304, or a HEAD request) legitimately
-    # carries no body and so no EOS, and must NOT be reset over HTTP/2.
-    # mod_cache revalidation of a cached, immediately-stale resource emits
-    # exactly such a 304 (EOR + Flush, no EOS). This guards the
-    # incomplete-response reset against re-opening PR 69580: the reset is
-    # for a truncation (a non-header-only response missing its EOS), never
-    # for a header-only one.
+    # A CGI that starts a response (status + headers + some body) and then goes
+    # silent past `Timeout` must lead to the HTTP/2 stream being RST_STREAM'd,
+    # not leave the client hanging. Regression test for the mod_http2 hang where
+    # a c2 that finished an *incomplete* response (no EOS, e.g. CGI timed out
+    # mid-body) was treated as complete and no reset was ever sent.
+    def test_h2_105_20(self, env):
+        conf = H2Conf(env)
+        conf.add("Timeout 1")
+        conf.add_vhost_cgi()
+        conf.install()
+        assert env.apache_restart() == 0
+        url = env.mkurl("https", "cgi", "/h2cgi_slow.py")
+        # Open many concurrent streams on one h2 connection. The missed reset
+        # is racy per stream: the single wakeup at close drives one receive,
+        # which resets only if it finds the beam already drained but usually
+        # still carries the response's trailing flush and re-suspends. So one
+        # stream is unreliable while many in flight hang at least one every
+        # run. Key on elapsed time, not curl's exit code (--parallel makes
+        # that ambiguous): a hang is a multi-second stall, a correct reset a
+        # sub-second teardown. --max-time bounds the client so a hang cannot
+        # wedge the test. The per-stream hang is a timing race, so its odds
+        # shift with hardware and load; 10 is cheap margin and, being
+        # concurrent, costs no wall-clock.
+        count = 10
+        max_time = 10
+        r = env.curl_raw([url] * count, options=[
+            "--parallel", "--parallel-immediate", "--max-time", str(max_time)])
+        assert r.duration < timedelta(seconds=max_time - 2), \
+            f'streams hung waiting for RST_STREAM (batch took {r.duration}): {r}'
+        # Resetting each silent CGI is logged as a CGI timeout (cgid) and the
+        # failed body read that follows it (core); both are expected here.
+        time.sleep(1)  # let the log flush
+        env.httpd_error_log.ignore_recent(
+            lognos = [
+                "AH01220",  # cgid: Timeout waiting for output from CGI script
+                "AH00574",  # core: ap_content_length_filter, apr_bucket_read() failed
+            ]
+        )
+
+    # Complement to test_h2_105_20: a header-only response (204/304, or a
+    # HEAD request) legitimately carries no body and so no EOS, and must
+    # NOT be reset over HTTP/2. mod_cache revalidation of a cached,
+    # immediately-stale resource emits exactly such a 304 (EOR + Flush, no
+    # EOS). This guards the incomplete-response reset against re-opening
+    # PR 69580: the reset is for a truncation (a non-header-only response
+    # missing its EOS), never for a header-only one.
     def test_h2_105_21(self, env):
         cacheroot = f"{env.server_dir}/cacheroot"
         env.mkpath(cacheroot)

--- a/test/modules/http2/test_105_timeout.py
+++ b/test/modules/http2/test_105_timeout.py
@@ -164,3 +164,36 @@ class TestTimeout:
         piper.close()
         assert piper.response, f'{piper}'
         assert piper.response['status'] == 408, f"{piper.response}"
+
+    # A header-only response (204/304, or a HEAD request) legitimately
+    # carries no body and so no EOS, and must NOT be reset over HTTP/2.
+    # mod_cache revalidation of a cached, immediately-stale resource emits
+    # exactly such a 304 (EOR + Flush, no EOS). This guards the
+    # incomplete-response reset against re-opening PR 69580: the reset is
+    # for a truncation (a non-header-only response missing its EOS), never
+    # for a header-only one.
+    def test_h2_105_21(self, env):
+        cacheroot = f"{env.server_dir}/cacheroot"
+        env.mkpath(cacheroot)
+        conf = H2Conf(env)
+        conf.add(f"""
+            CacheRoot "{cacheroot}"
+            CacheEnable disk /
+            Header set Cache-Control "public, max-age=0"
+            """)
+        conf.add_vhost_test1()
+        conf.install()
+        assert env.apache_restart() == 0
+        url = env.mkurl("https", "test1", "/006/006.css")
+        # prime the cache (stored, immediately stale via max-age=0)
+        r = env.curl_get(url)
+        assert r.exit_code == 0, f'{r}'
+        assert r.response["status"] == 200
+        lm = r.response["header"]["last-modified"]
+        # revalidate: mod_cache freshens the stale entry and the origin returns a
+        # body-less 304. The h2 stream must close cleanly; a regression shows up
+        # as a curl exit (92, "stream not closed cleanly"), not as a 304.
+        r = env.curl_get(url, options=["-H", "Cache-Control: max-age=0",
+                                       "-H", f"if-modified-since: {lm}"])
+        assert r.exit_code == 0, f'304 stream was reset (curl {r.exit_code}): {r}'
+        assert r.response["status"] == 304, f'{r.response}'


### PR DESCRIPTION
This series addresses two ways mod_http2 mis-terminates an HTTP/2 stream when
a c2 (request) handler finishes without sending an EOS. Patch 1 completes the
PR 69580 fix on trunk; patch 2 fixes a separate hang (PR 70131) on the 2.4.x
build path. Both come from one gap: h2_beam_is_complete() cannot tell a
header-only response (204/304, and HEAD, complete without a body EOS) from a
truncated one, and mod_http2 compiles one of two c2 output paths depending on
the server's module magic (AP_HAS_RESPONSE_BUCKETS is 1 for MMN >= 20211221,
0 for 2.4.x), so the two paths fail in opposite directions: the
response-bucket path resets a valid 304, and the legacy path leaves a
truncated response hanging.

r1924267 fixed PR 69580 by exempting header-only responses from the
missing-EOS reset in stream_data_cb(), and that exemption was backported to
2.4.x (r1928581), where it is enough: the legacy c2_process() closes the
output beam, so the 304's beam is complete by the time s_c2_done() runs and
stream_data_cb() is the only reset path. On trunk the response-bucket path
leaves the beam incomplete, and s_c2_done()'s own abort (added in the 2023
HTTP/2 WebSockets work) still resets the 304, a path r1924267 did not cover
and which is not exercised on 2.4.x. PR 69580 therefore still reproduces on
trunk. Patch 1 gives s_c2_done() the same header-only exemption that
stream_data_cb() already has.

The exemption is carried by a new conn_ctx flag, header_only ("the final
response is header-only: 204/304, or HEAD"), set once from
AP_STATUS_IS_HEADER_ONLY() where the response is finalized. The completeness
test at each c2 reset point is then h2_beam_is_complete() OR header_only: the
beam reports whether a body EOS was seen, and the flag supplies the one case
the beam cannot know. Both patches read the same flag, so the two output paths
make the decision the same way.

With these patches:

 * A header-only response (204/304, and HEAD) is no longer RST_STREAM'd on
   trunk. A mod_cache revalidation 304 (EOR + Flush, no body EOS) now closes
   cleanly rather than resetting the stream (PR 69580).

 * A response that started but never sent EOS (e.g. a CGI that hits the
   server Timeout mid-body) is reset instead of left parked, on the legacy
   c2 path. Previously a client without a stall timeout waited indefinitely,
   while the same handler over HTTP/1.1 closed the connection and failed
   fast (PR 70131).

The completeness decision is layered at the c2 level rather than pushed into
h2_beam_is_complete(): the beam has no view of the response status, so it
cannot know that a body-less 304 is complete, whereas the c2 filters and
conn_ctx do. h2_beam_is_complete() therefore stays a pure beam-state query,
and patch 1's exemption sits next to the one stream_data_cb() already applies.

Patch 2 changes only the legacy (!AP_HAS_RESPONSE_BUCKETS) path, which is not
compiled on trunk, and trunk does not have the hang. The worker enters c2 by
build (h2_workers.c): trunk calls ap_process_connection() directly, while
2.4.x calls h2_c2_process(), then c2_process(). c2_process() is the module's
only h2_beam_close() call site, so trunk never force-closes the output beam,
and a truncated response leaves it incomplete for s_c2_done() to reset. Patch 2
is therefore inert on trunk and becomes active when the module is built for, or
synced to, 2.4.x. Patch 1's response-bucket fix is the live fix on trunk.

 * Patch 1: complete r1924267 (PR 69580) on trunk. Introduce
   conn_ctx->header_only, set from AP_STATUS_IS_HEADER_ONLY() where the
   response is finalized (h2_c2_filter_out on the response-bucket path,
   pass_response / h2_c2_filter_response_out on the legacy path). In
   s_c2_done(), spare a header-only response from the "incomplete output"
   abort, since its beam is legitimately EOS-less, so a body-less mod_cache
   revalidation 304 is no longer reset. Adds test_h2_105_21 (a 304
   revalidation must close cleanly).

 * Patch 2: reset an incomplete response on the legacy c2 path (PR 70131).
   There the worker runs c2_process(), which closes the output beam
   unconditionally when the handler returns, so a response that began but
   never sent EOS leaves a closed beam that h2_beam_is_complete() reports
   complete; s_c2_done() then sends no reset, and stream_data_cb()'s
   APR_EOF reset never fires: h2_beam_receive() returns APR_EOF only on a
   zero-transfer receive of the closed beam, but the single re-dispatch
   usually transfers the response's trailing flush and returns
   APR_SUCCESS, so the stream re-suspends with no further wakeup, parking
   it. Abort the beam instead of closing it when a final response was
   started, its beam is incomplete, and the response is not header-only; an
   aborted beam returns APR_ECONNABORTED from h2_beam_receive() on the next
   pull (checked before the transfer loop), so the reset fires regardless of
   how the wakeup is scheduled. Header-only responses set header_only on this
   path in patch 1, so they are spared. Adds test_h2_105_20 (a CGI that goes
   silent past Timeout, run as concurrent streams, must be reset).

[1] PR 69580: https://bz.apache.org/bugzilla/show_bug.cgi?id=69580
[2] PR 70131: https://bz.apache.org/bugzilla/show_bug.cgi?id=70131
(Note: this series replaces the patch attached to the bug report)