### PR TITLE
mod_sed: fix out-of-bounds read in ycomp on mismatched y/// strings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,12 @@
                                                          -*- coding: utf-8 -*-
 Changes with Apache 2.5.1
 
+  *) mod_sed: Fix an out-of-bounds read in the "y" (transliterate) command
+     compiler when the replacement string is shorter than the source
+     string.  The parser now rejects the mismatched command instead of
+     reading past the end of the script line buffer.
+     [Ankit Prateek (OffByQuant) <ankit offbyquant.com>]
+
   *) mod_proxy_beacon: Back-end reverse proxy servers can announce
      themselves and be auto-added to their front-end proxy balancer.
      [Jim Jagielski]

--- a/modules/filters/sed0.c
+++ b/modules/filters/sed0.c
@@ -960,7 +960,13 @@ static char *ycomp(sed_commands_t *commands, char *expbuf)
             tsp++;
         }
         if(ep[cint] == commands->sseof || ep[cint] == '\0') {
+            /* Destination string is shorter than the source string: the byte
+             * just read is the closing delimiter or the NUL terminator, not a
+             * real replacement character.  Report the size mismatch and stop
+             * now -- continuing would walk tsp past the end of the line buffer
+             * (out-of-bounds read of linebuf). */
             command_errf(commands, SEDERR_TSNTSS, commands->linebuf);
+            return NULL;
         }
     }
     if(*tsp != commands->sseof) {


### PR DESCRIPTION
### Summary

`ycomp()` (`modules/filters/sed0.c`) compiles the sed `y/source/dest/` transliterate command by walking the source and destination strings in lock-step. The first scan loop guards `*tsp` against `'\0'`/`'\n'`, but the second loop reads the destination via `*tsp++` with **no such guard** — it stops only when the *source* pointer reaches the delimiter. When the destination string is shorter than the source, `tsp` runs past the destination's closing delimiter and the NUL terminator, reading past the end of the `LBSIZE + 1` line buffer (`commands->linebuf`) into adjacent memory until it happens to hit a matching byte.

The existing size-mismatch check (`SEDERR_TSNTSS`) already detects this case — it fires as soon as a destination byte reads back as the delimiter or NUL — but it only logs via `command_errf()` (which does not abort) and continues, so the over-read proceeds. This change makes that check `return NULL`, as every other error path in `ycomp` already does (the caller handles `NULL` by returning `-1`). That both fixes the over-read and rejects the malformed command, matching standard sed (`strings for 'y' command are different lengths`).

### Scope

The sed program is supplied via the `OutputSed`/`InputSed` configuration directives (`ACCESS_CONF`), so this is a robustness fix for malformed configuration, **not a remotely triggerable issue** — the HTTP request is only the data the compiled program is applied to and never re-enters `ycomp`.

### Testing

Built `sed0.c` + `sed1.c` + `regexp.c` with a small harness driving the real public API (`sed_init_commands` + `sed_compile_string`):

- **Before:** a `y` command with a 900-char source and 1-char destination read to offset **1802 of the 1001-byte line buffer** (802 out-of-bounds reads, shown via instrumentation — plain ASan does not flag it because APR pools sub-allocate `linebuf` from a larger block).
- **After:** 0 out-of-bounds reads; malformed `y` commands (shorter dest, longer dest, missing delimiter) are rejected cleanly with a single `SEDERR_TSNTSS`.
- **No regression:** valid `y`/`s`/chained-command output is byte-identical to the pristine build across a differential battery.
