### PR TITLE
mod_proxy_http2: reserve NUL when rewriting a backend Link header uri

### DIFF
--- a/changes-entries/h2-proxy-link-map-off-by-one.txt
+++ b/changes-entries/h2-proxy-link-map-off-by-one.txt
@@ -1,0 +1,3 @@
+  *) mod_proxy_http2: Reserve room for the terminating NUL when rewriting a
+     backend Link response header, fixing a one-byte stack overflow reachable
+     with a crafted Link header.  [arshiya tabasum]

--- a/modules/http2/h2_proxy_util.c
+++ b/modules/http2/h2_proxy_util.c
@@ -976,7 +976,7 @@ static void map_link(link_ctx *ctx)
              * to work, we need to use the proxy uri */
             int path_start = ctx->link_start + ctx->rbu_len;
             link_len -= ctx->rbu_len;
-            need_len = ctx->psu_len + link_len;
+            need_len = ctx->psu_len + link_len + 1;
             if (need_len > sizeof(buffer))
                 goto out;
             memcpy(buffer, ctx->p_server_uri, ctx->psu_len);


### PR DESCRIPTION
map_link() in h2_proxy_util.c rewrites the URI of a backend Link response header into a fixed HUGE_STRING_LEN stack buffer. In the branch that swaps the real backend uri for the proxy uri, need_len is computed as psu_len + link_len without the +1 the sibling branch a few lines above uses to reserve the terminating NUL, so the oversize guard admits need_len == sizeof(buffer) and the following buffer[buffer_len] = '\0' writes one byte past the array. A reverse proxy over HTTP/2 with ProxyPreserveHost off reaches this when a backend returns a Link header whose absolute URI is sized so psu_len + (link_len - rbu_len) equals 8192. Adding the +1 makes the check reserve room for the NUL, matching the other branch.