### PR TITLE
mod_mime_magic: reject negative indirect offset in mget

### DIFF
--- a/changes-entries/mime-magic-negative-offset.txt
+++ b/changes-entries/mime-magic-negative-offset.txt
@@ -1,0 +1,3 @@
+  *) mod_mime_magic: Reject negative indirect offsets in mget() so a crafted
+     file cannot drive an out-of-bounds read of the sniff buffer.
+     [arshiya tabasum]

--- a/modules/metadata/mod_mime_magic.c
+++ b/modules/metadata/mod_mime_magic.c
@@ -1814,7 +1814,7 @@ static int mget(request_rec *r, union VALUETYPE *p, unsigned char *s,
 {
     long offset = m->offset;
 
-    if (offset + sizeof(union VALUETYPE) > nbytes)
+    if (offset < 0 || (apr_size_t)offset + sizeof(union VALUETYPE) > nbytes)
                   return 0;
 
     memcpy(p, s + offset, sizeof(union VALUETYPE));
@@ -1836,7 +1836,7 @@ static int mget(request_rec *r, union VALUETYPE *p, unsigned char *s,
             break;
         }
 
-        if (offset + sizeof(union VALUETYPE) > nbytes)
+        if (offset < 0 || (apr_size_t)offset + sizeof(union VALUETYPE) > nbytes)
                       return 0;
 
         memcpy(p, s + offset, sizeof(union VALUETYPE));


### PR DESCRIPTION
mget() only checks the upper bound of the offset it uses to index the sniff buffer, but that offset is a signed long, and for indirect ">(...)" rules it is derived from a value read out of the file being sniffed (offset = p->l + m->in.offset, where p->l comes from a BELONG/LELONG conversion that sign-extends bytes >= 0x80). A crafted file whose field yields a small negative offset slips through the guard, because offset + sizeof(union VALUETYPE) promotes offset to size_t and wraps to a small positive value, so the following memcpy reads up to 64 bytes before buf in magic_process. Reject negative offsets in both bounds checks so the read stays inside the buffer; valid rules resolve to a non-negative in-buffer position and are unaffected.