### PR TITLE
mod_http2: preserve response metadata lifetime

### DIFF
--- a/modules/http2/h2_stream.c
+++ b/modules/http2/h2_stream.c
@@ -1169,7 +1169,7 @@ static apr_status_t stream_do_trailers(h2_stream *stream)
         if (APR_BUCKET_IS_METADATA(b)) {
 #if AP_HAS_RESPONSE_BUCKETS
             if (AP_BUCKET_IS_HEADERS(b)) {
-                headers = b->data;
+                headers = apr_pmemdup(stream->pool, b->data, sizeof(*headers));
 #else /* AP_HAS_RESPONSE_BUCKETS */
             if (H2_BUCKET_IS_HEADERS(b)) {
                 headers = h2_bucket_headers_get(b);
@@ -1609,7 +1609,7 @@ static apr_status_t stream_do_response(h2_stream *stream)
         if (APR_BUCKET_IS_METADATA(b)) {
 #if AP_HAS_RESPONSE_BUCKETS
             if (AP_BUCKET_IS_RESPONSE(b)) {
-                resp = b->data;
+                resp = apr_pmemdup(stream->pool, b->data, sizeof(*resp));
 #else /* AP_HAS_RESPONSE_BUCKETS */
             if (H2_BUCKET_IS_HEADERS(b)) {
                 resp = h2_bucket_headers_get(b);


### PR DESCRIPTION
## Summary

- copy HTTP/2 response metadata into the stream pool before destroying its bucket
- do the same for response trailer metadata consumed after bucket destruction
- keep the existing 2.4-compatible `h2_headers` path unchanged

## Root cause

With response buckets enabled, `stream_do_response()` retained `b->data`, destroyed
`b`, and later stored that pointer in `stream->response`. Destroying the bucket
returns its `ap_bucket_response` wrapper to the APR bucket allocator, so later
small bucket allocations can overwrite the retained response status and table
pointers. `stream_do_trailers()` had the same lifetime mismatch for its
`ap_bucket_headers` wrapper.

The tables and strings already live in the stream pool. Copying the small wrapper
before bucket destruction gives the retained metadata the same lifetime.

## Validation

- current trunk built successfully with `mod_http2` and `mod_proxy_http2`
- 58 focused upstream tests passed across GET responses, interim responses,
  response trailers, and server push
- a local APR allocator proof confirmed that the second ordinary small bucket
  allocation reuses and overwrites the freed response-wrapper address

Assisted-by: OpenAI Codex
