### PR TITLE
CI: Enable modules/md's ACME pytest suite

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -131,10 +131,8 @@ jobs:
               NO_TEST_FRAMEWORK=1
               TEST_PYTEST=1
           # -------------------------------------------------------------------------
-          # Runs every pytest-based test suite (pytest_suite/ + all
-          # test/modules/*/ pyhttpd suites except modules/md, which needs a
-          # local ACME/pebble server that isn't available here) via `make
-          # check-all-pytest`. See TEST_PYTEST in test/travis_run_linux.sh.
+          # Runs every pytest-based test suite via `make check-all-pytest`.
+          # See TEST_PYTEST/TEST_MD in test/travis_run_linux.sh.
           - name: Python pytest test suites
             config: --enable-mods-shared=reallyall --with-mpm=event --enable-mpms-shared=all
             pkgs: nghttp2-client
@@ -144,6 +142,7 @@ jobs:
               APU_CONFIG="--with-crypto"
               NO_TEST_FRAMEWORK=1
               TEST_PYTEST=1
+              TEST_MD=1
           # -------------------------------------------------------------------------
           # Test against a newer nghttp2 than in the Ubuntu images.
           - name: mod_http2 w/nghttp2 1.68.0
@@ -464,6 +463,13 @@ jobs:
       run: |
         pipx install uv
         echo "$HOME/.local/bin" >> $GITHUB_PATH
+    - name: Install pebble
+      if: env.TEST_MD == '1'
+      run: |
+        go install github.com/letsencrypt/pebble/v2/cmd/pebble@latest \
+          && go install github.com/letsencrypt/pebble/v2/cmd/pebble-challtestsrv@latest \
+          && echo "$(go env GOPATH)/bin" >> $GITHUB_PATH \
+          || echo "::warning::pebble install failed; modules/md tests will be skipped"
     - name: Build and test
       run: ./test/travis_run_linux.sh
     # Checks the config header in the build tree, so this must follow

