### PR TITLE
Fix the French DH parameter block in the SSL FAQ

### DIFF
--- a/docs/manual/ssl/ssl_faq.xml.fr
+++ b/docs/manual/ssl/ssl_faq.xml.fr
@@ -844,8 +844,8 @@ de 1024 bits ?</title>
     <example><pre>-----BEGIN DH PARAMETERS-----
     MIGHAoGBAP//////////yQ/aoiFowjTExmKLgNwc0SkCTgiKZ8x0Agu+pjsTmyJR
     Sgh5jjQE3e+VGbPNOkMbMCsKbfJfFDdP4TVtbVHCReSFtXZiXn7G9ExC6aY37WsL
-    /1y29Aa37e44a/taiZ+lrp8kEXxLH+ZJKGZR7OZTgf//////////AgEC -----END DH
-    PARAMETERS-----</pre></example> <p>Ajoute les paramètres personnalisés
+    /1y29Aa37e44a/taiZ+lrp8kEXxLH+ZJKGZR7OZTgf//////////AgEC
+    -----END DH PARAMETERS-----</pre></example> <p>Ajoute les paramètres personnalisés
     incluant les lignes "BEGIN DH PARAMETERS" et "END DH PARAMETERS" à la fin du
     premier fichier de certificat défini via la directive <directive
     module="mod_ssl">SSLCertificateFile</directive>.</p>


### PR DESCRIPTION
This fixes the DH parameter example in the French SSL FAQ.

The closing `-----END DH PARAMETERS-----` line was folded onto the previous base64 line, so the sample block was no longer formatted like a PEM block. The English source still has the expected two-line ending, and this brings the French source back in line with it.

Validation:
- `git diff --check`
- `xmllint --noout docs/manual/ssl/ssl_faq.xml.fr` (it still reports the same pre-existing `&httpd.docs;` entity warnings from this source file)
