### PR TITLE
Fix mod_asis handler names in mod_mime docs

### DIFF
--- a/docs/manual/mod/mod_mime.xml
+++ b/docs/manual/mod/mod_mime.xml
@@ -141,12 +141,12 @@ module="mod_mime_magic">MimeMagicFile</directive></seealso>
     to have the file <code>foo.html.asis</code> served by the <code>send-as-is</code>
     handler provided by <module>mod_asis</module>
     script, but not the file <code>bar.asis.html</code>, then instead
-    of using <code>AddHandler send-asis .asis</code>, use</p>
+    of using <code>AddHandler send-as-is .asis</code>, use</p>
 
     <example><title>Configure handler based on final extension only</title>
     <highlight language="config">
 &lt;FilesMatch "[^.]+\.asis$"&gt;
-  SetHandler send-asis
+  SetHandler send-as-is
 &lt;/FilesMatch&gt;
     </highlight>
     </example>
@@ -692,7 +692,7 @@ a matching file with MultiViews</description>
     bytes and <code>index.html.pl</code> of 1000 bytes, the <code>.cgi</code>
     file would win in this example. Users of <code>.asis</code> files
     might prefer to use the Handler option, if <code>.asis</code> files are
-    associated with the <code>asis-handler</code>.</p>
+    associated with the <code>send-as-is</code> handler.</p>
 
     <p>You may finally allow <code>Any</code> extensions to match, even if
     <module>mod_mime</module> doesn't recognize the extension. This can cause


### PR DESCRIPTION
The `mod_mime` examples currently use `send-asis` / `asis-handler`, but `mod_asis` registers `send-as-is`.

This updates the example and the later handler reference to use the actual handler name.