--- a/test/README.ci
+++ b/test/README.ci
@@ -65,12 +65,12 @@ The CI scripts use the following environment variables:
 * TEST_PYTEST - if set, runs all available pytest-based test suites
   via "make check-all-pytest" (pytest_suite/ and test/modules/*/
   pyhttpd suites).  Replaces the old per-suite TEST_CORE / TEST_PROXY
-  / TEST_H2 / TEST_MD flags.
+  / TEST_H2 flags.
 
 * PYHTTPD_TARGETS - with TEST_PYTEST, a space-separated list of
   test/modules/*/ suites to run (e.g. "modules/http2").  If unset, all
-  are run except modules/md, and modules/http2 when mod_http2 was not
-  built.
+  are run except modules/md when no `pebble` is on PATH, and
+  modules/http2 when mod_http2 was not built.
 
 * PYTEST_ARGS - with TEST_PYTEST, extra arguments passed through to
   test/run-all-tests.sh (e.g. "--only=pyhttpd" to skip pytest_suite/).
@@ -85,9 +85,9 @@ The CI scripts use the following environment variables:
   rustls-ffi from source and configures httpd with --with-tls
   --with-rustls for mod_tls testing.
 
-* TEST_MD - (currently unused) if set, builds pebble and runs the
-  mod_md ACME test suite.  Preserved for future use once a working
-  pebble build is available; see comments in travis_run_linux.sh.
+* TEST_MD - set together with TEST_PYTEST; installs pebble first so
+  PYHTTPD_TARGETS auto-detection includes modules/md.  See the
+  "Python pytest test suites" job in .github/workflows/linux.yml.
 
 * TEST_APR_TARBALL - if set, APR/APR-util source is fetched as a
   release tarball from archive.apache.org rather than cloned from git.
@@ -191,7 +191,6 @@ under the "Run" group of every step after the one which sets it.
 Travis to Github Actions Migration TODO
 ---------------------------------------
 
-* enable ACME/mod_md testing
 * test across different Ubuntu versions again
  - and test against OpenSSL 1.x since we're now ONLY building against 3.x
 * container testing for non-Ubuntu hosts

--- a/test/modules/md/md_env.py
+++ b/test/modules/md/md_env.py
@@ -90,8 +90,9 @@ class MDTestEnv(HttpdTestEnv):
     @classmethod
     def has_a2md(cls):
         d = os.path.dirname(inspect.getfile(HttpdTestEnv))
+        config_ini = os.getenv("PYHTTPD_CONFIG", os.path.join(d, 'config.ini'))
         config = ConfigParser(interpolation=ExtendedInterpolation())
-        config.read(os.path.join(d, 'config.ini'))
+        config.read(config_ini)
         bin_dir = config.get('global', 'bindir')
         a2md_bin = os.path.join(bin_dir, 'a2md')
         return os.path.isfile(a2md_bin)

--- a/test/travis_run_linux.sh
+++ b/test/travis_run_linux.sh
@@ -264,10 +264,9 @@ if test -v TEST_PYTEST -a $RV -eq 0; then
     # check-all-pytest instead builds and tests entirely from the in-tree
     # check/ build, needing no install.
     #
-    # modules/md is excluded: its ACME tests need a local pebble CA server,
-    # which isn't available here (built from source, pebble's Go module
-    # currently fails to build against modern Go -- see the old commit
-    # history for the details of that dead end).
+    # modules/md is included only when `pebble` is on PATH: its ACME
+    # tests need a local pebble CA server, so a job wanting md coverage
+    # must install pebble first; see README.ci.
     #
     # modules/http2 is excluded when mod_http2 wasn't built (e.g. the
     # UBSan job's --disable-http2): its pytest package hard-requires
@@ -288,7 +287,8 @@ if test -v TEST_PYTEST -a $RV -eq 0; then
         for d in test/modules/*/; do
             name=$(basename "$d")
             case "$name" in
-                md|__pycache__) continue ;;
+                __pycache__) continue ;;
+                md) command -v pebble >/dev/null 2>&1 || continue ;;
                 http2) test -f modules/http2/.libs/mod_http2.so || continue ;;
             esac
             PYHTTPD_TARGETS="$PYHTTPD_TARGETS modules/$name"
@@ -296,26 +296,6 @@ if test -v TEST_PYTEST -a $RV -eq 0; then
     fi
     export PYHTTPD_TARGETS
     make check-all-pytest PYTEST_ARGS="${PYTEST_ARGS:-}"
-    RV=$?
-fi
-
-if test -v TEST_MD -a $RV -eq 0; then
-    # Preserved for reference only: nothing sets TEST_MD, so this never
-    # runs. modules/md is covered by TEST_PYTEST's check-all-pytest run above
-    # for everything except its ACME tests, which need a local pebble CA
-    # server -- building pebble from source last failed with:
-    # package github.com/letsencrypt/pebble/cmd/pebble
-    #         imports crypto/ed25519: unrecognized import path "crypto/ed25519" (import path does not begin with hostname)
-    #
-    # Revive this (e.g. once a working pebble build/package is available)
-    # by setting TEST_MD=1 on a job and ensuring GOROOT/GOPATH are usable.
-    export GOPATH=${PREFIX}/gocode
-    mkdir -p "${GOPATH}"
-    export PATH="${GOROOT}/bin:${GOPATH}/bin:${PATH}"
-    go get -u github.com/letsencrypt/pebble/...
-    (cd $GOPATH/src/github.com/letsencrypt/pebble && go install ./...)
-
-    py.test-3 test/modules/md
     RV=$?
 fi
 


### PR DESCRIPTION
**Provided Changes**

 * Makefile.in: Add a check/bin/a2md rule (mirroring check/bin/ab) so
    check-all-pytest's check/ tree exposes a2md.
  * test/travis_run_linux.sh: Include modules/md in TEST_PYTEST's
    PYHTTPD_TARGETS whenever `pebble` is on PATH. Drop the long-dead
    TEST_MD block using the now-unusable `go get -u .../pebble/...`.
    
  * .github/workflows/linux.yml: Install pebble (v2 module) on the
    "Python pytest test suites" job via a new TEST_MD flag, non-fatally.
    
  * test/modules/md/md_env.py: Fix has_a2md() to honor PYHTTPD_CONFIG
    instead of hardcoding test/pyhttpd/config.ini.
    
  * test/README.ci: Update PYHTTPD_TARGETS/TEST_MD docs, drop the
    now-done "enable ACME/mod_md testing" TODO item.
    
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://github.com/ichristod/httpd/actions/runs/33186467555