### PR TITLE
Fix CGI Python examples in howto docs

### DIFF
--- a/docs/manual/howto/cgi.xml
+++ b/docs/manual/howto/cgi.xml
@@ -526,7 +526,7 @@ import os
 
 print("Content-type: text/html\n")
 for key, value in os.environ.items():
-print(f"{key} --&gt; {value}&lt;br&gt;")
+    print(f"{key} --&gt; {value}&lt;br&gt;")
 </highlight>
 </example>
     </section>

--- a/docs/manual/howto/cgi.xml.fr
+++ b/docs/manual/howto/cgi.xml.fr
@@ -365,7 +365,7 @@ print("Hello, World.")
 
 <example>
 <highlight language="bash">
-chmod a+x first.py
+chmod a+x premier.py
 </highlight>
 </example>
 
@@ -562,7 +562,7 @@ import os
 
 print("Content-type: text/html\n")
 for key, value in os.environ.items():
-print(f"{key} --&gt; {value}&lt;br&gt;")
+    print(f"{key} --&gt; {value}&lt;br&gt;")
 </highlight>
 </example>
     </section>


### PR DESCRIPTION
This fixes two small drift issues in the CGI Python examples.

The environment-dump example in both `cgi.xml` and `cgi.xml.fr` lost the indentation on the loop body, so the sample no longer parses as Python. The French page also still used `first.py` in the `chmod` example even though that page's sample script is named `premier.py`.

Checks:
- `xmllint --noout docs/manual/howto/cgi.xml`
- `xmllint --noout docs/manual/howto/cgi.xml.fr`
- `git diff --check`
