### PR TITLE
Use ProxySet for standalone worker example

### DIFF
--- a/docs/manual/mod/mod_proxy.xml
+++ b/docs/manual/mod/mod_proxy.xml
@@ -1614,10 +1614,10 @@ when the <var>url</var> parameter contains backreference(s) (see note below).
     reuse connections or cache DNS lookups. To enable connection
     pooling, define an explicit worker for the backend separately:</p>
     <highlight language="config">
-ProxyPass        "/notused" "http://backend.example.com/" connectiontimeout=5 timeout=30
+ProxySet         http://backend.example.com connectiontimeout=5 timeout=30
 ProxyPassMatch   "^/(.*\.gif)$" "http://backend.example.com/$1"
     </highlight>
-    <p>The explicit <directive>ProxyPass</directive> worker definition
+    <p>The explicit <directive>ProxySet</directive> worker definition
     ensures that the backend connection pool is available for use by
     <directive>ProxyPassMatch</directive> requests.</p>
     </note>


### PR DESCRIPTION
The `ProxyPass "/notused" ...` example defines the worker, but it also maps a live local path.

`ProxySet` already has a documented worker-only form in this file and expresses the intended setup here without creating an extra reverse-proxy mapping.
