### PR TITLE
mod_charset_lite: bound ctx->buf writes in finish_partial_char

### DIFF
--- a/modules/filters/mod_charset_lite.c
+++ b/modules/filters/mod_charset_lite.c
@@ -441,7 +441,8 @@ static apr_status_t finish_partial_char(charset_filter_ctx_t *ctx,
     /* Keep adding bytes from the input string to the saved string until we
      *    1) finish the input char
      *    2) get an error
-     * or 3) run out of bytes to add
+     *    3) run out of bytes to add
+     * or 4) fill ctx->buf, meaning the char is wider than we handle
      */
 
     do {
@@ -455,7 +456,8 @@ static apr_status_t finish_partial_char(charset_filter_ctx_t *ctx,
                                    &tmp_input_len,
                                    *out_str,
                                    out_len);
-    } while (rv == APR_INCOMPLETE && *cur_len);
+    } while (rv == APR_INCOMPLETE && *cur_len
+             && ctx->saved < sizeof(ctx->buf));
 
     if (rv == APR_SUCCESS) {
         ctx->saved = 0;


### PR DESCRIPTION
1. set_aside_partial_char stops once a straddling char reaches sizeof(ctx->buf) (FATTEST_CHAR) and flags EES_LIMIT, but finish_partial_char appends to ctx->buf[ctx->saved] with no such limit.
2. if apr_xlate_conv_buffer keeps returning APR_INCOMPLETE while input remains, ctx->saved grows past the 8-byte buffer and the next write lands out of bounds.

Added the sizeof(ctx->buf) bound to the loop so an over-wide char takes the existing EES_LIMIT path, the same way set_aside_partial_char already refuses one.