### PR TITLE
Fix French SSLVHostSNIPolicy authonly row

### DIFF
--- a/docs/manual/mod/mod_ssl.xml.fr
+++ b/docs/manual/mod/mod_ssl.xml.fr
@@ -2287,7 +2287,7 @@ décrite, et en fonction des différentes politiques utilisées&nbsp;:</p>
   <td><code>secure</code></td><td>autorisée</td><td>bloquée</td><td>bloquée</td>
 </tr>
 <tr>
-  <td><code>authonly</code></td><td>autorisée</td><td>bloquée</td><td>autorisée</td>
+  <td><code>authonly</code></td><td>autorisée</td><td>autorisée</td><td>bloquée</td>
 </tr>
 <tr>
   <td><code>insecure</code></td><td>autorisée</td><td>autorisée</td><td>autorisée</td>


### PR DESCRIPTION
The French `SSLVHostSNIPolicy` table has the `authonly` row inverted relative to the English source.

This updates the row so the client-verification and client-authentication columns match the current behavior described in `mod_ssl.xml`.
