### PR TITLE
Fix ACME RewriteRule pattern in .htaccess recipe

### DIFF
--- a/docs/manual/rewrite/remapping.xml
+++ b/docs/manual/rewrite/remapping.xml
@@ -188,7 +188,7 @@ RewriteRule "^(.*)" "https://%{SERVER_NAME}$1" [R=301,L]
 
 <highlight language="config">
 RewriteEngine On
-RewriteRule "^/\.well-known/acme-challenge/" - [L]
+RewriteRule "^\.well-known/acme-challenge/" - [L]
 RewriteCond "%{HTTPS}" !=on
 RewriteRule "^(.*)" "https://%{SERVER_NAME}$1" [R=301,L]
 </highlight>


### PR DESCRIPTION
The ACME exemption example is chained from the `.htaccess` HTTPS redirect recipe in this file.

In per-directory context, `RewriteRule` matches the path without a leading slash, so `^/\.well-known/acme-challenge/` does not match ordinary ACME challenge requests there. Dropping the leading slash makes the exemption line up with the `.htaccess` context described above it.
