### PR TITLE
fix a parallel build failure/race using buildmark.o

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -533,7 +533,7 @@ test/httpdunit.lo: test/httpdunit.c test/httpdunit.cases | unittest-objdir
 # libcheck on the system.
 httpdunit_OBJECTS := test/httpdunit.lo $(testcase_OBJECTS)
 $(httpdunit_OBJECTS): override LTCFLAGS += $(UNITTEST_CFLAGS)
-test/httpdunit: $(httpdunit_OBJECTS) $(PROGRAM_DEPENDENCIES) $(PROGRAM_OBJECTS)
+test/httpdunit: $(httpdunit_OBJECTS) $(PROGRAM_DEPENDENCIES) $(PROGRAM_OBJECTS) buildmark.o
 	$(LINK) $(httpdunit_OBJECTS) $(PROGRAM_OBJECTS) $(UNITTEST_LIBS) $(PROGRAM_LDADD)
 
 check-unittests: test/httpdunit

--- a/build/program.mk
+++ b/build/program.mk
@@ -18,6 +18,13 @@
 
 PROGRAM_OBJECTS = $(PROGRAM_SOURCES:.c=.lo)
 
-$(PROGRAM_NAME): $(PROGRAM_DEPENDENCIES) $(PROGRAM_OBJECTS)
+# buildmark.o is named in $(PROGRAM_LDADD), so give it an explicit rule
+# rather than building it as a side effect of the link below: other targets
+# which use $(PROGRAM_LDADD) can then depend on it, instead of racing
+# against this rule under "make -j".  Rebuilding it whenever the program is
+# relinked keeps the reported build timestamp current.
+buildmark.o: $(PROGRAM_DEPENDENCIES) $(PROGRAM_OBJECTS)
 	$(PROGRAM_PRELINK)
+
+$(PROGRAM_NAME): $(PROGRAM_DEPENDENCIES) $(PROGRAM_OBJECTS) buildmark.o
 	$(LINK) $(PROGRAM_LDFLAGS) $(PROGRAM_OBJECTS) $(PROGRAM_LDADD)


### PR DESCRIPTION
seen in https://github.com/apache/httpd/actions/runs/33171949169/job/98850995345 - likely since higher concurrency is now being used, only triggers if `test/httpdunit` is being built.

```
/usr/bin/ld: cannot find buildmark.o: No such file or directory
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:542: test/httpdunit] Error 1
make[1]: *** Waiting for unfinished jobs....
```