### PR TITLE
Clarify CGIVar REQUEST_URI query handling

### DIFF
--- a/docs/manual/mod/core.xml
+++ b/docs/manual/mod/core.xml
@@ -732,9 +732,13 @@ CGIVar REQUEST_URI current-uri
   </highlight>
 
   <note><title>Note</title>
-  <p>The CGI environment variable <code>REQUEST_URI</code> (in either
-  mode) contains the full URI including the query string. This differs
-  from the server variable <code>%{REQUEST_URI}</code> used in
+  <p>In the default <code>original-uri</code> mode, the CGI environment
+  variable <code>REQUEST_URI</code> contains the original URI from the
+  request line, including the query string if one was sent. With
+  <code>current-uri</code>, <code>REQUEST_URI</code> is set from the
+  current URI being processed, and the query string remains available
+  separately in <code>QUERY_STRING</code>. This differs from the server
+  variable <code>%{REQUEST_URI}</code> used in
   <module>mod_rewrite</module> and <a href="../expr.html">ap_expr</a>,
   which contains only the path component (no query string).</p></note>
 </usage>

--- a/docs/manual/mod/core.xml.fr
+++ b/docs/manual/mod/core.xml.fr
@@ -782,12 +782,16 @@ CGIVar REQUEST_URI current-uri
   </highlight>
 
   <note><title>Note</title>
-  <p>Dans tous les cas, la variable d’environnement CGI <code>REQUEST_URI</code>
-  contient l’URI complet, y compris la chaîne de paramètres. Cela est différent
-  pour la variable de serveur <code>%{REQUEST_URI}</code> utilisée dans
+  <p>Dans le mode <code>original-uri</code> (par défaut), la variable
+  d’environnement CGI <code>REQUEST_URI</code> contient l’URI original de la
+  ligne de requête, y compris la chaîne de paramètres si elle est présente.
+  Avec <code>current-uri</code>, <code>REQUEST_URI</code> est définie à partir
+  de l’URI actuellement traitée, et la chaîne de paramètres reste disponible
+  séparément dans <code>QUERY_STRING</code>. Cela est différent pour la
+  variable de serveur <code>%{REQUEST_URI}</code> utilisée dans
   <module>mod_rewrite</module> et les expressions de <a
-  href="../expr.html">ap_expr</a>, qui ne contient que la partie chemin (pas la
-  chaîne de paramètres).</p></note>
+  href="../expr.html">ap_expr</a>, qui ne contient que la partie chemin (sans
+  la chaîne de paramètres).</p></note>
 </usage>
 </directivesynopsis>
 


### PR DESCRIPTION
This looks like a small docs regression from `73565fac0a`.

Before that change, the note matched what `ap_add_cgi_vars()` still does today: the default `original-uri` mode can include the query string, while `current-uri` uses `r->uri` and leaves the query string in `QUERY_STRING`.

This patch narrows the note back to that behavior and mirrors the same correction in `core.xml.fr`.

Checks:
- `git diff --check`
- `xmllint --noout docs/manual/mod/core.xml` (same pre-existing entity warnings elsewhere in the file)
- `xmllint --noout docs/manual/mod/core.xml.fr` (same pre-existing entity warnings elsewhere in the file)
