### PR TITLE
mod_auth_digest: part 3

### DIFF
--- a/changes-entries/digest-shmem-size.txt
+++ b/changes-entries/digest-shmem-size.txt
@@ -1,0 +1,3 @@
+  *) mod_auth_digest: Increase the default AuthDigestShmemSize to 8192
+     bytes, tracking around 140 clients rather than around 12.
+     [Joe Orton]

--- a/docs/manual/mod/mod_auth_digest.xml
+++ b/docs/manual/mod/mod_auth_digest.xml
@@ -270,7 +270,7 @@ authentication</description>
 <description>The amount of shared memory to allocate for keeping track
 of clients</description>
 <syntax>AuthDigestShmemSize <var>size</var></syntax>
-<default>AuthDigestShmemSize 1000</default>
+<default>AuthDigestShmemSize 8192</default>
 <contextlist><context>server config</context></contextlist>
 
 <usage>
@@ -283,6 +283,13 @@ of clients</description>
     set <directive>AuthDigestShmemSize</directive> to the value of
     <code>0</code> and read the error message after trying to start the
     server.</p>
+
+    <p>The default holds roughly 140 clients. A client which is discarded
+    to make room for another is not denied access: it is issued a new
+    nonce with <code>stale=true</code>, which costs it one extra request.
+    Note that a request which does not authenticate also takes an entry,
+    since the challenge sent back to it carries the identifier the client
+    is tracked by.</p>
 
     <p>The <var>size</var> is normally expressed in Bytes, but you
     may follow the number with a <code>K</code> or an <code>M</code> to

