### PR TITLE
fix off-by-one buffer over-read in mod_autht_jwt check_token

### DIFF
--- a/modules/aaa/mod_autht_jwt.c
+++ b/modules/aaa/mod_autht_jwt.c
@@ -1051,7 +1051,7 @@ static autht_status check_token(request_rec *r, const char *type,
         }
 
         key = apr_psprintf(r->pool, AUTHT_PREFIX "%.*s", (int)kv->k->value.string.len, kv->k->value.string.p);
-        j = sizeof(AUTHT_PREFIX);
+        j = sizeof(AUTHT_PREFIX) - 1; /* string length of "TOKEN_", excluding the trailing NUL */
         while (key[j]) {
             if (apr_isalnum(key[j])) {
                 key[j] = apr_toupper(key[j]);


### PR DESCRIPTION
check_token in mod_autht_jwt.c starts the claim-name sanitizing loop at j = sizeof(AUTHT_PREFIX), one byte past the length of the "TOKEN_" prefix, so the first character of every claim name is left unsanitized and a token whose claims contain an empty-string key ({"":"..."}) makes key equal to "TOKEN_" in a 7-byte buffer where the loop then reads key[7], one past the allocation. Initialize j to sizeof(AUTHT_PREFIX) - 1, matching the AUTHN_PREFIX handling already used in mod_authn_dbd and mod_authnz_ldap.