### PR TITLE
http2: honor H2WindowSize as stream window floor

### DIFF
--- a/modules/http2/h2_stream.c
+++ b/modules/http2/h2_stream.c
@@ -1341,12 +1341,23 @@ apr_status_t h2_stream_in_consumed(h2_stream *stream, apr_off_t amount)
             int cur_size = nghttp2_session_get_stream_local_window_size(
                 session->ngh2, stream->id);
             int win = stream->in_window_size;
-            int thigh = win * 8/10;
-            int tlow = win * 2/10;
-            const int win_max = 2*1024*1024;
-            const int win_min = 32*1024;
-            
-            /* Work in progress, probably should add directives for these
+            const int win_min = h2_config_sgeti(session->s, H2_CONF_WIN_SIZE);
+            const int win_max = (win_min <= NGHTTP2_MAX_WINDOW_SIZE / 2)?
+                                win_min * 2 : NGHTTP2_MAX_WINDOW_SIZE;
+
+            if (win < win_min) {
+                win = win_min;
+            }
+
+            int thigh = (int)(((apr_int64_t)win * 8) / 10);
+            int tlow = (int)(((apr_int64_t)win * 2) / 10);
+
+           /* H2WindowSize is the configured receive window and acts as
+            * the lower bound for adaptive stream window sizing. This also
+            * prevents the tuner from getting stuck at a much smaller value.
+            */
+
+         /* Work in progress, probably should add directives for these
              * values once this stabilizes somewhat. The general idea is
              * to adapt stream window sizes if the input window changes
              * a) very quickly (< good RTT) from full to empty


### PR DESCRIPTION
This changes the adaptive HTTP/2 receive window logic so that the configured H2WindowSize is used as the lower bound for stream window sizing.

Without this, the adaptive tuner can start from a much smaller `stream->in_window_size` returned by nghttp2 and get stuck there. The growth condition depends on `amount > thigh`, while in practice the reported consumption chunks are often much smaller than `thigh`, so the window may never grow again.

The issue was reproduced with current httpd trunk, as well as with the older mod_http2 2.0.42, using repeated 4 GiB HTTP/2 request-body uploads over a non-zero RTT connection.

Before this change, the issue was repeatedly reproduced across many 4 GiB HTTP/2 request-body uploads, with RTTs ranging from approximately 1 ms to 150 ms. On current trunk, repeated consecutive test runs showed the characteristic collapse from full speed to about 4.7 MB/s, with occasional runs completing normally.

With this change applied to the same source tree and configuration, five consecutive 4 GiB uploads completed without a collapse, at approximately 328-341 MB/s on a sender limited to 3 Gbps.

The change also calculates the 80%/20% thresholds using `apr_int64_t` to avoid overflow when larger configured window sizes are used.