--- a/modules/aaa/mod_auth_digest.c
+++ b/modules/aaa/mod_auth_digest.c
@@ -824,33 +824,35 @@ static enum nonce_state client_update_nonce(const request_rec *r,
  */
 static unsigned long gc(server_rec *s)
 {
-    client_entry *entry, *prev;
     unsigned long num_removed = 0, idx;
 
-    /* garbage collect all last entries */
+    /* garbage collect one entry from each bucket */
 
     for (idx = 0; idx < client_list->tbl_len; idx++) {
-        entry = client_list->table[idx];
-        prev  = NULL;
+        client_entry **link, **victim = NULL;
+        int unused = 0;
 
-        if (!entry) {
-            /* This bucket is empty. */
-            continue;
+        /* The last entry is the least recently used, since find_client()
+         * moves an entry to the front on each access; but prefer a client
+         * which has never completed an authentication, whose entry records
+         * nothing and so costs it nothing to lose. Every request which
+         * fails to authenticate allocates one of those, and without this
+         * they would evict the clients which are using the server. */
+        for (link = &client_list->table[idx]; *link; link = &(*link)->next) {
+            if ((*link)->last_nonce_time == 0) {
+                victim = link;
+                unused = 1;
+            }
+            else if (!unused) {
+                victim = link;
+            }
         }
 
-        while (entry->next) {   /* find last entry */
-            prev  = entry;
-            entry = entry->next;
-        }
-        if (prev) {
-            prev->next = NULL;   /* cut list */
-        }
-        else {
-            client_list->table[idx] = NULL;
-        }
-        if (entry) {                    /* remove entry */
+        if (victim) {
+            client_entry *entry = *victim;
             apr_status_t err;
 
+            *victim = entry->next;
             err = rmm_free(client_rmm, entry);
             num_removed++;
 

--- a/modules/aaa/mod_auth_digest.c
+++ b/modules/aaa/mod_auth_digest.c
@@ -197,9 +197,14 @@ static apr_global_mutex_t *client_lock = NULL;
 static const char     *client_mutex_type = "authdigest-client";
 static const char     *client_shm_filename;
 
-#define DEF_SHMEM_SIZE  1000L           /* ~ 12 entries */
-#define DEF_NUM_BUCKETS 15L
+#define DEF_SHMEM_SIZE  8192L           /* ~ 140 entries */
 #define HASH_DEPTH      5
+/* Buckets for a given segment size, so that the default and
+ * AuthDigestShmemSize cannot disagree. */
+#define NUM_BUCKETS(size_) (((size_) - sizeof(*client_list)) /             \
+                            (sizeof(client_entry *)                       \
+                             + HASH_DEPTH * sizeof(client_entry)))
+#define DEF_NUM_BUCKETS NUM_BUCKETS(DEF_SHMEM_SIZE)
 
 static apr_size_t shmem_size  = DEF_SHMEM_SIZE;
 static unsigned long num_buckets = DEF_NUM_BUCKETS;
@@ -583,8 +588,7 @@ static const char *set_shmem_size(cmd_parms *cmd, void *config,
     }
 
     shmem_size  = size;
-    num_buckets = (size - sizeof(*client_list)) /
-                  (sizeof(client_entry*) + HASH_DEPTH * sizeof(client_entry));
+    num_buckets = NUM_BUCKETS(size);
     if (num_buckets == 0) {
         num_buckets = 1;
     }

--- a/modules/aaa/mod_auth_digest.c
+++ b/modules/aaa/mod_auth_digest.c
@@ -1194,11 +1194,8 @@ static int note_digest_auth_failure(request_rec *r,
                                     const digest_config_rec *conf,
                                     digest_header_rec *resp, int stale)
 {
-    const char   *qop, *opaque = NULL, *opaque_param = "", *domain, *nonce;
-    client_id_t   client_key = 0;
-
-    /* Setup qop */
-    qop = ", qop=\"auth\"";
+    const char   *opaque = NULL, *opaque_param = "", *domain, *nonce;
+    client_id_t   client_key;
 
     /* Setup opaque */
 
@@ -1231,7 +1228,6 @@ static int note_digest_auth_failure(request_rec *r,
          * here: the client may not even see this challenge (it may have
          * been triggered by somebody else quoting its opaque), and it is
          * tied to the nonce it was counted for in any case. */
-        client_key = resp->opaque_num;
         opaque = resp->opaque;
     }
 
@@ -1257,11 +1253,12 @@ static int note_digest_auth_failure(request_rec *r,
                      (PROXYREQ_PROXY == r->proxyreq)
                          ? "Proxy-Authenticate" : "WWW-Authenticate",
                      apr_psprintf(r->pool, "Digest realm=\"%s\", "
-                                  "nonce=\"%s\", algorithm=%s%s%s%s%s",
+                                  "nonce=\"%s\", algorithm=%s%s%s%s"
+                                  ", qop=\"auth\"",
                                   ap_auth_name(r), nonce, conf->algorithm,
                                   opaque_param,
                                   domain ? domain : "",
-                                  stale ? ", stale=true" : "", qop));
+                                  stale ? ", stale=true" : ""));
 
     return HTTP_UNAUTHORIZED;
 }

--- a/modules/aaa/mod_auth_digest.c
+++ b/modules/aaa/mod_auth_digest.c
@@ -269,6 +269,7 @@ static int initialize_tables(server_rec *s, apr_pool_t *ctx)
 {
     unsigned long idx;
     apr_status_t   sts;
+    client_id_t    seed;
 
     /* set up client list */
 
@@ -343,7 +344,15 @@ static int initialize_tables(server_rec *s, apr_pool_t *ctx)
         log_error_and_cleanup("failed to allocate shared memory", -1, s);
         return !OK;
     }
-    *client_id_counter = 1;
+    /* Start the ids at a random point rather than at 1. This segment does
+     * not survive a restart, but the nonces naming its entries do, since the
+     * secret they are hashed with is retained; ids restarting from 1 too
+     * would hand a returning client's id straight back out, so that client
+     * would be checked against whichever new client now held it. The ids are
+     * not secret - they are sent in the clear as the opaque - this only has
+     * to make them distinct across a restart. */
+    ap_random_insecure_bytes(&seed, sizeof seed);
+    *client_id_counter = seed ? seed : 1;
 
     /* setup one-time-nonce counter */
 
@@ -400,9 +409,10 @@ static int initialize_module(apr_pool_t *p, apr_pool_t *plog,
      * child of the previous generation keeps the mapping it inherited
      * until it exits, so the tables are not pulled out from under it.
      *
-     * Per-client state therefore does not survive a restart. A client
-     * which returns afterwards is simply unknown, and is re-challenged
-     * with stale=true at the cost of one extra request.
+     * Per-client state therefore does not survive a restart, and neither
+     * does the client id space; see the seeding in initialize_tables().
+     * A client which returns afterwards is simply unknown, and is
+     * re-challenged with stale=true at the cost of one extra request.
      */
     return initialize_tables(s, p);
 }

--- a/modules/aaa/mod_auth_digest.c
+++ b/modules/aaa/mod_auth_digest.c
@@ -44,6 +44,7 @@
  *     opposite of sharing: the two would have to be configured explicitly.
  */
 
+#include "apu_version.h"
 #include "apr_sha1.h"
 #include "apr_base64.h"
 #include "apr_lib.h"
@@ -82,6 +83,21 @@
 #error mod_auth_digest requires APR with random and shared memory support
 #endif
 
+/* The nonce is authenticated with a keyed hash, so that a client cannot
+ * forge one. apr_siphash() is a MAC, and is what that calls for; it is
+ * available in APU 1.6 / APR 2.0 and later. Older APR falls back to the
+ * original SHA-1 of the secret followed by the message, which is not a
+ * sound construction - a Merkle-Damgard hash keyed by a prefix can be
+ * extended without the key - but which is not attackable here, since the
+ * padding such an extension needs cannot survive the opaque being parsed
+ * as a hex number before the nonce is checked. */
+#if APU_MAJOR_VERSION > 1 || (APU_MAJOR_VERSION == 1 && APU_MINOR_VERSION >= 6)
+#define DIGEST_SIPHASH_NONCE 1
+#include "apr_siphash.h"
+#else
+#define DIGEST_SIPHASH_NONCE 0
+#endif
+
 /* struct to hold the configuration info */
 
 typedef struct digest_config_struct {
@@ -99,9 +115,16 @@ typedef struct digest_config_struct {
 #define NEXTNONCE_DELTA apr_time_from_sec(30)
 
 /* The server nonce has fixed length and is the concatenation of:
- *    base64(apr_time_t timestamp) + hex(SHA1(realm+time[+opaque])) */
+ *    base64(apr_time_t timestamp) + hex(keyed hash of realm+time[+opaque])
+ * The hash is half as long with siphash, which produces 64 bits: enough for
+ * a value which can only be attacked by presenting it to the server, there
+ * being no way to test a candidate offline. */
 #define NONCE_TIME_LEN  (((sizeof(apr_time_t)+2)/3)*4)
+#if DIGEST_SIPHASH_NONCE
+#define NONCE_HASH_LEN  (2*APR_SIPHASH_DSIZE)
+#else
 #define NONCE_HASH_LEN  (2*APR_SHA1_DIGESTSIZE)
+#endif
 #define NONCE_LEN       (int )(NONCE_TIME_LEN + NONCE_HASH_LEN)
 /* Evaluates to true if nonce string is valid. Since the time part of
  * the nonce is a base64 encoding of an apr_time_t (8 bytes), it
@@ -112,6 +135,10 @@ typedef struct digest_config_struct {
 
 #define SECRET_LEN          20
 #define RETAINED_DATA_ID    "mod_auth_digest"
+
+#if DIGEST_SIPHASH_NONCE && SECRET_LEN < APR_SIPHASH_KSIZE
+#error the secret is too short to key siphash
+#endif
 
 
 /* client list definitions */
@@ -1093,11 +1120,31 @@ static int init_digest_request(request_rec *r)
 
 /* Writes the hash part of the server nonce to hash, which must be of
  * minimum size (NONCE_HASH_LEN+1). */
-static void gen_nonce_hash(char hash[NONCE_HASH_LEN+1], const char *timestr, const char *opaque,
+static void gen_nonce_hash(apr_pool_t *p, char hash[NONCE_HASH_LEN+1],
+                           const char *timestr, const char *opaque,
                            const server_rec *server,
-                           const digest_config_rec *conf, 
+                           const digest_config_rec *conf,
                            const char *realm)
 {
+#if DIGEST_SIPHASH_NONCE
+    unsigned char mac[APR_SIPHASH_DSIZE];
+    const char *msg;
+
+    /* siphash takes the whole message at once, having no streaming
+     * interface, so the fields are joined here rather than fed in one at a
+     * time. The realm is length-prefixed, which keeps the boundaries
+     * between the fields unambiguous whatever they contain: without it a
+     * realm ending in what another realm's timestamp begins with would
+     * hash the same. An absent opaque is the empty string, which is what
+     * the challenge side passes for it too. */
+    msg = apr_psprintf(p, "%" APR_SIZE_T_FMT ":%s:%s:%s",
+                       (apr_size_t)strlen(realm), realm, timestr,
+                       opaque ? opaque : "");
+
+    apr_siphash24_auth(mac, msg, strlen(msg), secret);
+
+    ap_bin2hex(mac, APR_SIPHASH_DSIZE, hash);
+#else
     unsigned char sha1[APR_SHA1_DIGESTSIZE];
     apr_sha1_ctx_t ctx;
 
@@ -1113,6 +1160,7 @@ static void gen_nonce_hash(char hash[NONCE_HASH_LEN+1], const char *timestr, con
     apr_sha1_final(sha1, &ctx);
 
     ap_bin2hex(sha1, APR_SHA1_DIGESTSIZE, hash);
+#endif
 }
 
 
@@ -1136,7 +1184,7 @@ static const char *gen_nonce(apr_pool_t *p, apr_time_t now, const char *opaque,
         t.time = apr_atomic_inc32(otn_counter) + 1;
     }
     apr_base64_encode_binary(nonce, t.arr, sizeof(t.arr));
-    gen_nonce_hash(nonce+NONCE_TIME_LEN, nonce, opaque, server, conf, realm);
+    gen_nonce_hash(p, nonce+NONCE_TIME_LEN, nonce, opaque, server, conf, realm);
 
     return nonce;
 }
@@ -1415,7 +1463,8 @@ static int check_nonce(request_rec *r, digest_header_rec *resp,
     tmp = resp->nonce[NONCE_TIME_LEN];
     resp->nonce[NONCE_TIME_LEN] = '\0';
     apr_base64_decode_binary(nonce_time.arr, resp->nonce);
-    gen_nonce_hash(hash, resp->nonce, resp->opaque, r->server, conf, ap_auth_name(r));
+    gen_nonce_hash(r->pool, hash, resp->nonce, resp->opaque, r->server, conf,
+                   ap_auth_name(r));
     resp->nonce[NONCE_TIME_LEN] = tmp;
     resp->nonce_time = nonce_time.time;
 

--- a/modules/aaa/mod_auth_digest.c
+++ b/modules/aaa/mod_auth_digest.c
@@ -21,32 +21,27 @@
  * Updated to RFC-2617 by Ronald Tschalär <ronald@innovation.ch>
  * based on mod_auth, by Rob McCool and Robert S. Thau
  *
- * This module an updated version of modules/standard/mod_digest.c
- * It is still fairly new and problems may turn up - submit problem
- * reports to the Apache bug-database, or send them directly to me
- * at ronald@innovation.ch.
- *
  * Open Issues:
- *   - qop=auth-int (when streams and trailer support available)
- *   - nonce-format configurability
+ *   - MD5-sess and auth-int are not implemented; auth-int needs stream and
+ *     trailer support. An incomplete implementation has been removed and
+ *     can be retrieved from svn history.
  *   - Proxy-Authentication-Info header is set by this module, but is
  *     currently ignored by mod_proxy (needs patch to mod_proxy)
  *   - The source of the secret should be run-time directive (with server
- *     scope: RSRC_CONF)
- *   - shared-mem not completely tested yet. Seems to work ok for me,
- *     but... (definitely won't work on Windoze)
- *   - Sharing a realm among multiple servers has following problems:
- *     o Server name and port can't be included in nonce-hash
- *       (we need two nonce formats, which must be configured explicitly)
- *     o Nonce-count check can't be for equal, or then nonce-count checking
- *       must be disabled. What we could do is the following:
- *       (expected < received) ? set expected = received : issue error
- *       The only problem is that it allows replay attacks when somebody
- *       captures a packet sent to one server and sends it to another
- *       one. Should we add "AuthDigestNcCheck Strict"?
- *   - expired nonces give amaya fits.
- *   - MD5-sess and auth-int are not yet implemented. An incomplete
- *     implementation has been removed and can be retrieved from svn history.
+ *     scope: RSRC_CONF). Each server generates its own, so a nonce issued
+ *     by one does not verify at another, and a client moving between them
+ *     is re-challenged every time.
+ *   - Sharing a realm among multiple servers needs more than that secret,
+ *     though. It would be enough for a configuration which tracks no
+ *     per-client state, but the client table, the ids which key it and the
+ *     one-time nonce counter are all per-server, so under AuthDigestNcCheck
+ *     or AuthDigestNonceLifetime 0 a client would still be unknown to
+ *     whichever server it reached next.
+ *   - Sharing the secret would also make a request captured against one
+ *     server replayable against the others, and the nonce-count check
+ *     would not stop that, since each server counts separately. Hashing
+ *     the server name and port into the nonce would, but that is the
+ *     opposite of sharing: the two would have to be configured explicitly.
  */
 
 #include "apr_sha1.h"
@@ -399,15 +394,15 @@ static int initialize_module(apr_pool_t *p, apr_pool_t *plog,
     if (ap_state_query(AP_SQ_MAIN_STATE) == AP_SQ_MS_CREATE_PRE_CONFIG)
         return OK;
 
-    /* Note: this stuff is currently fixed for the lifetime of the server,
-     * i.e. even across restarts. This means that A) any shmem-size
-     * configuration changes are ignored, and B) certain optimizations,
-     * such as only allocating the smallest necessary entry for each
-     * client, can't be done. However, the alternative is a nightmare:
-     * we can't call apr_shm_destroy on a graceful restart because there
-     * will be children using the tables, and we also don't know when the
-     * last child dies. Therefore we can never clean up the old stuff,
-     * creating a creeping memory leak.
+    /* The client table belongs to one configuration generation: it is
+     * allocated from pconf, which the restart loop clears - destroying the
+     * segment - before running this hook again to create a new one. A
+     * child of the previous generation keeps the mapping it inherited
+     * until it exits, so the tables are not pulled out from under it.
+     *
+     * Per-client state therefore does not survive a restart. A client
+     * which returns afterwards is simply unknown, and is re-challenged
+     * with stale=true at the cost of one extra request.
      */
     return initialize_tables(s, p);
 }
@@ -1199,10 +1194,15 @@ static int note_digest_auth_failure(request_rec *r,
             }
             opaque = ltox(r->pool, client_key);
         }
-        /* else no opaque is needed, and none is sent */
+        /* else this configuration tracks no per-client state, so no entry
+         * is allocated and no opaque is sent */
     }
     else if (!client_exists(resp->opaque_num, r)) {
-        /* client info was gc'd */
+        /* We have no record of this client: its entry may have been
+         * garbage collected, the segment may have been recreated by a
+         * restart, or the opaque may never have been issued by us.
+         * Nothing was wrong with the credentials, so the challenge is
+         * stale and an RFC-compliant client retries silently. */
         if ((client_key = client_generate(r)) == 0) {
             return HTTP_SERVICE_UNAVAILABLE;
         }
@@ -1227,16 +1227,9 @@ static int note_digest_auth_failure(request_rec *r,
 
     nonce = gen_nonce(r->pool, r->request_time, opaque, r->server, conf, ap_auth_name(r));
 
-    /* setup domain attribute. We want to send this attribute wherever
-     * possible so that the client won't send the Authorization header
-     * unnecessarily (it's usually > 200 bytes!).
-     */
-
-
-    /* don't send domain
-     * - for proxy requests
-     * - if it's not specified
-     */
+    /* Setup domain, which tells the client which URIs share this
+     * protection space, so that it does not send the Authorization header
+     * (usually more than 200 bytes) where it is not needed. */
     if (r->proxyreq || !conf->uri_list) {
         domain = NULL;
     }

--- a/test/modules/aaa/conftest.py
+++ b/test/modules/aaa/conftest.py
@@ -43,6 +43,12 @@ def env(pytestconfig) -> AAATestEnv:
     docs = env.server_docs_dir
     pwfile = env.digest_pwfile
     conf = HttpdConf(env)
+    # Pin the client table to its historical size, ~12 entries, rather than
+    # the current default of ~140: the tests which need an entry to be
+    # garbage collected (085) drive that by filling the table with bare
+    # requests, and a table an order of magnitude larger makes them an order
+    # of magnitude slower for nothing.
+    conf.add('AuthDigestShmemSize 1000')
     conf.add(_digest_dir(docs, "default", [
         'AuthDigestProvider file',
         f'AuthUserFile "{pwfile}"',

--- a/test/modules/aaa/test_002_nonce.py
+++ b/test/modules/aaa/test_002_nonce.py
@@ -42,17 +42,22 @@ class TestDigestNonce:
         env.httpd_error_log.ignore_recent(lognos=["AH01776"])
 
     def test_digest_021_garbage_nonce_hash_is_stale(self, env):
-        # A nonce must still look like "b64(time)+sha1hex(hash)" (VALID_NONCE
-        # in mod_auth_digest.c checks length and the '=' padding boundary) to
+        # A nonce must still look like "b64(time)+hex(hash)" (VALID_NONCE in
+        # mod_auth_digest.c checks length and the '=' padding boundary) to
         # even be considered for a hash check; something that doesn't match
         # that shape is instead rejected as a malformed header (see
         # test_digest_010). Here we keep the genuine time-prefix (so the
         # shape is valid) but replace the whole hash suffix with garbage, to
         # hit check_nonce()'s "hash is not %s" path distinctly from
         # test_digest_020's single-flipped-character tamper.
+        #
+        # The hash length depends on which keyed hash the module was built
+        # with, so take it from the nonce rather than assuming: the time is
+        # base64 of 8 bytes and so ends with the only '=' in the string.
         challenge = self.challenge(env, "default")
-        time_prefix = challenge.nonce[:-40]
-        challenge.nonce = time_prefix + ("f" * 40)
+        time_prefix = challenge.nonce[:challenge.nonce.index('=') + 1]
+        hash_len = len(challenge.nonce) - len(time_prefix)
+        challenge.nonce = time_prefix + ("f" * hash_len)
         r = self.authenticate(env, "default", challenge)
         assert r.response["status"] == 401
         new_challenge = dc.DigestChallenge.parse(r.response["header"]["www-authenticate"])

--- a/test/modules/aaa/test_008_onetime_nccheck.py
+++ b/test/modules/aaa/test_008_onetime_nccheck.py
@@ -161,11 +161,13 @@ class TestOneTimeNonce:
     @pytest.mark.parametrize("location", BOTH)
     def test_digest_085_replay_rejected_when_the_client_entry_is_gone(self, env,
                                                                       location):
-        # The client table is small -- AuthDigestShmemSize defaults to 1000
-        # bytes, "~ 12 entries" -- and a request with no credentials at all
-        # allocates an entry, since the challenge it gets back has to carry an
-        # opaque. An attacker can therefore make gc() discard a client's entry
-        # for the price of a dozen bare requests.
+        # The client table is small here -- conftest pins AuthDigestShmemSize
+        # to 1000 bytes, "~ 12 entries" -- and a request with no credentials
+        # at all allocates an entry, since the challenge it gets back has to
+        # carry an opaque. An attacker can therefore make gc() discard a
+        # client's entry for the price of a dozen bare requests. The shipped
+        # default is larger, which raises that price but does not change the
+        # property under test.
         #
         # A captured request must still not be replayable once that has
         # happened. It used to be: check_nonce() skipped the one-time

--- a/test/modules/aaa/test_008_onetime_nccheck.py
+++ b/test/modules/aaa/test_008_onetime_nccheck.py
@@ -39,6 +39,7 @@ BOTH = ["onetime", "onetime-nccheck"]
 NC_FAILED = "AH01774"
 NONCE_HASH_INVALID = "AH01776"
 PASSWORD_MISMATCH = "AH01794"
+CLIENT_UNKNOWN = "AH10618"
 
 
 class TestOneTimeNonce:
@@ -162,15 +163,13 @@ class TestOneTimeNonce:
     def test_digest_085_replay_rejected_when_the_client_entry_is_gone(self, env,
                                                                       location):
         # The client table is small here -- conftest pins AuthDigestShmemSize
-        # to 1000 bytes, "~ 12 entries" -- and a request with no credentials
-        # at all allocates an entry, since the challenge it gets back has to
-        # carry an opaque. An attacker can therefore make gc() discard a
-        # client's entry for the price of a dozen bare requests. The shipped
-        # default is larger, which raises that price but does not change the
-        # property under test.
+        # to 1000 bytes, "~ 12 entries" -- so filling it makes gc() discard
+        # entries. The pressure has to come from clients which have
+        # authenticated: gc() discards the entries of clients which never
+        # did first, so bare requests no longer evict anybody who matters.
         #
-        # A captured request must still not be replayable once that has
-        # happened. It used to be: check_nonce() skipped the one-time
+        # A captured request must still not be replayable once the client's
+        # entry has gone. It used to be: check_nonce() skipped the one-time
         # comparison entirely when the client was unknown, so the nonce was
         # taken on trust and the replay served the protected resource.
         challenge = self.challenge(env, location)
@@ -178,10 +177,18 @@ class TestOneTimeNonce:
         assert self.send(env, location, captured).response["status"] == 200
         assert self.send(env, location, captured).response["status"] == 401
 
-        for _ in range(40):
-            env.curl_get(self.url(env, location))
+        # Note that the victim is left alone while the table fills: looking
+        # its entry up would move it to the front of its bucket, which is
+        # exactly what saves an entry from gc().
+        for _ in range(30):
+            other = self.challenge(env, location)
+            assert self.send(env, location,
+                             self.header(location, other)).response["status"] == 200
 
         r = self.send(env, location, captured)
-        env.httpd_error_log.ignore_recent(lognos=[NC_FAILED])
+        env.httpd_error_log.ignore_recent(lognos=[NC_FAILED, CLIENT_UNKNOWN])
         assert r.response["status"] == 401, \
             "captured request replayed once the client entry was evicted"
+        gone = dc.DigestChallenge.parse(r.response["header"]["www-authenticate"])
+        assert gone.opaque != challenge.opaque, \
+            "the entry was not evicted, so the gc'd-client path is untested"

--- a/test/modules/aaa/test_009_restart.py
+++ b/test/modules/aaa/test_009_restart.py
@@ -1,0 +1,200 @@
+"""Per-client state across a server restart.
+
+The client table lives in a shared memory segment created by post_config,
+and that segment does not survive a restart: the restart loop in
+server/main.c clears pconf, which destroys the segment, and post_config
+then builds a new one, empty.
+
+The nonce does survive, because the secret it is hashed with is kept in
+retained data across restarts. So a client returning after a restart
+presents a nonce which still verifies, naming per-client state which no
+longer exists.
+
+The right answer for such a client is a stale=true challenge: its
+credentials were never in doubt, only the server-side state backing its
+nonce is gone, so it should retry silently against the fresh nonce rather
+than being told its authentication failed. mod_auth_digest does exactly
+that when it finds the client unknown (AH10618).
+
+It stopped doing it once the id had been handed to somebody else, which the
+ids restarting from 1 made routine rather than exotic: the first clients
+seen after a restart took exactly the ids the clients from before it were
+still quoting. A returning client was then checked against a *different*
+client's entry and reported as a nonce-count failure -- stale=false, which
+a browser shows as a failed password.
+
+With one-time nonces it was a replay hole rather than a wrong answer to the
+user. Single use is enforced by remembering the last nonce each client
+used, and that memory dies with the segment while the nonce does not; the
+one-time counter restarts at 0, so a nonce from before the restart outranks
+anything the new holder of its id has reached, and was accepted. An
+eavesdropper who had captured one used request only had to wait for a
+restart.
+
+The ids are now seeded randomly for each segment, so a returning client's
+opaque no longer names anybody, and it takes the unknown-client path above.
+"""
+
+from . import digest_client as dc
+from .env import AAATestEnv
+
+NC_FAILED = "AH01774"
+CLIENT_UNKNOWN = "AH10618"
+ONETIME_REUSED = "AH01779"
+
+
+class TestDigestRestart:
+
+    def url(self, env, location, path="secret.txt"):
+        return env.mkurl("http", "aaa", f"/digest/{location}/{path}")
+
+    def uri(self, location):
+        return f"/digest/{location}/secret.txt"
+
+    def challenge(self, env, location):
+        r = env.curl_get(self.url(env, location))
+        assert r.response["status"] == 401
+        return dc.DigestChallenge.parse(r.response["header"]["www-authenticate"])
+
+    def header(self, location, challenge, nc="00000001", cnonce="restart-cnonce"):
+        return dc.build_authorization(
+            AAATestEnv.DIGEST_USER, challenge, AAATestEnv.DIGEST_PASSWORD,
+            method="GET", uri=self.uri(location), nc=nc, cnonce=cnonce)
+
+    def send(self, env, location, auth):
+        return env.curl_get(self.url(env, location),
+                            options=["-H", f"Authorization: {auth}"])
+
+    def reload(self, env):
+        assert env.apache_reload() == 0, "graceful restart failed"
+
+    def challenge_of(self, r):
+        """The challenge carried by a 401 response."""
+        return dc.DigestChallenge.parse(r.response["header"]["www-authenticate"])
+
+    def follow_nextnonce(self, r, challenge):
+        ai = dc.parse_params(r.response["header"]["authentication-info"])
+        assert "nextnonce" in ai
+        challenge.nonce = ai["nextnonce"]
+
+    def test_digest_090_returning_client_is_challenged_as_stale(self, env):
+        # A client which authenticated before a restart comes back afterwards
+        # with the nonce it was holding. The state naming its opaque is gone,
+        # so the request cannot be accepted -- but the client did nothing
+        # wrong, and must be told to retry rather than that it failed.
+        location = "nccheck"
+        self.reload(env)
+        challenge = self.challenge(env, location)
+        assert self.send(env, location,
+                         self.header(location, challenge)).response["status"] == 200
+
+        self.reload(env)
+
+        r = self.send(env, location, self.header(location, challenge, "00000002"))
+        env.httpd_error_log.ignore_recent(lognos=[NC_FAILED, CLIENT_UNKNOWN])
+        assert r.response["status"] == 401
+        fresh = self.challenge_of(r)
+        assert fresh.stale, \
+            "a client returning after a restart was told its authentication " \
+            "failed, rather than being asked to retry with a fresh nonce"
+
+        # ...and the retry against that fresh challenge succeeds.
+        assert self.send(env, location,
+                         self.header(location, fresh)).response["status"] == 200
+
+    def test_digest_091_returning_client_is_stale_even_if_its_id_was_reused(self, env):
+        # Same property, but now the id space has caught up: after the restart
+        # a new client is handed the id the returning client still quotes.
+        # That is not an unlikely coincidence -- the counter restarts from 1,
+        # so the first clients seen after a restart take exactly the ids the
+        # clients from before it are holding.
+        location = "nccheck"
+        self.reload(env)
+        challenge = self.challenge(env, location)
+        assert self.send(env, location,
+                         self.header(location, challenge)).response["status"] == 200
+
+        self.reload(env)
+
+        # A different client arrives first and is given the recycled id.
+        # Today that newcomer is handed the returning client's id, because
+        # the counter restarts at 1. The assertions below deliberately do not
+        # require it: a server which stops recycling ids satisfies this
+        # property by making the returning client simply unknown, which is
+        # the outcome under test either way.
+        newcomer = self.challenge(env, location)
+        assert self.send(env, location,
+                         self.header(location, newcomer)).response["status"] == 200
+
+        r = self.send(env, location, self.header(location, challenge, "00000002"))
+        env.httpd_error_log.ignore_recent(lognos=[NC_FAILED, CLIENT_UNKNOWN])
+        assert r.response["status"] == 401
+        assert self.challenge_of(r).stale, \
+            "a returning client was reported as a possible replay attack " \
+            "because its id had been given to somebody else"
+
+    def test_digest_092_onetime_nonce_from_before_a_restart_is_not_accepted(self, env):
+        # One-time nonces are ordered by a counter which restarts at 0 with
+        # the segment, while the nonce itself stays verifiable. A client
+        # holding an unused nonce from before the restart therefore presents
+        # a counter value the new server has not reached yet.
+        location = "onetime"
+        self.reload(env)
+        challenge = self.challenge(env, location)
+        for _ in range(5):
+            r = self.send(env, location, self.header(location, challenge))
+            assert r.response["status"] == 200
+            self.follow_nextnonce(r, challenge)
+        # challenge.nonce is now an unused nonce, well ahead of the counter
+        # that a restart will reset to 0.
+
+        self.reload(env)
+
+        newcomer = self.challenge(env, location)
+        r = self.send(env, location, self.header(location, newcomer))
+        assert r.response["status"] == 200
+        self.follow_nextnonce(r, newcomer)
+
+        # The nonce from the previous server generation must not be usable.
+        stale_use = self.send(env, location, self.header(location, challenge))
+        env.httpd_error_log.ignore_recent(lognos=[NC_FAILED, CLIENT_UNKNOWN,
+                                                  ONETIME_REUSED])
+        assert stale_use.response["status"] == 401, \
+            "a one-time nonce issued before the restart was accepted after it"
+
+        # ...and the client which legitimately owns that entry still works.
+        assert self.send(env, location,
+                         self.header(location, newcomer)).response["status"] == 200, \
+            "the stale nonce locked out the client holding that id"
+
+    def test_digest_093_onetime_request_cannot_be_replayed_across_a_restart(self, env):
+        # The severity case. A one-time nonce is single-use because the server
+        # remembers the last nonce each client used -- and that memory does
+        # not survive a restart, while the nonce does. So an eavesdropper who
+        # captured one *successfully used* request needs only to wait for a
+        # restart: the counter it outranks has gone back to zero, and the id
+        # it names is handed straight back out.
+        location = "onetime"
+        self.reload(env)
+        challenge = self.challenge(env, location)
+        for _ in range(5):
+            r = self.send(env, location, self.header(location, challenge))
+            assert r.response["status"] == 200
+            captured = self.header(location, challenge)   # a used request
+            self.follow_nextnonce(r, challenge)
+
+        assert self.send(env, location, captured).response["status"] == 401, \
+            "the captured request was not single-use before the restart"
+
+        self.reload(env)
+
+        # Somebody authenticates, so the recycled id names a live entry.
+        newcomer = self.challenge(env, location)
+        assert self.send(env, location,
+                         self.header(location, newcomer)).response["status"] == 200
+
+        replay = self.send(env, location, captured)
+        env.httpd_error_log.ignore_recent(lognos=[NC_FAILED, CLIENT_UNKNOWN,
+                                                  ONETIME_REUSED])
+        assert replay.response["status"] == 401, \
+            "a captured one-time request was replayed successfully after a restart"

--- a/test/modules/aaa/test_010_eviction.py
+++ b/test/modules/aaa/test_010_eviction.py
@@ -1,0 +1,120 @@
+"""Which client entries are discarded when the table is full.
+
+The client table is a fixed-size shared memory segment (AuthDigestShmemSize,
+pinned small by conftest here), and gc() makes room by discarding one entry
+from each bucket. An entry is allocated for any request which needs a
+challenge, including one carrying no credentials at all, since the challenge
+has to carry the identifier the client will be tracked by. An attacker can
+therefore fill the table with bare requests as fast as it can send them.
+
+What that costs the clients already using the server depends on which entry
+gc() picks. Discarding a client which has authenticated costs it a request:
+its nonce-count and last-used nonce go with the entry, so its next request
+is answered with a fresh challenge (stale=true) and has to be retried.
+Discarding a client which has never authenticated costs nothing at all --
+the entry records nothing yet, and the client simply gets a new identifier
+with its next challenge.
+
+So gc() prefers the entries which have never been used to authenticate,
+which are exactly the ones a flood of unauthenticated requests creates.
+
+"Never used to authenticate" is last_nonce_time == 0, which is exact in both
+of the configurations that track clients: an accepted request stores the
+time its nonce was generated at, which is a wall-clock time for a nonce with
+a lifetime and a counter which starts at 1 for a one-time nonce. Neither is
+ever 0. The tests below run against both to pin that.
+"""
+
+import pytest
+
+from . import digest_client as dc
+from .env import AAATestEnv
+
+NC_FAILED = "AH01774"
+CLIENT_UNKNOWN = "AH10618"
+
+# A location tracking clients for the nonce-count, and one tracking them for
+# one-time nonces: the two put different kinds of value in last_nonce_time.
+BOTH = ["nccheck", "onetime"]
+
+
+class TestDigestEviction:
+
+    def url(self, env, location):
+        return env.mkurl("http", "aaa", f"/digest/{location}/secret.txt")
+
+    def uri(self, location):
+        return f"/digest/{location}/secret.txt"
+
+    def challenge(self, env, location):
+        r = env.curl_get(self.url(env, location))
+        assert r.response["status"] == 401
+        return dc.DigestChallenge.parse(r.response["header"]["www-authenticate"])
+
+    def header(self, location, challenge, nc="00000001", cnonce="eviction-cnonce"):
+        return dc.build_authorization(
+            AAATestEnv.DIGEST_USER, challenge, AAATestEnv.DIGEST_PASSWORD,
+            method="GET", uri=self.uri(location), nc=nc, cnonce=cnonce)
+
+    def send(self, env, location, auth):
+        return env.curl_get(self.url(env, location),
+                            options=["-H", f"Authorization: {auth}"])
+
+    def advance(self, r, challenge):
+        """Prepare the client's next request, and return the nc to send with
+        it. A one-time nonce is replaced by the nextnonce just handed out,
+        and the count restarts at 1 for it; otherwise the nonce stays and the
+        count goes up."""
+        ai = r.response["header"].get("authentication-info")
+        if ai:
+            params = dc.parse_params(ai)
+            if "nextnonce" in params:
+                challenge.nonce = params["nextnonce"]
+                return "00000001"
+        return "00000002"
+
+    def flood(self, env, location, count):
+        """Bare requests, each of which allocates a client entry."""
+        for _ in range(count):
+            env.curl_get(self.url(env, location))
+
+    @pytest.mark.parametrize("location", BOTH)
+    def test_digest_100_authenticated_client_survives_a_flood(self, env, location):
+        # The legitimate client authenticates, so its entry now records the
+        # nonce it used.
+        challenge = self.challenge(env, location)
+        r = self.send(env, location, self.header(location, challenge))
+        assert r.response["status"] == 200
+        nc = self.advance(r, challenge)
+
+        # An attacker fills the table several times over with requests which
+        # carry no credentials at all.
+        self.flood(env, location, 60)
+
+        # The victim carries on. Its entry must still be there: it is the
+        # only one in the table which is worth keeping.
+        r = self.send(env, location, self.header(location, challenge, nc))
+        env.httpd_error_log.ignore_recent(lognos=[NC_FAILED, CLIENT_UNKNOWN])
+        assert r.response["status"] == 200, \
+            "a flood of unauthenticated requests evicted an authenticated client"
+
+    @pytest.mark.parametrize("location", BOTH)
+    def test_digest_101_unused_entries_are_the_ones_discarded(self, env, location):
+        # The counterpart: the entries a flood creates are themselves the
+        # ones discarded, so a flood cannot fill the table permanently. The
+        # opaque handed out at the start of one no longer names an entry by
+        # the end, which the server reports by minting a new one rather than
+        # echoing it back -- and as a stale challenge, since nothing was
+        # wrong with the client's credentials.
+        first = self.challenge(env, location)
+        self.flood(env, location, 60)
+
+        r = self.send(env, location, self.header(location, first))
+        env.httpd_error_log.ignore_recent(lognos=[NC_FAILED, CLIENT_UNKNOWN])
+        assert r.response["status"] == 401
+        again = dc.DigestChallenge.parse(r.response["header"]["www-authenticate"])
+        assert again.opaque != first.opaque, \
+            "the unused entry should have been discarded by the flood"
+        assert again.stale, \
+            "a client whose unused entry was discarded should be re-challenged " \
+            "as stale, not told its authentication failed"


### PR DESCRIPTION
* update some stale comments
* randomize client ids
* raise the default shmem size, 12 is a bit stingy
* better, happier GC
* fitter, happier nonce hashing