### PR TITLE
Fix mod_rewrite guide seealso link

### DIFF
--- a/docs/manual/mod/mod_rewrite.xml
+++ b/docs/manual/mod/mod_rewrite.xml
@@ -59,7 +59,7 @@ URLs on the fly</description>
       <p>Further details, discussion, and examples, are provided in the
       detailed <a href="../rewrite/">Guide to mod_rewrite</a>.</p>
 </summary>
-<seealso><a href="rewrite/index.html">Guide to mod_rewrite</a></seealso>
+<seealso><a href="../rewrite/">Guide to mod_rewrite</a></seealso>
 
 <section id="logging"><title>Logging</title>
 


### PR DESCRIPTION
The `mod_rewrite` module page already links to `../rewrite/` in the summary, but the `See also` entry still points at `rewrite/index.html` from inside `docs/manual/mod/`.

This switches the `See also` link to the same working relative target.
