### PR TITLE
Fix French H2MaxStreamErrors zero description

### DIFF
--- a/docs/manual/mod/mod_http2.xml.fr
+++ b/docs/manual/mod/mod_http2.xml.fr
@@ -1363,8 +1363,8 @@ H2EarlyHint Link "&lt;/my.css&gt;;rel=preload;as=style"
 		malveillante de la part du client.
             </p>
             <p>
-                Définissez cette directive à 0 pour vous prémunir contre les
-		clients qui provoquent des erreurs.
+                Définissez cette directive à 0 pour tolérer les clients
+			défaillants.
             </p>
         </usage>
     </directivesynopsis>


### PR DESCRIPTION
The French `H2MaxStreamErrors` text currently reverses the meaning of `0`.

The English source says `0` tolerates faulty clients. This updates the French sentence to match that behavior.
