### PR TITLE
Remove unsupported AllowCONNECT None syntax

### DIFF
--- a/docs/manual/mod/mod_proxy_connect.xml
+++ b/docs/manual/mod/mod_proxy_connect.xml
@@ -83,7 +83,7 @@
 <description>Ports that are allowed to <code>CONNECT</code> through the
 proxy</description>
 <syntax>AllowCONNECT <var>port</var>[-<var>port</var>]
-[<var>port</var>[-<var>port</var>]] ... | None</syntax>
+[<var>port</var>[-<var>port</var>]] ...</syntax>
 <default>AllowCONNECT 443 563</default>
 <contextlist><context>server config</context><context>virtual host</context>
 </contextlist>
@@ -101,8 +101,6 @@ Port ranges available since Apache 2.3.7.</compatibility>
     <directive>AllowCONNECT</directive> directive to override this default and
     allow connections to the listed ports only.</p>
 
-    <p>Set the value to <code>None</code> to disallow
-    <code>CONNECT</code> requests to all ports, including the defaults.</p>
 </usage>
 </directivesynopsis>
 


### PR DESCRIPTION
`mod_proxy_connect` parses `AllowCONNECT` arguments as numeric ports or ranges only.

This removes the unsupported `None` alternative from the directive syntax and drops the sentence that recommends it.
