### PR TITLE
mod_lua: fix stack write past apr_size_t in r:parsebody

### DIFF
--- a/changes-entries/lua-parsebody-off-t.txt
+++ b/changes-entries/lua-parsebody-off-t.txt
@@ -1,0 +1,4 @@
+  *) mod_lua: Fix a stack write past a 4-byte object in r:parsebody() where
+     the body length was read through an apr_off_t* aliased onto an apr_size_t,
+     corrupting adjacent stack on builds with sizeof(apr_off_t) > sizeof(apr_size_t)
+     (32-bit large-file). [arshiya tabasum]

--- a/modules/lua/lua_request.c
+++ b/modules/lua/lua_request.c
@@ -399,9 +399,11 @@ static int req_parsebody(lua_State *L)
         int         i;
         size_t      vlen = 0;
         size_t      len = 0;
-        if (lua_read_body(r, &data, (apr_off_t*) &size, max_post_size) != OK) {
+        apr_off_t   body_len = 0;
+        if (lua_read_body(r, &data, &body_len, max_post_size) != OK) {
             return 2;
         }
+        size = (apr_size_t) body_len;
         len = strlen(multipart);
         i = 0;
         for


### PR DESCRIPTION
req_parsebody() declares size as an apr_size_t but hands lua_read_body() a (apr_off_t*)&size, and that callee stores the body length back through the pointer as an 8-byte apr_off_t, so on builds where apr_off_t is wider than apr_size_t (32-bit with large-file support) every multipart POST writes four bytes past the size object into adjacent stack. The sibling call in lua_ap_requestbody already reads into a real apr_off_t, so this multipart path is the only site that aliases the narrower type. Read the length into a local apr_off_t and narrow it into size, matching what the urlencoded branch just below already does.