### PR TITLE
Add slash to .htaccess HTTPS redirect examples

### DIFF
--- a/docs/manual/rewrite/remapping.xml
+++ b/docs/manual/rewrite/remapping.xml
@@ -119,7 +119,7 @@ RewriteRule    "^<strong>/foo</strong>\.html$"  "<strong>/bar</strong>.html" [PT
 <highlight language="config">
 RewriteEngine On
 RewriteCond "%{HTTPS}" !=on
-RewriteRule "^(.*)" "https://%{SERVER_NAME}$1" [R=301,L]
+RewriteRule "^(.*)" "https://%{SERVER_NAME}/$1" [R=301,L]
 </highlight>
 
       <p>The <code>%{HTTPS}</code> variable is set to <code>on</code>
@@ -149,7 +149,7 @@ RewriteRule "^(.*)" "https://%{SERVER_NAME}$1" [R=301,L]
 <highlight language="config">
 RewriteEngine On
 RewriteCond "%{HTTP:X-Forwarded-Proto}" =http [NC]
-RewriteRule "^(.*)" "https://%{SERVER_NAME}$1" [R=301,L]
+RewriteRule "^(.*)" "https://%{SERVER_NAME}/$1" [R=301,L]
 </highlight>
 
       <note type="warning">
@@ -190,7 +190,7 @@ RewriteRule "^(.*)" "https://%{SERVER_NAME}$1" [R=301,L]
 RewriteEngine On
 RewriteRule "^/\.well-known/acme-challenge/" - [L]
 RewriteCond "%{HTTPS}" !=on
-RewriteRule "^(.*)" "https://%{SERVER_NAME}$1" [R=301,L]
+RewriteRule "^(.*)" "https://%{SERVER_NAME}/$1" [R=301,L]
 </highlight>
     </dd>
 


### PR DESCRIPTION
These rewrite recipes are presented as `.htaccess` / per-directory examples.

In that context the matched path does not include a leading slash, so the absolute redirect target needs an explicit `/` between the authority and `$1`.
